### PR TITLE
ACK 4.18 node-density run linked to same cdv2 regression nightly

### DIFF
--- a/ack/4.18_cluster-density_ack.yaml
+++ b/ack/4.18_cluster-density_ack.yaml
@@ -15,3 +15,12 @@ ack:
   - uuid: 35bbc7f2-195c-43c2-8d43-62142d8bb33a
     metric: ovnCPU_avg
     reason: "Opened Bug: https://issues.redhat.com/browse/OCPBUGS-49613"
+  - uuid: 90e38f9e-9b90-4f8a-af97-8ccbdb3ef800
+    metric: ovnCPU_avg
+    reason: "See OCPBUGS-49613"
+  - uuid: 90e38f9e-9b90-4f8a-af97-8ccbdb3ef800
+    metric: podReadyLatency_P99
+    reason: "Latency increase overlaps with ovnCPU_avg. See OCPBUGS-49613"
+  - uuid: 373effda-bcfd-42fe-8ba5-fd539bf2c755
+    metric: kubelet_avg
+    reason: "False positive. Values look fine."

--- a/ack/4.18_node-density_ack.yaml
+++ b/ack/4.18_node-density_ack.yaml
@@ -3,6 +3,12 @@ ack:
   - uuid: 7f7337aa-cee3-4a36-b154-a7c48ed1fb75
     metric: etcdCPU_avg
     reason: "Below 10%"
-  - uuid: 35bbc7f2-195c-43c2-8d43-62142d8bb33a
+  - uuid: fc420bd9-fde1-48ad-ab7b-7843c32164b8
     metric: ovnCPU_avg
     reason: "Opened Bug: https://issues.redhat.com/browse/OCPBUGS-49613"
+  - uuid: ace8d433-0e4a-4758-9e84-6d5c7566a3ec
+    metric: ovnCPU_avg
+    reason: "See OCPBUGS-49613"
+  - uuid: ace8d433-0e4a-4758-9e84-6d5c7566a3ec
+    metric: podReadyLatency_P99
+    reason: "See OCPBUGS-49613"

--- a/ack/4.19_cluster-density_ack.yaml
+++ b/ack/4.19_cluster-density_ack.yaml
@@ -3,6 +3,9 @@ ack:
   - uuid: cfae6e1e-8c47-4628-be52-8705c8c64285
     metric: kubelet_avg
     reason: "kube-burner change which increased cpu for kubelet, it was reverted."
-  - uuid: 35bbc7f2-195c-43c2-8d43-62142d8bb33a
+  - uuid: a7006f55-489b-4b79-96ed-5d3fd3f050b0
     metric: ovnCPU_avg
     reason: "Opened Bug: https://issues.redhat.com/browse/OCPBUGS-49613"
+  - uuid: 858c1aa1-eb87-4551-b6b8-f432807fff8d
+    metric: podReadyLatency_P99
+    reason: "Opened Bug: https://issues.redhat.com/browse/OCPBUGS-50522"

--- a/ack/4.19_node-density_ack.yaml
+++ b/ack/4.19_node-density_ack.yaml
@@ -1,5 +1,5 @@
 ---
 ack:
-  - uuid: 35bbc7f2-195c-43c2-8d43-62142d8bb33a
+  - uuid: fe3c49e3-0b53-4fb1-88bf-bbf3bd187efc
     metric: ovnCPU_avg
     reason: "Opened Bug: https://issues.redhat.com/browse/OCPBUGS-49613"


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

ACK'ing the node-density UUID from the nightly we already have OCPBUGS-49613 open for.

## Related Tickets & Documents

- Related Issue: OCPBUGS-49613

## Checklist before requesting a review

- [x] I have performed a self-review of my code.