### PR TITLE
[PERFSCALE-3433] Add virt-density support

### DIFF
--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -9,7 +9,7 @@ tests :
       masterNodesCount: 3
       workerNodesType.keyword: ""
       workerNodesCount: 4
-      benchmark.keyword: node-density-heavy
+      benchmark.keyword: virt-density
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
 

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -21,7 +21,7 @@ tests :
       not:
         jobConfig.name: "garbage-collection"
       labels:
-        - "[Jira: PodLatency]"
+        - "[Jira: VmiLatency]"
 
     - name:  apiserverCPU
       metricName : containerCPU

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -1,5 +1,5 @@
 tests :
-  - name : metal-perfscale-cpt-node-density-heavy
+  - name : metal-perfscale-cpt-virtdensity
     index: {{ es_metadata_index }}
     benchmarkIndex: {{ es_benchmark_index }}
     metadata:

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -16,7 +16,7 @@ tests :
     metrics :
     - name:  vmiReadyLatency
       metricName: vmiLatencyQuantilesMeasurement
-      quantileName: Ready
+      quantileName: VMReady
       metric_of_interest: P99
       not:
         jobConfig.name: "garbage-collection"

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -21,7 +21,7 @@ tests :
       not:
         jobConfig.name: "garbage-collection"
       labels:
-        - "[Jira: VmiLatency]"
+        - "[Jira: PerfScale]"
 
     - name:  apiserverCPU
       metricName : containerCPU

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -1,0 +1,92 @@
+tests :
+  - name : metal-perfscale-cpt-node-density-heavy
+    index: {{ es_metadata_index }}
+    benchmarkIndex: {{ es_benchmark_index }}
+    metadata:
+      platform: BareMetal
+      clusterType: self-managed
+      masterNodesType.keyword: ""
+      masterNodesCount: 3
+      workerNodesType.keyword: ""
+      workerNodesCount: 4
+      benchmark.keyword: node-density-heavy
+      ocpVersion: {{ version }}
+      networkType: OVNKubernetes
+
+    metrics :
+    - name:  vmiReadyLatency
+      metricName: vmiLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PodLatency]"
+
+    - name:  apiserverCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-kube-apiserver
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: kube-apiserver]"
+
+    - name: multusCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-multus
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: multus]"
+
+    - name: monitoringCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-monitoring
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: monitoring]"
+
+    - name:  ovnCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+
+    - name:  etcdCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-etcd
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+
+    - name:  etcdDisk
+      metricName : 99thEtcdDiskBackendCommitDurationSeconds
+      metric_of_interest: value
+      agg:
+        value: duration
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+
+    - name: kubelet
+      metricName : kubeletCPU
+      metric_of_interest: value
+      labels:
+        - "[Jira: Node]"
+      agg:
+        value: cpu
+        agg_type: avg

--- a/test.bats
+++ b/test.bats
@@ -86,14 +86,17 @@ setup() {
   run_cmd orion cmd --config "examples/readout-control-plane-node-density.yaml" --hunter-analyze --output-format json --save-output-path=output.json --node-count True
 }
 
-
 @test "orion cmd readout netperf tcp with junit output " {
   export es_benchmark_index="k8s-netperf"
   run_cmd orion cmd --config "examples/readout-netperf-tcp.yaml" --output-format junit --hunter-analyze --save-output-path=output.xml
 }
 
