### PR TITLE
Update fmatch version and not set keys

### DIFF
--- a/orion.py
+++ b/orion.py
@@ -117,19 +117,6 @@ def get_metadata(test,logger):
     Returns:
         dict: dictionary of the metadata
     """
-    # metadata_columns = [
-    #     "platform",
-    #     "masterNodesType",
-    #     "masterNodesCount",
-    #     "workerNodesType",
-    #     "workerNodesCount",
-    #     "benchmark",
-    #     "ocpVersion",
-    #     "networkType",
-    #     "encrypted",
-    #     "fips",
-    #     "ipsec",
-    # ]
     metadata = {}
     for k,v in test.items(): 
         if k == "metrics" or k == "name": 

--- a/orion.py
+++ b/orion.py
@@ -119,7 +119,7 @@ def get_metadata(test,logger):
     """
     metadata = {}
     for k,v in test.items(): 
-        if k == "metrics" or k == "name": 
+        if k in ["metrics","name"]: 
             continue
         metadata[k] = v
     metadata["ocpVersion"] = str(metadata["ocpVersion"])

--- a/orion.py
+++ b/orion.py
@@ -118,8 +118,8 @@ def get_metadata(test,logger):
         dict: dictionary of the metadata
     """
     metadata = {}
-    for k,v in test.items(): 
-        if k in ["metrics","name"]: 
+    for k,v in test.items():
+        if k in ["metrics","name"]:
             continue
         metadata[k] = v
     metadata["ocpVersion"] = str(metadata["ocpVersion"])

--- a/orion.py
+++ b/orion.py
@@ -52,7 +52,7 @@ def orion(config, debug, output):
         logger.error("An error occurred: %s", e)
         sys.exit(1)
     for test in data["tests"]:
-        metadata = get_metadata(test)
+        metadata = get_metadata(test, logger)
         logger.info("The test %s has started", test["name"])
         match = Matcher(index="perf_scale_ci", level=level)
         uuids = match.get_uuid_by_metadata(metadata)
@@ -108,7 +108,7 @@ def orion(config, debug, output):
         match.save_results(merged_df, csv_file_path=output)
 
 
-def get_metadata(test):
+def get_metadata(test,logger):
     """Gets metadata of the run from each test
 
     Args:
@@ -117,21 +117,26 @@ def get_metadata(test):
     Returns:
         dict: dictionary of the metadata
     """
-    metadata_columns = [
-        "platform",
-        "masterNodesType",
-        "masterNodesCount",
-        "workerNodesType",
-        "workerNodesCount",
-        "benchmark",
-        "ocpVersion",
-        "networkType",
-        "encrypted",
-        "fips",
-        "ipsec",
-    ]
-    metadata = {key: test[key] for key in metadata_columns if key in test}
+    # metadata_columns = [
+    #     "platform",
+    #     "masterNodesType",
+    #     "masterNodesCount",
+    #     "workerNodesType",
+    #     "workerNodesCount",
+    #     "benchmark",
+    #     "ocpVersion",
+    #     "networkType",
+    #     "encrypted",
+    #     "fips",
+    #     "ipsec",
+    # ]
+    metadata = {}
+    for k,v in test.items(): 
+        if k == "metrics" or k == "name": 
+            continue
+        metadata[k] = v
     metadata["ocpVersion"] = str(metadata["ocpVersion"])
+    logger.debug('metadata' + str(metadata))
     return metadata
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click==8.1.7
 elastic-transport==8.11.0
 elasticsearch==8.11.1
 elasticsearch7==7.13.0
-fmatch==0.0.2
+fmatch==0.0.3
 numpy==1.26.3
 pandas==2.1.4
 python-dateutil==2.8.2


### PR DESCRIPTION
## Type of change

- [X] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Saw that there was an update version of fmatch that I think we should go ahead and update

The set columns that were defined in get_metadata did not allow for defining extra variables like clusterType for rosa/hcp or defining infraNodeCounts 


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.



```
tests :
  - name : rosa-small-scale-cluster-density-v2
    platform: AWS
    workerNodesType: m5.xlarge
    workerNodesCount: 24
    benchmark: cluster-density-v2
    ocpVersion: 4.15
    networkType: OVNKubernetes
    clusterType: rosa
    masterNodesCount: 3
    metrics : 
    - metric : podReadyLatency
      metricType : latency
      
    - metric : apiserverCPU
      metricType : cpu
      namespace: openshift-kube-apiserver

    - metric: ovnCPU
      metricType: cpu
      namespace: openshift-ovn-kubernetes
    
    - metric: etcdCPU
      metricType: cpu
      namespace: openshift-ovn-kubernetes
```