### PR TITLE
Max lookback

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Orion now supports anomaly detection for your data. Use the ```--anomaly-detecti
 
 You can now constrain your look-back period using the ```--lookback``` option. The format for look-back is ```XdYh```, where X represents the number of days and Y represents the number of hours.
 
+To specify how many runs to look back, you can use the ```--lookback-size``` option. By default, this option is set to 10000.
+
 You can open the match requirement by using the ```--node-count``` option to find any matching uuid based on the metadata and not have to have the same jobConfig.jobIterations. This variable is a ```True``` or ```False```, defaulted to False. 
 
 **_NOTE:_**  The ```--hunter-analyze``` and ```--anomaly-detection``` flags are mutually exclusive. They cannot be used together because they represent different algorithms designed for distinct use cases.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,33 @@ You can now constrain your look-back period using the ```--lookback``` option. T
 
 To specify how many runs to look back, you can use the ```--lookback-size``` option. By default, this option is set to 10000.
 
+**_Note_** This particular feature clashes along with the idea of having to lookback for X number of days. The precedence of both the flags are equal and the using both at the same time returns the runs until the cutoff whichever is shorter. To provide precedence context one can understand the following example:
+
+Consider the following runs
+```
+1 -- 21 Aug
+2 -- 22 Aug
+3 -- 22 Aug
+4 -- 22 Aug
+5 -- 23 Aug
+6 -- 23 Aug
+7 -- 24 Aug
+8 -- 25 Aug
+9 -- 26 Aug
+```
+Today is 27 Aug, and 
+case 1: we want to get data of previous 5 days, the `--lookback` flag gets us the runs [2,9]
+case 2: we want to get data of previous 6 runs, the `--lookback-size` flag gets us the runs [4,9]
+case 3: when we use both `--lookback` and `--lookback-size`
+- Consider we pass `--lookback 5d --lookback-size 6` now this gets the union of both [2,9] and [4,9] which is [4,9]
+- Consider we pass `--lookback 3d --lookback-size 6` now this gets the union of both [7,9] and [4,9] which is [7,9]
+
+This is similar to how car manufacturers warranty plays out such as 5years or 60k miles whichever comes first.
+
+**Why we do not want higher precedence for a single flag?**
+- These flags are optional to use, if we give higher precedence to a single flag and use both flags, the same functionality  can be achieved by just passing the single flag(higher precedence) and ignoring the other.
+- In a use case where we would like to just see latest n number of runs and restricted to a date, using both operators can achieve it. Say I want latest 15 runs from past 10 days, this way of having no precedence allows us to have it. If there are more than 15 runs it gets only 15 runs, if there are less than 15 runs it gets the last 10 days runs.
+
 You can open the match requirement by using the ```--node-count``` option to find any matching uuid based on the metadata and not have to have the same jobConfig.jobIterations. This variable is a ```True``` or ```False```, defaulted to False. 
 
 **_NOTE:_**  The ```--hunter-analyze``` and ```--anomaly-detection``` flags are mutually exclusive. They cannot be used together because they represent different algorithms designed for distinct use cases.

--- a/orion.py
+++ b/orion.py
@@ -114,7 +114,7 @@ def cmd_analysis(**kwargs):
     logger_instance = SingletonLogger(debug=level, name="Orion")
     logger_instance.info("🏹 Starting Orion in command-line mode")
     kwargs["configMap"] = load_config(kwargs["config"])
-    output = run(**kwargs)
+    output, regression_flag = run(**kwargs)
     if output is None:
         logger_instance.error("Terminating test")
         sys.exit(0)
@@ -126,6 +126,8 @@ def cmd_analysis(**kwargs):
         output_file_name = f"{kwargs['save_output_path'].split('.')[0]}_{test_name}.{kwargs['save_output_path'].split('.')[1]}"
         with open(output_file_name, 'w', encoding="utf-8") as file:
             file.write(str(result_table))
+    if regression_flag:
+        sys.exit(1)
 
 
 

--- a/orion.py
+++ b/orion.py
@@ -106,6 +106,7 @@ def cli(max_content_width=120):  # pylint: disable=unused-argument
 @click.option("--convert-tinyurl", is_flag=True, help="Convert buildUrls to tiny url format for better formatting")
 @click.option("--collapse", is_flag=True, help="Only outputs changepoints, previous and later runs in the xml format")
 @click.option("--node-count", default=False, help="Match any node iterations count")
+@click.option("--lookback-size", type=int, default=10000, help="Maximum number of entries to be looked back")
 def cmd_analysis(**kwargs):
     """
     Orion runs on command line mode, and helps in detecting regressions

--- a/pkg/algorithms/algorithm.py
+++ b/pkg/algorithms/algorithm.py
@@ -30,8 +30,9 @@ class Algorithm(ABC):
         self.test = test
         self.options = options
         self.metrics_config = metrics_config
+        self.regression_flag = False
 
-    def output_json(self) -> Tuple[str, str]:
+    def output_json(self) -> Tuple[str, str, bool]:
         """Method to output json output
 
         Returns:
@@ -64,9 +65,9 @@ class Algorithm(ABC):
                     ] = percentage_change
                     dataframe_json[index]["is_changepoint"] = True
 
-        return self.test["name"], json.dumps(dataframe_json, indent=2)
+        return self.test["name"], json.dumps(dataframe_json, indent=2), self.regression_flag
 
-    def output_text(self) -> Tuple[str,str]:
+    def output_text(self) -> Tuple[str,str, bool]:
         """Outputs the data in text/tabular format"""
         series, change_points_by_metric = self._analyze()
         change_points_by_time = self.group_change_points_by_time(
@@ -76,9 +77,9 @@ class Algorithm(ABC):
         output_table = report.produce_report(
             test_name=self.test["name"], report_type=ReportType.LOG
         )
-        return self.test["name"], output_table
+        return self.test["name"], output_table, self.regression_flag
 
-    def output_junit(self) -> Tuple[str,str]:
+    def output_junit(self) -> Tuple[str,str, bool]:
         """Output junit format
 
         Returns:
@@ -92,7 +93,7 @@ class Algorithm(ABC):
             metrics_config=self.metrics_config,
             options=self.options,
         )
-        return test_name, data_junit
+        return test_name, data_junit, self.regression_flag
 
     @abstractmethod
     def _analyze(self):

--- a/pkg/algorithms/edivisive/edivisive.py
+++ b/pkg/algorithms/edivisive/edivisive.py
@@ -25,5 +25,6 @@ class EDivisive(Algorithm):
                 if ((self.metrics_config[metric]["direction"] == 1 and changepoint_list[i].stats.mean_1 > changepoint_list[i].stats.mean_2) or
                     (self.metrics_config[metric]["direction"] == -1 and changepoint_list[i].stats.mean_1 < changepoint_list[i].stats.mean_2) ):
                     del changepoint_list[i]
-
+        if [val for li in change_points_by_metric.values() for val in li]:
+            self.regression_flag=True
         return series, change_points_by_metric

--- a/pkg/algorithms/isolationforest/isolationForest.py
+++ b/pkg/algorithms/isolationforest/isolationForest.py
@@ -70,5 +70,6 @@ class IsolationForestWeightedMean(Algorithm):
                                                            pvalue=1
                                                        ))
                             change_points_by_metric[feature].append(change_point)
-
+        if [val for li in change_points_by_metric.values() for val in li]:
+            self.regression_flag=True
         return series, change_points_by_metric

--- a/pkg/daemon.py
+++ b/pkg/daemon.py
@@ -53,7 +53,8 @@ async def daemon_changepoint( # pylint: disable = R0913
     filter_changepoints = (
         True if filter_changepoints == "true" else False  # pylint: disable = R1719
     )
-    result = runTest.run(**option_arguments)
+    result, _ = runTest.run(**option_arguments)
+    result = {k:json.loads(v) for k,v in result.items()}
     if result is None:
         return {"Error":"No UUID with given metadata"}
     result = {k:json.loads(v) for k,v in result.items()}
@@ -129,7 +130,8 @@ async def daemon_anomaly( # pylint: disable = R0913, R0914
     filter_points = (
         True if filter_points == "true" else False  # pylint: disable = R1719
     )
-    result = runTest.run(**option_arguments)
+    result, _ = runTest.run(**option_arguments)
+    result = {k:json.loads(v) for k,v in result.items()}
     if result is None:
         return {"Error":"No UUID with given metadata"}
     result = {k:json.loads(v) for k,v in result.items()}

--- a/pkg/runTest.py
+++ b/pkg/runTest.py
@@ -10,7 +10,7 @@ from pkg.utils import get_datasource, process_test, get_subtracted_timestamp
 
 
 
-def run(**kwargs: dict[str, Any]) -> dict[str, Any]:
+def run(**kwargs: dict[str, Any]) -> dict[str, Any]: #pylint: disable = R0914
     """run method to start the tests
 
     Args:
@@ -26,6 +26,7 @@ def run(**kwargs: dict[str, Any]) -> dict[str, Any]:
     config_map = kwargs["configMap"]
     datasource = get_datasource(config_map)
     result_output = {}
+    regression_flag = False
     for test in config_map["tests"]:
         # Create fingerprint Matcher
         matcher = Matcher(
@@ -42,7 +43,6 @@ def run(**kwargs: dict[str, Any]) -> dict[str, Any]:
             kwargs,
             start_timestamp,
         )
-
         if fingerprint_matched_df is None:
             return None
 
@@ -62,9 +62,10 @@ def run(**kwargs: dict[str, Any]) -> dict[str, Any]:
                 kwargs,
                 metrics_config,
             )
-        testname, result_data = algorithm.output(kwargs["output_format"])
+        testname, result_data, test_flag = algorithm.output(kwargs["output_format"])
         result_output[testname] = result_data
-    return result_output
+        regression_flag = regression_flag or test_flag
+    return result_output, regression_flag
 
 
 def get_start_timestamp(kwargs: Dict[str, Any]) -> str:

--- a/pkg/utils.py
+++ b/pkg/utils.py
@@ -263,6 +263,7 @@ def process_test(
             else buildUrls[uuid]
         )  # pylint: disable = cell-var-from-loop
     )
+    merged_df=merged_df.reset_index(drop=True)
     #save the dataframe
     output_file_path = f"{options['save_data_path'].split('.')[0]}-{test['name']}.csv"
     match.save_results(merged_df, csv_file_path=output_file_path)

--- a/pkg/utils.py
+++ b/pkg/utils.py
@@ -221,7 +221,7 @@ def process_test(
     # getting metadata
     metadata = extract_metadata_from_test(test) if options["uuid"] in ("", None) else get_metadata_with_uuid(options["uuid"], match)
     # get uuids, buildUrls matching with the metadata
-    runs = match.get_uuid_by_metadata(metadata, fingerprint_index, lookback_date=start_timestamp)
+    runs = match.get_uuid_by_metadata(metadata, fingerprint_index, lookback_date=start_timestamp, lookback_size=options['lookback_size'])
     uuids = [run["uuid"] for run in runs]
     buildUrls = {run["uuid"]: run["buildUrl"] for run in runs}
     # get uuids if there is a baseline


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Added to lookback for n number of runs. Do not merge unit fmatch 0.0.9 and #57 is merged
```
(venv) sboyapal orion (max-lookback) >> orion cmd --hunter-analyze --lookback-size=15
2024-08-19 16:32:00,136 - Orion      - INFO - file: orion.py - line: 116 - 🏹 Starting Orion in command-line mode
2024-08-19 16:32:00,139 - Orion      - INFO - file: utils.py - line: 218 - The test aws-small-scale-cluster-density-v2 has started
2024-08-19 16:32:00,139 - Matcher    - INFO - file: matcher.py - line: 66 - Executing query against index=ospst-perf-scale-ci-*
2024-08-19 16:32:00,861 - Matcher    - INFO - file: matcher.py - line: 66 - Executing query against index=ospst-ripsaw-kube-burner*
2024-08-19 16:32:01,071 - Orion      - INFO - file: utils.py - line: 52 - Collecting podReadyLatency
2024-08-19 16:32:01,071 - Matcher    - INFO - file: matcher.py - line: 66 - Executing query against index=ospst-ripsaw-kube-burner*
2024-08-19 16:32:01,272 - Orion      - INFO - file: utils.py - line: 52 - Collecting apiserverCPU
2024-08-19 16:32:01,272 - Matcher    - INFO - file: matcher.py - line: 66 - Executing query against index=ospst-ripsaw-kube-burner*
2024-08-19 16:32:04,082 - Orion      - INFO - file: utils.py - line: 52 - Collecting ovnCPU
2024-08-19 16:32:04,082 - Matcher    - INFO - file: matcher.py - line: 66 - Executing query against index=ospst-ripsaw-kube-burner*
2024-08-19 16:32:06,093 - Orion      - INFO - file: utils.py - line: 52 - Collecting etcdCPU
2024-08-19 16:32:06,093 - Matcher    - INFO - file: matcher.py - line: 66 - Executing query against index=ospst-ripsaw-kube-burner*
2024-08-19 16:32:07,905 - Orion      - INFO - file: utils.py - line: 52 - Collecting etcdDisk
2024-08-19 16:32:07,905 - Matcher    - INFO - file: matcher.py - line: 66 - Executing query against index=ospst-ripsaw-kube-burner*
aws-small-scale-cluster-density-v2
==================================
time                       uuid                                  buildUrl                                                                                                                                                                                                                            podReadyLatency_P99    apiserverCPU_avg    ovnCPU_avg    etcdCPU_avg    etcdDisk_avg
-------------------------  ------------------------------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ---------------------  ------------------  ------------  -------------  --------------
2024-07-09 02:36:57 +0000  108ae357-69b1-450f-841b-e31192b06124  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-etcdencrypt-24nodes/1810464372661686272                                                            13000             9.23414       2.60243        6.77876       0.015257
2024-07-09 03:57:37 +0000  1992c5cc-14a6-4b9c-821c-9c9190e33fee  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-24nodes/1810494340527558656                                                                        13000             9.22411       2.68723        6.44685       0.0164871
2024-07-12 05:59:57 +0000  19cc5420-7874-4a1d-a7a4-145b2cb1e137  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/53778/rehearse-53778-pull-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-24nodes-acs/1811616167136071680                  13000            13.6386        2.70217        7.19755       0.0176438
2024-07-12 17:12:09 +0000  61b2585e-bae0-43c6-b20e-7836d82966d0  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/53778/rehearse-53778-pull-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-24nodes-acs/1811785760332845056                  13000            13.5351        2.82861        7.47695       0.0153671
2024-07-16 10:30:54 +0000  f7542179-1f7f-49f7-9d97-8d1dd6ce84a4  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-etcdencrypt-24nodes/1813121615911718912                                                            13000             9.19822       2.63155        6.7938        0.0147343
2024-07-16 13:57:59 +0000  1480099e-e108-4ee9-9519-722e63ed87b9  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-24nodes/1813182064762032128                                                                        13000             9.08859       2.63408        6.55184       0.0172996
2024-07-17 11:24:00 +0000  040128c5-b39c-43c3-8ca9-dfb9b10e91e9  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-loaded-upgrade-from-4.16-loaded-upgrade-416to417-24nodes/1813514179735195648                                     13000            13.2697        2.49219        8.41471       0.0226731
2024-07-24 11:08:53 +0000  34812eed-0200-4ac1-9312-874706b35730  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-loaded-upgrade-from-4.16-loaded-upgrade-416to417-24nodes/1816050985663991808                                     13000            13.3616        2.52808        8.72798       0.0216129
2024-08-02 10:48:28 +0000  9a52078d-1f01-43bd-8bc3-81e6deb18965  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-etcdencrypt-24nodes/1819282228899745792                                                            13000             9.10756       2.74433        6.59389       0.0149613
2024-08-02 13:46:48 +0000  3384ae7d-8c37-4750-ae36-4d4eb7571bca  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-24nodes/1819342668765859840                                                                        13000             9.65455       2.60241        6.97501       0.0139434
2024-08-03 11:04:05 +0000  d4aa2b85-2bcf-4dbb-a6e8-acf3ce184289  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-loaded-upgrade-from-4.16-loaded-upgrade-416to417-24nodes/1819674770665377792                                     13000            13.554         2.55718        8.47033       0.0155697
2024-08-10 10:51:39 +0000  e4555243-7beb-4535-b2aa-271917e2ad0c  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-loaded-upgrade-from-4.16-loaded-upgrade-416to417-24nodes/1822211571330322432                                     13000            13.42          2.55408        8.64175       0.0253407
2024-08-16 10:19:01 +0000  87c6e9ad-6ac5-459e-b5f4-b47108a72414  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-etcdencrypt-24nodes/1824355887179894784                                                            13000             9.18769       2.65559        6.82992       0.0165064
2024-08-16 13:46:53 +0000  7b481c82-438e-4461-a4ac-ea7da4f0b5f3  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-control-plane-24nodes/1824416115749556224                                                                        13000             9.17754       2.72878        6.85646       0.0164923
2024-08-17 11:01:37 +0000  362922df-34ff-44bd-b741-e4a5b437df67  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-loaded-upgrade-from-4.16-loaded-upgrade-416to417-24nodes/1824748253506179072                                     13000            13.4152        2.57022        8.58397       0.0172752
```
## Context
This particular feature clashes along with the idea of having to lookback for X number of days. The precedence of both the flags are equal and the it returns the runs until the cutoff whichever is shorter. To provide precedency one can understand the following example:

Consider the following runs
```
1 -- 21 Aug
2 -- 22 Aug
3 -- 22 Aug
4 -- 22 Aug
5 -- 23 Aug
6 -- 23 Aug
7 -- 24 Aug
8 -- 25 Aug
9 -- 26 Aug
```
Today is 27 Aug, and 
case 1: we want to get data of previous 5 days, the `--lookback` flag gets us the runs [2,9]
case 2: we want to get data of previous 6 runs, the `--lookback-size` flag gets us the runs [4,9]
case 3: when we use both `--lookback` and `--lookback-size`
- Consider we pass `--lookback 5d --lookback-size 6` now this gets the union of both [2,9] and [4,9] which is [4,9]
- Consider we pass `--lookback 3d --lookback-size 6` now this gets the union of both [7,9] and [4,9] which is [7,9]

This is similar to how car manufacturers warranty plays out such as 5years of 60k miles.

### Why we do not want higher precedence for a single flag?
- These flags are optional to use, if we give higher precedence to a single flag and use both flags the same functionality  can be achieved by  just passing the single flag(higher precedence) and ignoring the other.
- In a use case where we would like to just see latest n number of runs and restricted to a date, using both operators can achieve it. Say I want latest 15 runs from past 10 days, this way of having no precedence allows us to have it. If there are more than 15 runs it gets only 15 runs, if there are less than 15 runs it gets the last 10 days runs.

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