+@test "orion cmd virt-density " {
+  run_cmd orion cmd --config examples/metal-perfscale-cpt-virt-density.yaml --lookback 15d --hunter-analyze
+}
+
 @test "orion cmd small scale cluster density with anomaly detection " {
-  run_cmd orion cmd --config "examples/small-scale-cluster-density.yaml" --lookback 5d --anomaly-detection 
+  run_cmd orion cmd --config "examples/small-scale-cluster-density.yaml" --lookback 5d --anomaly-detection
 }
 
 @test "orion cmd small scale node density cni anomaly detection with a window " {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add support for the virt-density workload

## Testing

```
orion cmd --config examples/metal-perfscale-cpt-virt-density.yaml --lookback 15d --hunter-analyze
2025-04-22 11:06:03,315 - Orion      - INFO - file: orion.py - line: 125 - 🏹 Starting Orion in command-line mode
2025-04-22 11:06:03,321 - Orion      - INFO - file: utils.py - line: 241 - The test metal-perfscale-cpt-virtdensity has started
2025-04-22 11:06:03,321 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=perf_scale_ci-*
2025-04-22 11:06:03,737 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=ripsaw-kube-burner-*
2025-04-22 11:06:03,864 - Orion      - INFO - file: utils.py - line: 52 - Collecting vmiReadyLatency
2025-04-22 11:06:03,864 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=ripsaw-kube-burner-*
2025-04-22 11:06:03,988 - Orion      - ERROR - file: utils.py - line: 72 - Couldn't get metrics vmiReadyLatency, exception 'timestamp'
2025-04-22 11:06:03,989 - Orion      - INFO - file: utils.py - line: 52 - Collecting apiserverCPU
2025-04-22 11:06:03,989 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=ripsaw-kube-burner-*
2025-04-22 11:06:04,771 - Orion      - INFO - file: utils.py - line: 52 - Collecting multusCPU
2025-04-22 11:06:04,772 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=ripsaw-kube-burner-*
2025-04-22 11:06:05,469 - Orion      - INFO - file: utils.py - line: 52 - Collecting monitoringCPU
2025-04-22 11:06:05,469 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=ripsaw-kube-burner-*
2025-04-22 11:06:06,505 - Orion      - INFO - file: utils.py - line: 52 - Collecting ovnCPU
2025-04-22 11:06:06,505 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=ripsaw-kube-burner-*
2025-04-22 11:06:07,645 - Orion      - INFO - file: utils.py - line: 52 - Collecting etcdCPU
2025-04-22 11:06:07,645 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=ripsaw-kube-burner-*
2025-04-22 11:06:07,915 - Orion      - INFO - file: utils.py - line: 52 - Collecting etcdDisk
2025-04-22 11:06:07,915 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=ripsaw-kube-burner-*
2025-04-22 11:06:08,065 - Orion      - INFO - file: utils.py - line: 52 - Collecting kubelet
2025-04-22 11:06:08,066 - Matcher    - INFO - file: matcher.py - line: 65 - Executing query against index=ripsaw-kube-burner-*
metal-perfscale-cpt-virtdensity
===============================
time                       uuid                                  buildUrl                                                                                                                                                                                                                          apiserverCPU_avg    multusCPU_avg    monitoringCPU_avg    ovnCPU_avg    etcdCPU_avg    etcdDisk_avg    kubelet_avg
-------------------------  ------------------------------------  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ------------------  ---------------  -------------------  ------------  -------------  --------------  -------------
2025-04-09 17:19:56 +0000  796c69d4-e6da-4686-a6d6-19b559cb60ab  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/63576/rehearse-63576-periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-latest-x86-daily-virt-6nodes/1909955347544543232             39.9121          1.2819               1.65655       7.38165        27.179       0.00211551        82.5442
2025-04-11 12:18:30 +0000  cec16171-6032-4c8e-a45d-f0e2a6f33a50  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-latest-x86-daily-virt-6nodes/1910604335176224768                                                                   38.1838          1.29651              1.7238        8.39057        26.3422      0.00230283        85.4776
2025-04-12 12:17:41 +0000  3b43430c-6247-48e1-92b3-96935f2bb2b3  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-latest-x86-daily-virt-6nodes/1910966521669095424                                                                   34.9846          1.10082              1.83616       6.72837        26.9721      0.00219237        91.5808
2025-04-13 12:19:50 +0000  80f35bd0-fb8a-4af0-830c-5e4240d69c1b  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-latest-x86-daily-virt-6nodes/1911328930829176832                                                                   37.374           1.16559              1.77984       6.50982        25.1575      0.00193925        90.7012
2025-04-18 12:46:06 +0000  5161c287-ee85-4196-a39c-62b59d1d036d  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-latest-x86-daily-virt-6nodes/1913140951249850368                                                                   42.0289          1.19714              1.83381       5.99746        25.1435      0.00205797        93.1571
2025-04-19 12:21:43 +0000  9cb213cc-b1f8-4819-8ee9-5c92086531ed  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-latest-x86-daily-virt-6nodes/1913503093274710016                                                                   49.3949          1.06481              1.82749       6.61046        26.247       0.00223316        91.3276
2025-04-20 14:21:05 +0000  a6dc9ea4-3c6b-404a-90e4-2a5d69ff999d  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-latest-x86-daily-virt-6nodes/1913865506993999872                                                                   36.1069          1.20301              1.95915       5.7773         25.3389      0.00212432        85.5051
```
