### PR TITLE
Adding custom uuid field

### DIFF
--- a/examples/chaos_results.yaml
+++ b/examples/chaos_results.yaml
@@ -1,0 +1,38 @@
+tests :
+  - name : chaos
+    index: krkn-telemetry*
+    benchmarkIndex: krkn-metrics*
+    version: cluster_version
+    uuid_field: run_uuid
+    metadata:
+      cloud_infrastructure.keyword: AWS
+      cluster_version: {{ version }}
+      scenarios.scenario_type.keyword: pod_disruption_scenarios
+      scenarios.affected_pods.recovered.namespace.keyword: openshift-monitoring
+
+    metrics :
+    - name: monitoring_recovery_time
+      metric_of_interest: total_recovery_time
+      metricName: affected_pods_recovery
+
+    - name:  masterNodeUtilCPU
+      metricName: nodeCPUSeconds-Masters
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: max
+  
+    - name: workerNodeUtilCPU
+      metricName: nodeCPUSeconds-Workers
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: max
+
+    - name: kubelet 
+      metricName : cpu-kubelet 
+      metric_of_interest: value
+      agg: 
+        value: cpu 
+        agg_type: avg
+      direction: 1

--- a/pkg/utils.py
+++ b/pkg/utils.py
@@ -21,411 +21,436 @@ import pyshorteners
 from pkg.constants import NANO_SECONDS_PATTERN
 
 
-# pylint: disable=too-many-locals
-def get_metric_data(
-    uuids: List[str], index: str, metrics: Dict[str, Any], match: Matcher, test_threshold: int, timestamp_field: str="timestamp"
-) -> List[pd.DataFrame]:
-    """Gets details metrics based on metric yaml list
-
-    Args:
-        ids (list): list of all uuids
-        index (dict): index in es of where to find data
-        metrics (dict): metrics to gather data on
-        match (Matcher): current matcher instance
-        logger (logger): log data to one output
-
-    Returns:
-        dataframe_list: dataframe of the all metrics
+class Utils:
     """
-    logger_instance = SingletonLogger.getLogger("Orion")
-    dataframe_list = []
-    metrics_config = {}
+    Helper utils class
+    """
 
-    for metric in metrics:
-        metric_name = metric["name"]
-        metric_value_field = metric["metric_of_interest"]
+    def __init__(self, uuid_field: str ="uuid", version_field: str ="ocpVersion"):
+        """Instanciates utils class with uuid and version fields 
 
