### PR TITLE
Enabling collapse for both JSON and JUNIT output formats

### DIFF
--- a/examples/ols-load-generator.yaml
+++ b/examples/ols-load-generator.yaml
@@ -1,7 +1,7 @@
 tests :
   - name : ols-load-generator-{{ ols_test_workers }}w-5m
-    index: perf_scale_ci*
-    benchmarkIndex: ols-load-test-results*
+    index: {{ es_metadata_index }}
+    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       olsTestWorkers: {{ ols_test_workers }}
       olsTestDuration: "5m"
@@ -128,8 +128,8 @@ tests :
       direction: 1
 
   - name : ols-load-generator-{{ ols_test_workers }}w-10m
-    index: perf_scale_ci*
-    benchmarkIndex: ols-load-test-results*
+    index: {{ es_metadata_index }}
+    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       olsTestWorkers: {{ ols_test_workers }}
       olsTestDuration: "10m"
@@ -256,8 +256,8 @@ tests :
       direction: 1
 
   - name : ols-load-generator-{{ ols_test_workers }}w-20m
-    index: perf_scale_ci*
-    benchmarkIndex: ols-load-test-results*
+    index: {{ es_metadata_index }}
+    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       olsTestWorkers: {{ ols_test_workers }}
       olsTestDuration: "20m"

