### PR TITLE
Getting build urls for when uuid and baseline are set

### DIFF
--- a/orion.py
+++ b/orion.py
@@ -67,7 +67,8 @@ def orion(**kwargs):
         benchmarkIndex=test['benchmarkIndex']
         uuid = kwargs["uuid"]
         baseline = kwargs["baseline"]
-        match = Matcher(index="ospst-perf-scale-ci-*",
+        index = "ospst-perf-scale-ci-*"
+        match = Matcher(index=index,
                         level=level, ES_URL=ES_URL, verify_certs=False)
         if uuid == "":
             metadata = orion_funcs.get_metadata(test, logger)
@@ -85,6 +86,8 @@ def orion(**kwargs):
         else:
             uuids = [uuid for uuid in re.split(' |,',baseline) if uuid]
             uuids.append(uuid)
+            buildUrls = orion_funcs.get_build_urls(index, uuids,match)
+
         index=benchmarkIndex
         if metadata["benchmark.keyword"] in ["ingress-perf","k8s-netperf"] :
             ids = uuids

--- a/utils/orion_funcs.py
+++ b/utils/orion_funcs.py
@@ -118,6 +118,24 @@ def get_metadata(test,logger):
     return metadata
 
 
+def get_build_urls(index, uuids,match):
+    """Gets metadata of the run from each test 
+        to get the build url
+
+    Args:
+        uuids (list): str list of uuid to find build urls of
+        match: the fmatch instance
+        
+
+    Returns:
+        dict: dictionary of the metadata
+    """
+
+    test = match.getResults("",uuids,index,{})
+    buildUrls = {run["uuid"]: run["buildUrl"] for run in test}
+    return buildUrls
+
+
 def filter_metadata(uuid,match,logger):
     """Gets metadata of the run from each test
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
With the changes from https://github.com/cloud-bulldozer/orion/pull/15, when using the uuid and baseline parameters I had added, it was now throwing an error trying to find the buildUrl for each uuid. This will get that data without erroring 

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
`$orion --uuid $UUID --baseline $BASELINE_UUID --config examples/small-scale-node-density-cni.yaml --debug`
```
,uuid,timestamp,P99,apiserverCPU_cpu_avg,ovnCPU_cpu_avg,etcdCPU_cpu_avg,etcdDisk_duration_avg,buildUrl
0,26feeb47-3f7d-45b4-9926-f8f774a08385,2023-12-14T23:13:52.563810987Z,2000,22.754171747822074,3.4660279278374864,21.24262421293023,0.010324644209403131,https://tinyurl.com/26843gjw
1,0f731581-6630-4620-921f-3d9fa11d1330,2024-05-07T21:20:02.737893524Z,2000,19.23959183682067,3.21447647319984,16.56003964168054,0.009221293420220414,https://tinyurl.com/266dh3ay
```

