### PR TITLE
Previous version comparison and baseline updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Clone the current repository using git clone.
 >> source venv/bin/activate
 >> pip install -r requirements.txt
 >> export ES_SERVER = <es_server_url>
+>> export version=<ocp version>
 >> pip install .
 ```
 ## Run Orion
@@ -198,10 +199,9 @@ POST http://127.0.0.1:8080/daemon/changepoint
 
 - uuid (optional): The uuid of the run you want to compare with similar runs.
 - baseline (optional): The runs you want to compare with.
-- version (optional): The ocpVersion you want to use for metadata defaults to `4.15`
 - filter_changepoints (optional): set to `true` if you only want changepoints to show up in the response
 - test_name (optional): name of the test you want to perform defaults to `small-scale-cluster-density`
-
+- previous-version (optional): Compare most recent run or given UUID with previous versions
 
 Example
 ```

--- a/orion.py
+++ b/orion.py
@@ -116,6 +116,7 @@ def cli(max_content_width=120):  # pylint: disable=unused-argument
 @click.option("--collapse", is_flag=True, help="Only outputs changepoints, previous and later runs in the xml format")
 @click.option("--node-count", default=False, help="Match any node iterations count")
 @click.option("--lookback-size", type=int, default=10000, help="Maximum number of entries to be looked back")
+@click.option("--previous-version", is_flag=True, default=False, help="Match with previous version from metadata")
 def cmd_analysis(**kwargs):
     """
     Orion runs on command line mode, and helps in detecting regressions

--- a/test.bats
+++ b/test.bats
@@ -62,6 +62,12 @@ setup() {
   export version=$(echo "$LATEST_VERSION" | cut -d. -f1,2)
 }
 
+
+@test "orion cmd with previous version" {
+  run_cmd orion cmd --config "configs/small-scale-cluster-density.yaml" --previous-version
+}
+
+
 @test "orion cmd label small scale cluster density with hunter-analyze " {
   run_cmd orion cmd --config "examples/label-small-scale-cluster-density.yaml" --lookback 5d --hunter-analyze
 }


### PR DESCRIPTION
## Type of change

- [X] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In this PR I have added a way for us to compare data on with the most recent run (or specified uuid) to a previous release

I also updated the code that if a baseline uuid is given we do not need to call to get the metadata specified as a user would expect only the data of the uuid and baseline uuid to be defined in their output

## Related Tickets & Documents

- Closes #46 

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
`orion cmd --config configs/small-scale-cluster-density.yaml --previous-version `


A change that might still be needed past this is adding in a column into the base information of the run to show the version 