### PR TITLE
Generic comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,43 @@ tests :
     # ipsec: false
 
     metrics : 
-    - metric : podReadyLatency
-      metricType : latency
+    - name:  podReadyLatency
+      metricName: podLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not: 
+      - jobConfig.name: "garbage-collection"
       
-    - metric : apiserverCPU
-      metricType : cpu
-      namespace: openshift-kube-apiserver
+    - name:  apiserverCPU
+      metricName : containerCPU
+      labels.namespace: openshift-kube-apiserver
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
 
-    - metric: ovnCPU
-      metricType: cpu
-      namespace: openshift-ovn-kubernetes
+    - name:  ovnCPU
+      metricName : containerCPU
+      labels.namespace: openshift-ovn-kubernetes
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+
+    - name:  etcdCPU
+      metricName : containerCPU
+      labels.namespace: openshift-etcd
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
     
-    - metric: etcdCPU
-      metricType: cpu
-      namespace: openshift-ovn-kubernetes
+    - name:  etcdDisck
+      metricName : 99thEtcdDiskBackendCommitDurationSeconds
+      metric_of_interest: value
+      agg:
+        value: duration
+        agg_type: avg
 
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click==8.1.7
 elastic-transport==8.11.0
 elasticsearch==8.11.1
 elasticsearch7==7.13.0
-fmatch==0.0.3
+fmatch==0.0.4
 numpy==1.26.3
 pandas==2.1.4
 python-dateutil==2.8.2


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Using the changes in [fmatch pr](https://github.com/cloud-bulldozer/py-commons/pull/16) I was able to add in more options into the yaml and have a working ingress perf comparison 

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

2 sample configs: 

```
tests :
  - name : rosa-small-scale-ingress
    platform: AWS
    workerNodesType: m5.xlarge
    workerNodesCount: 9
    benchmark: ingress-perf
    ocpVersion: 4.15
    networkType: OVNKubernetes
    clusterType: rosa
    masterNodesCount: 3
    # encrypted: true
    # fips: false
    # ipsec: false
    #    masterNodesType: m6a.xlarge
    #    masterNodesCount: 3

    metrics : 
    - metric: Termination
      config.termination: passthrough
      sample: "*"
      config.serverReplicas: "*"
      metric_of_interest: total_avg_rps

```



```
tests :
  - name : rosa-small-scale-cluster-density-v2
    platform: AWS
    workerNodesType: m5.xlarge
    workerNodesCount: 24
    benchmark: cluster-density-v2
    ocpVersion: 4.15
    networkType: OVNKubernetes
    clusterType: rosa
    masterNodesCount: 3
    # encrypted: true
    # fips: false
    # ipsec: false
    #    masterNodesType: m6a.xlarge
    #    masterNodesCount: 3

    metrics : 
    - metric: podReadyLatency
      metricName: podLatencyQuantilesMeasurement
      quantileName: Ready
      metric_of_interest: P99
      not: 
      - jobConfig.name: "garbage-collection"
      
    - metric : apiserverCPU
      metricName : containerCPU
      labels.namespace: openshift-kube-apiserver
      metric_of_interest: value
      agg:
        value: cpu
        agg_type: avg

    - metric : ovnCPU
      metricName : containerCPU
      labels.namespace: openshift-ovn-kubernetes
      metric_of_interest: value
      agg:
        value: cpu
        agg_type: avg

    - metric : etcdCPU
      metricName : containerCPU
      labels.namespace: openshift-etcd
      metric_of_interest: value
      agg:
        value: cpu
        agg_type: avg
    
    - metric : etcdDisck
      metricName : 99thEtcdDiskBackendCommitDurationSeconds
      metric_of_interest: value
      agg:
        value: duration
        agg_type: avg


```
