### PR TITLE
[Trivial] Refine uuid split

### DIFF
--- a/orion.py
+++ b/orion.py
@@ -74,7 +74,7 @@ def orion(**kwargs):
                 logging.info("No UUID present for given metadata")
                 sys.exit()
         else:
-            uuids = re.split(' |,',baseline)
+            uuids = [uuid for uuid in re.split(' |,',baseline) if uuid]
             uuids.append(uuid)
         if metadata["benchmark.keyword"] == "k8s-netperf" :
             index = "k8s-netperf"


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Trivial bug fix in baseline UUIDs split.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Verified in local in a hacky way.
```
>>> import re
>>> baseline="uuid1,uuid2, uuid3,uuid4 uuid5 uuid6, uuid7,uuid8,                uuid9"
>>> uuids = re.split(' |,',baseline)
>>> print(uuids)
['uuid1', 'uuid2', '', 'uuid3', 'uuid4', 'uuid5', 'uuid6', '', 'uuid7', 'uuid8', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'uuid9']
>>> uuids = [uuid for uuid in re.split(' |,',baseline) if uuid]
>>> print(uuids)
['uuid1', 'uuid2', 'uuid3', 'uuid4', 'uuid5', 'uuid6', 'uuid7', 'uuid8', 'uuid9']
>>> exit()
```
