### PR TITLE
Node densityn ignore iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Orion now supports anomaly detection for your data. Use the ```--anomaly-detecti
 
 You can now constrain your look-back period using the ```--lookback``` option. The format for look-back is ```XdYh```, where X represents the number of days and Y represents the number of hours.
 
+You can open the match requirement by using the ```--node-count``` option to find any matching uuid based on the metadata and not have to have the same jobConfig.jobIterations. This variable is a ```True``` or ```False```, defaulted to False. 
+
 **_NOTE:_**  The ```--hunter-analyze``` and ```--anomaly-detection``` flags are mutually exclusive. They cannot be used together because they represent different algorithms designed for distinct use cases.
 
 ### Daemon mode

--- a/orion.py
+++ b/orion.py
@@ -105,6 +105,7 @@ def cli(max_content_width=120):  # pylint: disable=unused-argument
 @click.option("--lookback", help="Get data from last X days and Y hours. Format in XdYh")
 @click.option("--convert-tinyurl", is_flag=True, help="Convert buildUrls to tiny url format for better formatting")
 @click.option("--collapse", is_flag=True, help="Only outputs changepoints, previous and later runs in the xml format")
+@click.option("--node-count", default=False, help="Match any node iterations count")
 def cmd_analysis(**kwargs):
     """
     Orion runs on command line mode, and helps in detecting regressions

--- a/pkg/utils.py
+++ b/pkg/utils.py
@@ -157,6 +157,7 @@ def filter_uuids_on_index(
     uuids: List[str],
     match: Matcher,
     baseline: str,
+    filter_node_count: bool
 ) -> List[str]:
     """returns the index to be used and runs as uuids
 
@@ -170,7 +171,7 @@ def filter_uuids_on_index(
     """
     if metadata["benchmark.keyword"] in ["ingress-perf", "k8s-netperf"]:
         return uuids
-    if baseline == "":
+    if baseline == "" and not filter_node_count:
         runs = match.match_kube_burner(uuids, fingerprint_index)
         ids = match.filter_runs(runs, runs)
     else:
@@ -235,7 +236,7 @@ def process_test(
     benchmark_index = test["benchmarkIndex"]
 
     uuids = filter_uuids_on_index(
-        metadata, benchmark_index, uuids, match, options["baseline"]
+        metadata, benchmark_index, uuids, match, options["baseline"], options['node_count']
     )
     # get metrics data and dataframe
     metrics = test["metrics"]

--- a/test.bats
+++ b/test.bats
@@ -38,6 +38,11 @@ setup() {
   run_cmd orion cmd --config "examples/readout-control-plane-node-density.yaml" --hunter-analyze --output-format json --save-output-path=output.json
 }
 
+@test "orion cmd readout control plane node-density with json output and match all iterations " {
+  run_cmd orion cmd --config "examples/readout-control-plane-node-density.yaml" --hunter-analyze --output-format json --save-output-path=output.json --node-count True
+}
+
+
 @test "orion cmd readout netperf tcp with junit output " {
   run_cmd orion cmd --config "examples/readout-netperf-tcp.yaml" --output-format junit --hunter-analyze --save-output-path=output.xml
 }


### PR DESCRIPTION
## Type of change

- [X] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This change will allow us to match uuids no matter there jobIterations. This is important for node-density because the number of iterations is calculated based on how many nodes are currently on the cluster and this number can fluctuate. 

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
The old way of running produces less results than the new flag

orion cmd --config examples/trt-external-payload-node-density.yaml --lookback 5d  --hunter-analyze 
```
,uuid,timestamp,podReadyLatency_P99,apiserverCPU_avg,ovnCPU_avg,etcdCPU_avg,kubelet_avg,buildUrl
0,0d472812-58c4-4d17-9241-595e54e789a1,2024-08-04T05:20:49.559886961Z,3000,8.346889860243925,2.4993164237465395,8.512982301910718,24.588333408037823,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1819941002970927104
1,73a5ddf9-1ad9-463a-866c-0bb7ee33fa2d,2024-08-06T09:53:53.960806551Z,2000,9.917386528040515,2.9165261534623683,8.232103824615479,23.14861095448335,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820732996609642496
2,aba6b499-1e6b-455b-94bf-f1f360387c25,2024-08-06T15:42:13.289451287Z,3000,8.68606343644766,2.8989181143536698,7.900732731377637,24.709259218639797,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820818543520780288
3,707cf66f-c7de-473d-9155-a35fb81b6b44,2024-08-06T19:51:56.020648472Z,3000,9.36453001043119,2.842460772863333,8.242996867332193,24.676388904452324,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820883258565464064
4,6d99bef0-c342-4ccb-9d04-2ef7a54c479f,2024-08-07T01:54:37.370508933Z,2000,8.907801432446286,2.562429538004141,7.662414407150613,23.09930546581745,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820972948597510144
5,e212ce7c-ddf2-4967-89d4-52a637f092ff,2024-08-07T14:43:08.617067442Z,3000,8.03217322994955,2.490557001078843,8.363801335295042,25.229444408416747,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1821167776920768512
```


orion cmd --config examples/trt-external-payload-node-density.yaml --lookback 5d  --hunter-analyze --node-count True
```
,uuid,timestamp,podReadyLatency_P99,apiserverCPU_avg,ovnCPU_avg,etcdCPU_avg,kubelet_avg,buildUrl
0,a65533b2-b96b-4975-a683-5c8c41317db9,2024-08-02T22:44:13.115031954Z,3000,9.05506926860005,2.6793121076059183,7.832702014181349,24.659876682140208,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1819476387262631936
1,3bf39005-d8b3-4167-a003-63c258582527,2024-08-03T03:40:00.061127136Z,2000,9.333829958437542,3.0431592265737812,8.905316504221114,25.346031677155267,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1819552804872654848
2,ca470b99-684f-4804-8040-245469d36a0a,2024-08-03T12:06:39.550167246Z,2000,10.04589718492103,2.938977014894182,8.667146306107009,22.56984125432514,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1819681099010281472
3,0d472812-58c4-4d17-9241-595e54e789a1,2024-08-04T05:20:49.559886961Z,3000,8.346889860243925,2.4993164237465395,8.512982301910718,24.588333408037823,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1819941002970927104
4,e9b93114-6cc1-412d-b628-c046e7a1d4ca,2024-08-05T08:31:46.013914888Z,3000,8.460509004894508,2.836086990957304,7.733555127349165,22.969444140791893,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820348477922611200
5,22d07632-578d-46ac-82a2-04b2ece66283,2024-08-05T22:20:36.740563901Z,2000,7.813337978324853,2.595532922870286,8.23953664302826,24.6055556624024,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820557122354548736
6,c2cf30e0-ab8c-4714-b78a-1645cdfa411e,2024-08-06T05:35:24.554795997Z,2000,9.24912150722273,2.582041348531111,8.039307292964724,24.625925969194483,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820667850361147392
7,73a5ddf9-1ad9-463a-866c-0bb7ee33fa2d,2024-08-06T09:53:53.960806551Z,2000,9.917386528040515,2.9165261534623683,8.232103824615479,23.14861095448335,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820732996609642496
8,aba6b499-1e6b-455b-94bf-f1f360387c25,2024-08-06T15:42:13.289451287Z,3000,8.68606343644766,2.8989181143536698,7.900732731377637,24.709259218639797,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820818543520780288
9,707cf66f-c7de-473d-9155-a35fb81b6b44,2024-08-06T19:51:56.020648472Z,3000,9.36453001043119,2.842460772863333,8.242996867332193,24.676388904452324,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820883258565464064
10,6d99bef0-c342-4ccb-9d04-2ef7a54c479f,2024-08-07T01:54:37.370508933Z,2000,8.907801432446286,2.562429538004141,7.662414407150613,23.09930546581745,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1820972948597510144
11,2cbbe23a-bfca-4b1c-831f-1402fa443eb5,2024-08-07T06:29:02.30197508Z,2000,8.41378196755131,2.6346652609732533,8.286598180915103,23.116049263212417,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1821044084718964736
12,e212ce7c-ddf2-4967-89d4-52a637f092ff,2024-08-07T14:43:08.617067442Z,3000,8.03217322994955,2.490557001078843,8.363801335295042,25.229444408416747,https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-payload-control-plane-6nodes/1821167776920768512

```