--- a/test.bats
+++ b/test.bats
@@ -118,7 +118,7 @@ setup() {
 
 @test "orion cmd ols configuration test " {
   export ols_test_workers=10
-  run_cmd orion cmd --config "examples/ols-load-generator.yaml" --hunter-analyze
+  es_metadata_index="perf_scale_ci*" es_benchmark_index="ols-load-test-results*" run_cmd orion cmd --config "examples/ols-load-generator.yaml" --hunter-analyze
 }
 
 @test "orion daemon small scale cluster density with anomaly detection " {


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Enabling collapse for both JSON and JUNIT output workflows. This will help us only look at changepoints and few points around it when `--collapse` is specified as a parameter.

## Related Issue 
It is very hard to interpret the entire output in JSON and JUNIT formats when this filter is not applied. Hoping for this code change to fix it.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
JUNIT
```
orion cmd --config examples/readout-control-plane-cdv2.yaml --hunter-analyze --output-format junit --collapse
cdv2-kube-apiserver-etcd-249nodes
=================================
<?xml version="1.0" ?>
<testsuites>
	<testsuite name="cdv2-kube-apiserver-etcd-249nodes nightly compare" failures="2" tests="4">
		<testcase name=" CPU_Usage_kube-apiserver_avg regression detection" timestamp="1739904386">
			<failure>
+----+--------------------------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------+------------------+---------------------+
|    | uuid                                 | timestamp            | buildUrl                                                                                                                                                                          |   CPU_Usage_kube-apiserver_avg | is_changepoint   |   percentage_change |
|----+--------------------------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------+------------------+---------------------|
|  0 | 56e2f264-42a6-4cfc-bd68-2cd0e2f2de87 | 2024-05-01T11:39:18Z | https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.15-nightly-x86-cluster-density-v2-249nodes/1785580293059514368 |                        2.49575 | False            |              0      |
|  1 | 862c1600-77a4-44d4-9485-0baf8405a52d | 2024-05-08T11:57:34Z | https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.15-nightly-x86-cluster-density-v2-249nodes/1788116834482917376 |                        2.8695  | True             |             13.7587 | -- changepoint
|  2 | 22fd3de6-bfcd-4eb3-92d6-74987158041d | 2024-05-15T11:44:35Z | https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.15-nightly-x86-cluster-density-v2-249nodes/1790653688797204480 |                        2.83686 | False            |              0      |
+----+--------------------------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------+------------------+---------------------+
</failure>
		</testcase>
		<testcase name=" Max_Aggregated_RSS_Usage_kube-apiserver_avg regression detection" timestamp="1739904386"/>
		<testcase name=" CPU_Usage_etcd_avg regression detection" timestamp="1739904386">
			<failure>
+----+--------------------------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+------------------+---------------------+
|    | uuid                                 | timestamp            | buildUrl                                                                                                                                                                          |   CPU_Usage_etcd_avg | is_changepoint   |   percentage_change |
|----+--------------------------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+------------------+---------------------|
|  0 | 56e2f264-42a6-4cfc-bd68-2cd0e2f2de87 | 2024-05-01T11:39:18Z | https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.15-nightly-x86-cluster-density-v2-249nodes/1785580293059514368 |             0.585683 | False            |              0      |
|  1 | 862c1600-77a4-44d4-9485-0baf8405a52d | 2024-05-08T11:57:34Z | https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.15-nightly-x86-cluster-density-v2-249nodes/1788116834482917376 |             0.754282 | True             |             27.8321 | -- changepoint
|  2 | 22fd3de6-bfcd-4eb3-92d6-74987158041d | 2024-05-15T11:44:35Z | https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.15-nightly-x86-cluster-density-v2-249nodes/1790653688797204480 |             0.729422 | False            |              0      |
+----+--------------------------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+------------------+---------------------+
</failure>
		</testcase>
		<testcase name=" Max_Aggregated_RSS_Usage_etcd_avg regression detection" timestamp="1739904386"/>
	</testsuite>
</testsuites>
```

JSON
```
orion cmd --config examples/readout-control-plane-cdv2.yaml --hunter-analyze --output-format json --collapse
cdv2-kube-apiserver-etcd-249nodes
=================================
[
  {
    "uuid": "56e2f264-42a6-4cfc-bd68-2cd0e2f2de87",
    "timestamp": 1714563558,
    "buildUrl": "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.15-nightly-x86-cluster-density-v2-249nodes/1785580293059514368",
    "metrics": {
      "CPU_Usage_kube-apiserver_avg": {
        "value": 2.4957456589,
        "percentage_change": 0
      },
      "Max_Aggregated_RSS_Usage_kube-apiserver_avg": {
        "value": 66823225344.0,
        "percentage_change": 0
      },
      "CPU_Usage_etcd_avg": {
        "value": 0.5856829584,
        "percentage_change": 0
      },
      "Max_Aggregated_RSS_Usage_etcd_avg": {
        "value": 1221199872.0,
        "percentage_change": 0
      }
    },
    "is_changepoint": false
  },
  {
    "uuid": "862c1600-77a4-44d4-9485-0baf8405a52d",
    "timestamp": 1715169454,
    "buildUrl": "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.15-nightly-x86-cluster-density-v2-249nodes/1788116834482917376",
    "metrics": {
      "CPU_Usage_kube-apiserver_avg": {
        "value": 2.8694996834,
        "percentage_change": 13.758697480438748
      },
      "Max_Aggregated_RSS_Usage_kube-apiserver_avg": {
        "value": 65120421888.0,
        "percentage_change": 0
      },
      "CPU_Usage_etcd_avg": {
        "value": 0.7542824447,
        "percentage_change": 27.8321422409534
      },
      "Max_Aggregated_RSS_Usage_etcd_avg": {
        "value": 1182590976.0,
        "percentage_change": 0
      }
    },
    "is_changepoint": true
  },
  {
    "uuid": "22fd3de6-bfcd-4eb3-92d6-74987158041d",
    "timestamp": 1715773475,
    "buildUrl": "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.15-nightly-x86-cluster-density-v2-249nodes/1790653688797204480",
    "metrics": {
      "CPU_Usage_kube-apiserver_avg": {
        "value": 2.8368564844,
        "percentage_change": 0
      },
      "Max_Aggregated_RSS_Usage_kube-apiserver_avg": {
        "value": 63856326656.0,
        "percentage_change": 0
      },
      "CPU_Usage_etcd_avg": {
        "value": 0.7294223905,
        "percentage_change": 0
      },
      "Max_Aggregated_RSS_Usage_etcd_avg": {
        "value": 1409490944.0,
        "percentage_change": 0
      }
    },
    "is_changepoint": false
  }
]
```