### PR TITLE
Consider all the iterations for control plane test comparisons

### DIFF
--- a/orion.py
+++ b/orion.py
@@ -67,7 +67,7 @@ def orion(**kwargs):
         benchmarkIndex=test['benchmarkIndex']
         uuid = kwargs["uuid"]
         baseline = kwargs["baseline"]
-        match = Matcher(index="ospst-perf-scale-ci-*",
+        match = Matcher(index="ospst-perf-scale-ci*",
                         level=level, ES_URL=ES_URL, verify_certs=False)
         if uuid == "":
             metadata = orion_funcs.get_metadata(test, logger)
@@ -85,18 +85,11 @@ def orion(**kwargs):
         else:
             uuids = [uuid for uuid in re.split(' |,',baseline) if uuid]
             uuids.append(uuid)
+            buildUrls = orion_funcs.get_build_urls(uuids,match)
         index=benchmarkIndex
-        if metadata["benchmark.keyword"] in ["ingress-perf","k8s-netperf"] :
-            ids = uuids
-        else:
-            if baseline == "":
-                runs = match.match_kube_burner(uuids, index)
-                ids = match.filter_runs(runs, runs)
-            else:
-                ids = uuids
 
         metrics = test["metrics"]
-        dataframe_list = orion_funcs.get_metric_data(ids, index, metrics, match, logger)
+        dataframe_list = orion_funcs.get_metric_data(uuids, index, metrics, match, logger)
 
         for i, df in enumerate(dataframe_list):
             if i != 0:

--- a/orion.py
+++ b/orion.py
@@ -85,7 +85,6 @@ def orion(**kwargs):
         else:
             uuids = [uuid for uuid in re.split(' |,',baseline) if uuid]
             uuids.append(uuid)
-            buildUrls = orion_funcs.get_build_urls(uuids,match)
         index=benchmarkIndex
 
         metrics = test["metrics"]

--- a/utils/orion_funcs.py
+++ b/utils/orion_funcs.py
@@ -118,6 +118,22 @@ def get_metadata(test,logger):
     return metadata
 
 
+def get_build_urls(uuids,match):
+    """Gets metadata of the run from each test 
+        to get the build url
+    Args:
+        uuids (list): str list of uuid to find build urls of
+        match: the fmatch instance
+        
+    Returns:
+        dict: dictionary of the metadata
+    """
+
+    test = match.getResults("",uuids,"ospst-perf-scale-ci-*",{})
+    buildUrls = {run["uuid"]: run["buildUrl"] for run in test}
+    return buildUrls
+
+
 def filter_metadata(uuid,match,logger):
     """Gets metadata of the run from each test
 

--- a/utils/orion_funcs.py
+++ b/utils/orion_funcs.py
@@ -118,22 +118,6 @@ def get_metadata(test,logger):
     return metadata
 
 
-def get_build_urls(uuids,match):
-    """Gets metadata of the run from each test 
-        to get the build url
-    Args:
-        uuids (list): str list of uuid to find build urls of
-        match: the fmatch instance
-        
-    Returns:
-        dict: dictionary of the metadata
-    """
-
-    test = match.getResults("",uuids,"ospst-perf-scale-ci-*",{})
-    buildUrls = {run["uuid"]: run["buildUrl"] for run in test}
-    return buildUrls
-
-
 def filter_metadata(uuid,match,logger):
     """Gets metadata of the run from each test
 


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Prerequisite: https://github.com/cloud-bulldozer/orion/pull/32

To consider all the iterations while comparing control plane tests. Because iterations are calculated in the run-time based on ppn for all the node-density tests so that they can be ignored in the fingerprint. Please feel free to correct me If I am wrong.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested and verified in local able to fetch all the similar UUIDs.