-        labels = metric.pop("labels", None)
-        direction = int(metric.pop("direction", 0))
-        threshold = abs(int(metric.pop("threshold", test_threshold)))
-        timestamp_field = metric.pop("timestamp", timestamp_field)
-        correlation = metric.pop("correlation", "")
-        context = metric.pop("context", 5)
-        logger_instance.info("Collecting %s", metric_name)
-        try:
-            if "agg" in metric:
-                metric_df, metric_dataframe_name = process_aggregation_metric(
-                    uuids, index, metric, match, timestamp_field
+        Args:
+            uuid_field (str): key to find the uuid
+            version_field (str): key to find the version
+        """
+        self.uuid_field = uuid_field
+        self.version_field = version_field
+
+    # pylint: disable=too-many-locals
+    def get_metric_data(
+        self, uuids: List[str], index: str, metrics: Dict[str, Any], match: Matcher, test_threshold: int, timestamp_field: str="timestamp"
+    ) -> List[pd.DataFrame]:
+        """Gets details metrics based on metric yaml list
+
+        Args:
+            ids (list): list of all uuids
+            index (dict): index in es of where to find data
+            metrics (dict): metrics to gather data on
+            match (Matcher): current matcher instance
+            logger (logger): log data to one output
+
+        Returns:
+            dataframe_list: dataframe of the all metrics
+        """
+        logger_instance = SingletonLogger.getLogger("Orion")
+        dataframe_list = []
+        metrics_config = {}
+
+        for metric in metrics:
+            metric_name = metric["name"]
+            metric_value_field = metric["metric_of_interest"]
+
+            labels = metric.pop("labels", None)
+            direction = int(metric.pop("direction", 0))
+            threshold = abs(int(metric.pop("threshold", test_threshold)))
+            timestamp_field = metric.pop("timestamp", timestamp_field)
+            correlation = metric.pop("correlation", "")
+            context = metric.pop("context", 5)
+            logger_instance.info("Collecting %s", metric_name)
+            try:
+                if "agg" in metric:
+                    metric_df, metric_dataframe_name = self.process_aggregation_metric(
+                        uuids, index, metric, match, timestamp_field
+                    )
+                else:
+                    metric_df, metric_dataframe_name = self.process_standard_metric(
+                        uuids, index, metric, match, metric_value_field, timestamp_field
+                    )
+                metric["labels"] = labels
+                metric["direction"] = direction
+                metric["threshold"] = threshold
+                metric["correlation"] = correlation
+                metric["context"] = context
+                metrics_config[metric_dataframe_name] = metric
+                dataframe_list.append(metric_df)
+                logger_instance.debug(metric_df)
+            except Exception as e:
+                logger_instance.error(
+                    "Couldn't get metrics %s, exception %s",
+                    metric_name,
+                    e,
                 )
-            else:
-                metric_df, metric_dataframe_name = process_standard_metric(
-                    uuids, index, metric, match, metric_value_field, timestamp_field
-                )
-            metric["labels"] = labels
-            metric["direction"] = direction
-            metric["threshold"] = threshold
-            metric["correlation"] = correlation
-            metric["context"] = context
-            metrics_config[metric_dataframe_name] = metric
-            dataframe_list.append(metric_df)
-            logger_instance.debug(metric_df)
-        except Exception as e:
-            logger_instance.error(
-                "Couldn't get metrics %s, exception %s",
-                metric_name,
-                e,
+        return dataframe_list, metrics_config
+
+
+    def process_aggregation_metric(
+        self, uuids: List[str], index: str, metric: Dict[str, Any], match: Matcher, timestamp_field: str="timestamp"
+    ) -> pd.DataFrame:
+        """Method to get aggregated dataframe
+
+        Args:
+            uuids (List[str]): _description_
+            index (str): _description_
+            metric (Dict[str, Any]): _description_
+            match (Matcher): _description_
+
+        Returns:
+            pd.DataFrame: _description_
+        """
+        aggregated_metric_data = match.get_agg_metric_query(uuids, index, metric, timestamp_field)
+        aggregation_value = metric["agg"]["value"]
+        aggregation_type = metric["agg"]["agg_type"]
+        aggregation_name = f"{aggregation_value}_{aggregation_type}"
+        if len(aggregated_metric_data) == 0:
+            aggregated_df = pd.DataFrame(columns=[self.uuid_field, timestamp_field, aggregation_name])
+        else:
+            aggregated_df = match.convert_to_df(
+                aggregated_metric_data, columns=[self.uuid_field, timestamp_field, aggregation_name],
+                timestamp_field=timestamp_field
             )
-    return dataframe_list, metrics_config
+            aggregated_df[timestamp_field] = aggregated_df[timestamp_field].apply(self.standardize)
 
-
-def process_aggregation_metric(
-    uuids: List[str], index: str, metric: Dict[str, Any], match: Matcher, timestamp_field: str="timestamp"
-) -> pd.DataFrame:
-    """Method to get aggregated dataframe
-
-    Args:
-        uuids (List[str]): _description_
-        index (str): _description_
-        metric (Dict[str, Any]): _description_
-        match (Matcher): _description_
-
-    Returns:
-        pd.DataFrame: _description_
-    """
-    aggregated_metric_data = match.get_agg_metric_query(uuids, index, metric, timestamp_field)
-    aggregation_value = metric["agg"]["value"]
-    aggregation_type = metric["agg"]["agg_type"]
-    aggregation_name = f"{aggregation_value}_{aggregation_type}"
-    if len(aggregated_metric_data) == 0:
-        aggregated_df = pd.DataFrame(columns=["uuid", timestamp_field, aggregation_name])
-    else:
-        aggregated_df = match.convert_to_df(
-            aggregated_metric_data, columns=["uuid", timestamp_field, aggregation_name],
-            timestamp_field=timestamp_field,
-        )
-        aggregated_df[timestamp_field] = aggregated_df[timestamp_field].apply(standardize)
-
-    aggregated_df = aggregated_df.drop_duplicates(subset=["uuid"], keep="first")
-    aggregated_metric_name = f"{metric['name']}_{aggregation_type}"
-    aggregated_df = aggregated_df.rename(
-        columns={aggregation_name: aggregated_metric_name}
-    )
-    if timestamp_field != "timestamp":
+        aggregated_df = aggregated_df.drop_duplicates(subset=[self.uuid_field], keep="first")
+        aggregated_metric_name = f"{metric['name']}_{aggregation_type}"
         aggregated_df = aggregated_df.rename(
-            columns={timestamp_field: "timestamp"}
+            columns={aggregation_name: aggregated_metric_name}
         )
-    return aggregated_df, aggregated_metric_name
+        if timestamp_field != "timestamp":
+            aggregated_df = aggregated_df.rename(
+                columns={timestamp_field: "timestamp"}
+            )
+        return aggregated_df, aggregated_metric_name
 
-def standardize(timestamp: Any) -> str:
-    """Method to standardize timestamp formats
+    def standardize(self, timestamp: Any) -> str:
+        """Method to standardize timestamp formats
 
-    Args:
-        timestamp Any: timestamp object with various formats 
+        Args:
+            timestamp Any: timestamp object with various formats 
 
-    Returns:
-        str: _description_
-    """
-    if timestamp is None:
-        return timestamp
-    if isinstance(timestamp, str) and NANO_SECONDS_PATTERN.match(timestamp):
-        return timestamp
-    dt = pd.to_datetime(timestamp, utc=True)
-    ns = f"{dt.microsecond:06d}000"
-    return dt.strftime(f"%Y-%m-%dT%H:%M:%S.{ns}Z")
+        Returns:
+            str: _description_
+        """
+        if timestamp is None:
+            return timestamp
+        if isinstance(timestamp, str) and NANO_SECONDS_PATTERN.match(timestamp):
+            return timestamp
+        dt = pd.to_datetime(timestamp, utc=True)
+        ns = f"{dt.microsecond:06d}000"
+        return dt.strftime(f"%Y-%m-%dT%H:%M:%S.{ns}Z")
 
 
-def process_standard_metric(
-    uuids: List[str],
-    index: str,
-    metric: Dict[str, Any],
-    match: Matcher,
-    metric_value_field: str,
-    timestamp_field: str="timestamp",
-) -> pd.DataFrame:
-    """Method to get dataframe of standard metric
+    def process_standard_metric(
+        self,
+        uuids: List[str],
+        index: str,
+        metric: Dict[str, Any],
+        match: Matcher,
+        metric_value_field: str,
+        timestamp_field: str="timestamp"
+    ) -> pd.DataFrame:
+        """Method to get dataframe of standard metric
 
-    Args:
-        uuids (List[str]): _description_
-        index (str): _description_
-        metric (Dict[str, Any]): _description_
-        match (Matcher): _description_
-        metric_value_field (str): _description_
+        Args:
+            uuids (List[str]): _description_
+            index (str): _description_
+            metric (Dict[str, Any]): _description_
+            match (Matcher): _description_
+            metric_value_field (str): _description_
 
-    Returns:
-        pd.DataFrame: _description_
-    """
-    standard_metric_data = match.getResults("", uuids, index, metric)
-    if len(standard_metric_data) == 0:
-        standard_metric_df = pd.DataFrame(columns=["uuid", timestamp_field, metric_value_field])
-    else:
-        standard_metric_df = match.convert_to_df(
-            standard_metric_data, columns=["uuid", timestamp_field, metric_value_field],
+        Returns:
+            pd.DataFrame: _description_
+        """
+        standard_metric_data = match.getResults("", uuids, index, metric)
+        if len(standard_metric_data) == 0:
+            standard_metric_df = pd.DataFrame(columns=[self.uuid_field, timestamp_field, metric_value_field])
+        else:
+            standard_metric_df = match.convert_to_df(
+                standard_metric_data, columns=[self.uuid_field, timestamp_field, metric_value_field],
+                timestamp_field=timestamp_field
+            )
+            standard_metric_df[timestamp_field] = standard_metric_df[timestamp_field].apply(self.standardize)
+        standard_metric_name = f"{metric['name']}_{metric_value_field}"
+        standard_metric_df = standard_metric_df.rename(
+            columns={metric_value_field: standard_metric_name}
+        )
+        if timestamp_field != "timestamp":
+            standard_metric_df = standard_metric_df.rename(
+                columns={timestamp_field: "timestamp"}
+            )
+
+        standard_metric_df = standard_metric_df.drop_duplicates()
+        return standard_metric_df, standard_metric_name
+
+
+    def extract_metadata_from_test(self, test: Dict[str, Any]) -> Dict[Any, Any]:
+        """Gets metadata of the run from each test
+
+        Args:
+            test (dict): test dictionary
+
+        Returns:
+            dict: dictionary of the metadata
+        """
+        logger_instance = SingletonLogger.getLogger("Orion")
+        metadata = test["metadata"]
+        metadata[self.version_field] = str(metadata[self.version_field])
+        logger_instance.debug("metadata" + str(metadata))
+        return metadata
+
+
+    def get_datasource(self, data: Dict[Any, Any]) -> str:
+        """Gets es url from config or env
+
+        Args:
+            data (_type_): config file data
+            logger (_type_): logger
+
+        Returns:
+            str: es url
+        """
+        logger_instance = SingletonLogger.getLogger("Orion")
+        if "ES_SERVER" in data.keys():
+            return data["ES_SERVER"]
+        if "ES_SERVER" in os.environ:
+            return os.environ.get("ES_SERVER")
+        logger_instance.error("ES_SERVER environment variable/config variable not set")
+        sys.exit(1)
+
+
+    def filter_uuids_on_index(
+        self,
+        metadata: Dict[str, Any],
+        benchmark_index: str,
+        uuids: List[str],
+        match: Matcher,
+        baseline: str,
+        filter_node_count: bool,
+    ) -> List[str]:
+        """returns the index to be used and runs as uuids
+
+        Args:
+            metadata (_type_): metadata from config
+            uuids (_type_): uuids collected
+            match (_type_): Matcher object
+
+        Returns:
+            _type_: index and uuids
+        """
+        if "jobConfig.name" in metadata:
+            return uuids
+        if "benchmark.keyword" in metadata:
+            if metadata["benchmark.keyword"] in ["ingress-perf", "k8s-netperf"]:
+                return uuids
+            if baseline == "" and not filter_node_count and "kube-burner" in benchmark_index:
+                runs = match.match_kube_burner(uuids, benchmark_index)
+                ids = match.filter_runs(runs, runs)
+            else:
+                ids = uuids
+        else:
+            ids = uuids
+        return ids
+
+
+    def get_build_urls(self, index: str, uuids: List[str], match: Matcher):
+        """Gets metadata of the run from each test
+            to get the build url
+
+        Args:
+            uuids (list): str list of uuid to find build urls of
+            match: the fmatch instance
+
+
+        Returns:
+            dict: dictionary of the metadata
+        """
+
+        test = match.getResults("", uuids, index, {})
+        buildUrls = {run[self.uuid_field]: run["buildUrl"] for run in test}
+        return buildUrls
+
+
+    def process_test(
+        self,
+        test: Dict[str, Any],
+        match: Matcher,
+        options: Dict[str, Any],
+        start_timestamp: datetime
+    ) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+        """generate the dataframe for the test given
+
+        Args:
+            test (_type_): test from process test
+            match (_type_): matcher object
+            logger (_type_): logger object
+            output (_type_): output file name
+
+        Returns:
+            _type_: merged dataframe
+        """
+        logger = SingletonLogger.getLogger("Orion")
+        logger.info("The test %s has started", test["name"])
+        fingerprint_index = test["index"]
+
+        test_threshold=0
+        if "threshold" in test:
+            test_threshold=test["threshold"]
+        timestamp_field = "timestamp"
+        if "timestamp" in test:
+            timestamp_field=test["timestamp"]
+
+        # getting metadata
+        metadata = (
+            self.extract_metadata_from_test(test)
+            if options["uuid"] in ("", None)
+            else self.get_metadata_with_uuid(options["uuid"], match)
+        )
+        # get uuids, buildUrls matching with the metadata
+        runs = match.get_uuid_by_metadata(
+            metadata,
+            fingerprint_index,
+            lookback_date=start_timestamp,
+            lookback_size=options["lookback_size"],
             timestamp_field=timestamp_field
         )
-        standard_metric_df[timestamp_field] = standard_metric_df[timestamp_field].apply(standardize)
-    standard_metric_name = f"{metric['name']}_{metric_value_field}"
-    standard_metric_df = standard_metric_df.rename(
-        columns={metric_value_field: standard_metric_name}
-    )
-    if timestamp_field != "timestamp":
-        standard_metric_df = standard_metric_df.rename(
-            columns={timestamp_field: "timestamp"}
+        uuids = [run[self.uuid_field] for run in runs]
+        buildUrls = {run[self.uuid_field]: run["buildUrl"] for run in runs}
+        # get uuids if there is a baseline
+        if options["baseline"] not in ("", None):
+            uuids = [uuid for uuid in re.split(r" |,", options["baseline"]) if uuid]
+            uuids.append(options["uuid"])
+            buildUrls = self.get_build_urls(fingerprint_index, uuids, match)
+        elif not uuids:
+            logger.info("No UUID present for given metadata")
+            return None, None
+
+        benchmark_index = test["benchmarkIndex"]
+
+        uuids = self.filter_uuids_on_index(
+            metadata,
+            benchmark_index,
+            uuids,
+            match,
+            options["baseline"],
+            options["node_count"],
         )
-    standard_metric_df = standard_metric_df.drop_duplicates()
-    return standard_metric_df, standard_metric_name
+        # get metrics data and dataframe
+        metrics = test["metrics"]
+        dataframe_list, metrics_config = self.get_metric_data(
+            uuids, benchmark_index, metrics, match, test_threshold, timestamp_field
+        )
+        if not dataframe_list:
+            return None, metrics_config
 
+        uuid_timestamp_map = pd.DataFrame()
+        for df in dataframe_list:
+            if "timestamp" in df.columns:
+                uuid_timestamp_map = pd.concat(
+                    [uuid_timestamp_map, df[[self.uuid_field, "timestamp"]].drop_duplicates()]
+                )
+        uuid_timestamp_map = uuid_timestamp_map.drop_duplicates(subset=[self.uuid_field])
 
-def extract_metadata_from_test(test: Dict[str, Any]) -> Dict[Any, Any]:
-    """Gets metadata of the run from each test
+        for i, df in enumerate(dataframe_list):
+            dataframe_list[i] = df.drop(columns=["timestamp"], errors="ignore")
 
-    Args:
-        test (dict): test dictionary
+        merged_df = reduce(
+            lambda left, right: pd.merge(left, right, on=self.uuid_field, how="outer"),
+            dataframe_list,
+        )
 
-    Returns:
-        dict: dictionary of the metadata
-    """
-    logger_instance = SingletonLogger.getLogger("Orion")
-    metadata = test["metadata"]
-    metadata["ocpVersion"] = str(metadata["ocpVersion"])
-    logger_instance.debug("metadata" + str(metadata))
-    return metadata
+        merged_df = merged_df.merge(uuid_timestamp_map, on=self.uuid_field, how="left")
+        merged_df = merged_df.sort_values(by="timestamp")
 
-
-def get_datasource(data: Dict[Any, Any]) -> str:
-    """Gets es url from config or env
-
-    Args:
-        data (_type_): config file data
-        logger (_type_): logger
-
-    Returns:
-        str: es url
-    """
-    logger_instance = SingletonLogger.getLogger("Orion")
-    if "ES_SERVER" in data.keys():
-        return data["ES_SERVER"]
-    if "ES_SERVER" in os.environ:
-        return os.environ.get("ES_SERVER")
-    logger_instance.error("ES_SERVER environment variable/config variable not set")
-    sys.exit(1)
-
-
-def filter_uuids_on_index(
-    metadata: Dict[str, Any],
-    benchmark_index: str,
-    uuids: List[str],
-    match: Matcher,
-    baseline: str,
-    filter_node_count: bool,
-) -> List[str]:
-    """returns the index to be used and runs as uuids
-
-    Args:
-        metadata (_type_): metadata from config
-        uuids (_type_): uuids collected
-        match (_type_): Matcher object
-
-    Returns:
-        _type_: index and uuids
-    """
-    if "jobConfig.name" in metadata :
-        return uuids
-    if metadata["benchmark.keyword"] in ["ingress-perf", "k8s-netperf"]:
-        return uuids
-    if baseline == "" and not filter_node_count and "kube-burner" in benchmark_index:
-        runs = match.match_kube_burner(uuids, benchmark_index)
-        ids = match.filter_runs(runs, runs)
-    else:
-        ids = uuids
-    return ids
-
-
-def get_build_urls(index: str, uuids: List[str], match: Matcher):
-    """Gets metadata of the run from each test
-        to get the build url
-
-    Args:
-        uuids (list): str list of uuid to find build urls of
-        match: the fmatch instance
-
-
-    Returns:
-        dict: dictionary of the metadata
-    """
-
-    test = match.getResults("", uuids, index, {})
-    buildUrls = {run["uuid"]: run["buildUrl"] for run in test}
-    return buildUrls
-
-
-def process_test(
-    test: Dict[str, Any],
-    match: Matcher,
-    options: Dict[str, Any],
-    start_timestamp: datetime,
-) -> Tuple[pd.DataFrame, Dict[str, Any]]:
-    """generate the dataframe for the test given
-
-    Args:
-        test (_type_): test from process test
-        match (_type_): matcher object
-        logger (_type_): logger object
-        output (_type_): output file name
-
-    Returns:
-        _type_: merged dataframe
-    """
-    logger = SingletonLogger.getLogger("Orion")
-    logger.info("The test %s has started", test["name"])
-    fingerprint_index = test["index"]
-
-    test_threshold=0
-    if "threshold" in test:
-        test_threshold=test["threshold"]
-    timestamp_field = "timestamp"
-    if "timestamp" in test:
-        timestamp_field=test["timestamp"]
-
-    # getting metadata
-    metadata = (
-        extract_metadata_from_test(test)
-        if options["uuid"] in ("", None)
-        else get_metadata_with_uuid(options["uuid"], match)
-    )
-    # get uuids, buildUrls matching with the metadata
-    runs = match.get_uuid_by_metadata(
-        metadata,
-        fingerprint_index,
-        lookback_date=start_timestamp,
-        lookback_size=options["lookback_size"],
-        timestamp_field=timestamp_field,
-    )
-    uuids = [run["uuid"] for run in runs]
-    buildUrls = {run["uuid"]: run["buildUrl"] for run in runs}
-    # get uuids if there is a baseline
-    if options["baseline"] not in ("", None):
-        uuids = [uuid for uuid in re.split(r" |,", options["baseline"]) if uuid]
-        uuids.append(options["uuid"])
-        buildUrls = get_build_urls(fingerprint_index, uuids, match)
-    elif not uuids:
-        logger.info("No UUID present for given metadata")
-        return None, None
-
-    benchmark_index = test["benchmarkIndex"]
-
-    uuids = filter_uuids_on_index(
-        metadata,
-        benchmark_index,
-        uuids,
-        match,
-        options["baseline"],
-        options["node_count"],
-    )
-    # get metrics data and dataframe
-    metrics = test["metrics"]
-    dataframe_list, metrics_config = get_metric_data(
-        uuids, benchmark_index, metrics, match, test_threshold, timestamp_field
-    )
-    if not dataframe_list:
-        return None, metrics_config
-
-    uuid_timestamp_map = pd.DataFrame()
-    for df in dataframe_list:
-        if "timestamp" in df.columns:
-            uuid_timestamp_map = pd.concat(
-                [uuid_timestamp_map, df[["uuid", "timestamp"]].drop_duplicates()]
+        shortener = pyshorteners.Shortener(timeout=10)
+        merged_df["buildUrl"] = merged_df[self.uuid_field].apply(
+            lambda uuid: (
+                self.shorten_url(shortener, buildUrls[uuid])
+                if options["convert_tinyurl"]
+                else buildUrls[uuid]
             )
-    uuid_timestamp_map = uuid_timestamp_map.drop_duplicates(subset=["uuid"])
-
-    for i, df in enumerate(dataframe_list):
-        dataframe_list[i] = df.drop(columns=["timestamp"], errors="ignore")
-
-    merged_df = reduce(
-        lambda left, right: pd.merge(left, right, on="uuid", how="outer"),
-        dataframe_list,
-    )
-
-    merged_df = merged_df.merge(uuid_timestamp_map, on="uuid", how="left")
-    merged_df = merged_df.sort_values(by="timestamp")
-
-    shortener = pyshorteners.Shortener(timeout=10)
-    merged_df["buildUrl"] = merged_df["uuid"].apply(
-        lambda uuid: (
-            shorten_url(shortener, buildUrls[uuid])
-            if options["convert_tinyurl"]
-            else buildUrls[uuid]
+            # pylint: disable = cell-var-from-loop
         )
-        # pylint: disable = cell-var-from-loop
-    )
-    merged_df = merged_df.reset_index(drop=True)
-    # save the dataframe
-    output_file_path = f"{options['save_data_path'].split('.')[0]}-{test['name']}.csv"
-    match.save_results(merged_df, csv_file_path=output_file_path)
-    return merged_df, metrics_config
+
+        merged_df = merged_df.reset_index(drop=True)
+        # save the dataframe
+        output_file_path = f"{options['save_data_path'].split('.')[0]}-{test['name']}.csv"
+        match.save_results(merged_df, csv_file_path=output_file_path)
+        return merged_df, metrics_config
 
 
-def shorten_url(shortener: any, uuids: str) -> str:
-    """Shorten url if there is a list of buildUrls
+    def shorten_url(self, shortener: any, uuids: str) -> str:
+        """Shorten url if there is a list of buildUrls
 
-    Args:
-        shortener (any): shortener object to use tinyrl.short on
-        uuids (List[str]): List of uuids to shorten
+        Args:
+            shortener (any): shortener object to use tinyrl.short on
+            uuids (List[str]): List of uuids to shorten
 
-    Returns:
-        str: a combined string of shortened urls
-    """
-    short_url_list = []
-    for buildUrl in uuids.split(","):
-        short_url_list.append(shortener.tinyurl.short(buildUrl))
-    short_url = ",".join(short_url_list)
-    return short_url
-
-
-def get_metadata_with_uuid(uuid: str, match: Matcher) -> Dict[Any, Any]:
-    """Gets metadata of the run from each test
-
-    Args:
-        uuid (str): str of uuid ot find metadata of
-        match: the fmatch instance
+        Returns:
+            str: a combined string of shortened urls
+        """
+        short_url_list = []
+        for buildUrl in uuids.split(","):
+            short_url_list.append(shortener.tinyurl.short(buildUrl))
+        short_url = ",".join(short_url_list)
+        return short_url
 
 
-    Returns:
-        dict: dictionary of the metadata
-    """
-    logger_instance = SingletonLogger.getLogger("Orion")
-    test = match.get_metadata_by_uuid(uuid)
-    metadata = {
-        "platform": "",
-        "clusterType": "",
-        "masterNodesCount": 0,
-        "workerNodesCount": 0,
-        "infraNodesCount": 0,
-        "masterNodesType": "",
-        "workerNodesType": "",
-        "infraNodesType": "",
-        "totalNodesCount": 0,
-        "ocpVersion": "",
-        "networkType": "",
-        "ipsec": "",
-        "fips": "",
-        "encrypted": "",
-        "publish": "",
-        "computeArch": "",
-        "controlPlaneArch": "",
-    }
-    for k, v in test.items():
-        if k not in metadata:
-            continue
-        metadata[k] = v
-    metadata["benchmark.keyword"] = test["benchmark"]
-    metadata["ocpVersion"] = str(metadata["ocpVersion"])
+    def get_metadata_with_uuid(self, uuid: str, match: Matcher) -> Dict[Any, Any]:
+        """Gets metadata of the run from each test
 
-    # Remove any keys that have blank values
-    no_blank_meta = {k: v for k, v in metadata.items() if v}
-    logger_instance.debug("No blank metadata dict: " + str(no_blank_meta))
-    return no_blank_meta
+        Args:
+            uuid (str): str of uuid ot find metadata of
+            match: the fmatch instance
 
 
+        Returns:
+            dict: dictionary of the metadata
+        """
+        logger_instance = SingletonLogger.getLogger("Orion")
+        test = match.get_metadata_by_uuid(uuid)
+        metadata = {
+            "platform": "",
+            "clusterType": "",
+            "masterNodesCount": 0,
+            "workerNodesCount": 0,
+            "infraNodesCount": 0,
+            "masterNodesType": "",
+            "workerNodesType": "",
+            "infraNodesType": "",
+            "totalNodesCount": 0,
+            "ocpVersion": "",
+            "networkType": "",
+            "ipsec": "",
+            "fips": "",
+            "encrypted": "",
+            "publish": "",
+            "computeArch": "",
+            "controlPlaneArch": "",
+        }
+        for k, v in test.items():
+            if k not in metadata:
+                continue
+            metadata[k] = v
+        if "benchmark" in test:
+            metadata["benchmark.keyword"] = test["benchmark"]
+        if "ocpVersion" in metadata:
+            metadata["ocpVersion"] = str(metadata["ocpVersion"])
+
+        # Remove any keys that have blank values
+        no_blank_meta = {k: v for k, v in metadata.items() if v}
+        logger_instance.debug("No blank metadata dict: " + str(no_blank_meta))
+        return no_blank_meta
+
+# pylint: disable=too-many-locals
 def json_to_junit(
     test_name: str, data_json: Dict[Any, Any], metrics_config: Dict[Any, Any]
 ) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2023.11.17
 click==8.1.7
 elastic-transport==8.11.0
 elasticsearch==7.13.0
-fmatch==0.1.2
+fmatch==0.1.3
 Jinja2==3.1.3
 python-dateutil==2.8.2
 pytz==2023.3.post1

--- a/test.bats
+++ b/test.bats
@@ -119,6 +119,10 @@ setup() {
   run_cmd orion cmd --config "examples/trt-payload-cluster-density.yaml" --hunter-analyze
 }
 
+@test "orion cmd chaos pod recovery " {
+  run_cmd orion cmd --config "examples/chaos_results.yaml" --lookback 10d
+}
+
 @test "orion cmd ols configuration test " {
   export ols_test_workers=10
   es_metadata_index="perf_scale_ci*" es_benchmark_index="ols-load-test-results*" run_cmd orion cmd --config "examples/ols-load-generator.yaml" --hunter-analyze --ack ack/4.15_ols-load-generator-10w_ack.yaml


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [X] Bug fix
- [X] Optimization
- [ ] Documentation Update

## Description
Adds support for custom UUID and version fields. Will be use for Chaos Onboarding.

## Related Tickets & Documents
https://issues.redhat.com/browse/CHAOS-1028 
- Related Issue #https://github.com/cloud-bulldozer/orion/issues/98

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

https://github.com/cloud-bulldozer/py-commons/pull/39
```
tests :
  - name : chaos
    index: krkn-telemetry*
    benchmarkIndex: krkn-metrics*
    version: cluster_version
    uuid_field: run_uuid
    metadata:
      cloud_infrastructure.keyword: AWS
      cluster_version: 4.19
      scenarios.scenario_type: pod_disruption_scenarios
      scenarios.affected_pods.recovered.namespace: openshift-monitoring

```