### PR TITLE
Adding baseline and uuid options

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,4 +22,4 @@ jobs:
         pip install .
     - name: Analysing the code with pylint
       run: |
-        pylint -d C0103 $(git ls-files '*.py')
+        pylint -d C0103 -d R0912 $(git ls-files '*/*.py' '*.py')

--- a/README.md
+++ b/README.md
@@ -97,3 +97,19 @@ Additionally, users can specify a custom path for the output CSV file using the 
 Orion's seamless integration with metadata and hunter ensures a robust regression detection tool for perf-scale CPT runs.
 
 
+```--uuid``` : If you have a specific uuid in mind (maybe a current run), you can bypass the metadata configuration portion of the config file and use this paraemter. You will still need to specify a config file that contains a metrics section for the metrics you want to collect on the current uuid and uuids that match the metadata of the uuid configuration
+
+```
+tests :
+  - name : current-uuid-etcd-duration
+    metrics : 
+    - name:  etcdDisck
+      metricName : 99thEtcdDiskBackendCommitDurationSeconds
+      metric_of_interest: value
+      agg:
+        value: duration
+        agg_type: avg
+```
+
+Orion provides flexibility if you know the comparison uuid you want to compare among, use the ```--baseline``` flag. This should only be used in conjunction when setting uuid. Similar to the uuid section mentioned above, you'll have to set a metrics section to specify the data points you want to collect on
+

--- a/examples/small-scale-node-density-cni.yaml
+++ b/examples/small-scale-node-density-cni.yaml
@@ -7,7 +7,7 @@ tests :
       workerNodesType: m6a.xlarge
       workerNodesCount: 6
       infraNodesCount: 3
-      benchmar.keyword: node-density-cni
+      benchmark.keyword: node-density-cni
       ocpVersion: 4.15
       networkType: OVNKubernetes
       infraNodesType: r5.2xlarge

--- a/examples/small-scale-node-density-cni.yaml
+++ b/examples/small-scale-node-density-cni.yaml
@@ -7,7 +7,7 @@ tests :
       workerNodesType: m6a.xlarge
       workerNodesCount: 6
       infraNodesCount: 3
-      benchmark.keyword: node-density-cni
+      benchmar.keyword: node-density-cni
       ocpVersion: 4.15
       networkType: OVNKubernetes
       infraNodesType: r5.2xlarge

--- a/orion.py
+++ b/orion.py
@@ -74,9 +74,7 @@ def orion(**kwargs):
                 logging.info("No UUID present for given metadata")
                 sys.exit()
         else:
-            print("baseline" + str(baseline))
             uuids = re.split(' |,',baseline)
-            print("uuids" + str(uuids))
             uuids.append(uuid)
         if metadata["benchmark.keyword"] == "k8s-netperf" :
             index = "k8s-netperf"
@@ -99,8 +97,10 @@ def orion(**kwargs):
             lambda left, right: pd.merge(left, right, on="uuid", how="inner"),
             dataframe_list,
         )
+
+        csv_name = kwargs["output"].split(".")[0]+"-"+test['name']+".csv"
         match.save_results(
-            merged_df, csv_file_path=kwargs["output"].split(".")[0]+"-"+test['name']+".csv"
+            merged_df, csv_file_path=csv_name
         )
 
         if kwargs["hunter_analyze"]:

--- a/utils/orion_funcs.py
+++ b/utils/orion_funcs.py
@@ -116,6 +116,48 @@ def get_metadata(test,logger):
     return metadata
 
 
+def filter_metadata(uuid,match,logger):
+    """Gets metadata of the run from each test
+
+    Args:
+        uuid (str): str of uuid ot find metadata of
+        match: the fmatch instance
+        
+
+    Returns:
+        dict: dictionary of the metadata
+    """
+
+    test= match.get_metadata_by_uuid(uuid)
+    metadata = {
+        'platform': '', 
+        'clusterType': '', 
+        'masterNodesCount': 0,
+        'workerNodesCount': 0,
+        'infraNodesCount': 0,
+        'masterNodesType': '',
+        'workerNodesType': '',
+        'infraNodesType': '',
+        'totalNodesCount': 0,
+        'ocpVersion': '',
+        'networkType': '',
+        'ipsec': '',
+        'fips': '',
+        'encrypted': '',
+        'publish': '',
+        'computeArch': '', 
+        'controlPlaneArch': ''
+    }
+    for k,v in test.items():
+        if k not in metadata:
+            continue
+        metadata[k] = v
+    metadata['benchmark.keyword'] = test['benchmark']
+    metadata["ocpVersion"] = str(metadata["ocpVersion"])
+    logger.debug('metadata' + str(metadata))
+    return metadata
+
+
 
 def set_logging(level, logger):
     """sets log level and format

--- a/utils/orion_funcs.py
+++ b/utils/orion_funcs.py
@@ -128,7 +128,7 @@ def filter_metadata(uuid,match,logger):
         dict: dictionary of the metadata
     """
 
-    test= match.get_metadata_by_uuid(uuid)
+    test = match.get_metadata_by_uuid(uuid)
     metadata = {
         'platform': '', 
         'clusterType': '', 
@@ -154,8 +154,11 @@ def filter_metadata(uuid,match,logger):
         metadata[k] = v
     metadata['benchmark.keyword'] = test['benchmark']
     metadata["ocpVersion"] = str(metadata["ocpVersion"])
-    logger.debug('metadata' + str(metadata))
-    return metadata
+
+    #Remove any keys that have blank values
+    no_blank_meta = {k: v for k, v in metadata.items() if v}
+    logger.debug('No blank metadata dict: ' + str(no_blank_meta))
+    return no_blank_meta
 
 
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
A lot of the times we have a set uuid (current run) or one in mind that it would be nice to not have to go get the metadata of the run, create a config file and then run. This would allow a user to set a uuid on command line and have the config file only define the metrics wanted to be collected 

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Example: 
`orion --uuid dc9431e4-43c9-482d-861b-87ab11afbd3a --baseline 2076cfe3-00fc-4fdd-bf76-016bb31264f1`