### PR TITLE
fix udn jobName and add med-scale-udn-l2 config

### DIFF
--- a/examples/med-scale-udn-l2.yaml
+++ b/examples/med-scale-udn-l2.yaml
@@ -1,14 +1,14 @@
 # This is a template file
 tests :
-  - name : aws-small-scale-udn-density-l2-pods
+  - name : aws-med-scale-udn-density-l2-pods
     index: {{ es_metadata_index }} 
     benchmarkIndex: {{ es_benchmark_index }} 
     metadata:
       platform: AWS
-      masterNodesType: m6a.xlarge
-      masterNodesCount: 3
+      masterNodesType: m6a.4xlarge
+      masterNodesCount: 3 
       workerNodesType: m5.xlarge
-      workerNodesCount: 24
+      workerNodesCount: 120 
       benchmark.keyword: udn-density-pods 
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
@@ -23,7 +23,7 @@ tests :
     - name:  podReadyLatency
       metricName: podLatencyQuantilesMeasurement
       quantileName: Ready
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       metric_of_interest: P99
       not: 
         jobConfig.name: "garbage-collection"
@@ -33,7 +33,7 @@ tests :
 
     - name:  ovsCPU
       metricName : cgroupCPUSeconds-Workers
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.id.keyword : /system.slice/ovs-vswitchd.service
       metric_of_interest: value
       agg:
@@ -44,7 +44,7 @@ tests :
 
     - name:  ovnkCPU-overall
       metricName : containerCPU
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       metric_of_interest: value
       agg:
@@ -56,7 +56,7 @@ tests :
 
     - name:  ovnCPU-ovncontroller
       metricName : containerCPU
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovn-controller 
       metric_of_interest: value
@@ -69,7 +69,7 @@ tests :
 
     - name:  ovnCPU-northd
       metricName : containerCPU
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: northd
       metric_of_interest: value
@@ -82,7 +82,7 @@ tests :
 
     - name:  ovnCPU-nbdb
       metricName : containerCPU
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: nbdb
       metric_of_interest: value
@@ -95,7 +95,7 @@ tests :
 
     - name:  ovnCPU-sbdb
       metricName : containerCPU
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: sbdb
       metric_of_interest: value
@@ -108,7 +108,7 @@ tests :
 
     - name:  ovnCPU-ovnk-controller
       metricName : containerCPU
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovnkube-controller
       metric_of_interest: value
@@ -121,7 +121,7 @@ tests :
 
     - name:  ovsMemory
       metricName : cgroupMemoryRSS-Workers
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.id.keyword : /system.slice/ovs-vswitchd.service
       metric_of_interest: value
       agg:
@@ -132,7 +132,7 @@ tests :
 
     - name:  ovnkMem-overall
       metricName : containerMemory
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       metric_of_interest: value
       agg:
@@ -144,7 +144,7 @@ tests :
 
     - name:  ovnMem-ovncontroller
       metricName : containerMemory
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovn-controller 
       metric_of_interest: value
@@ -157,7 +157,7 @@ tests :
 
     - name:  ovnMem-northd
       metricName : containerMemory
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: northd
       metric_of_interest: value
@@ -170,7 +170,7 @@ tests :
 
     - name:  ovnMem-nbdb
       metricName : containerMemory
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: nbdb 
       metric_of_interest: value
@@ -183,7 +183,7 @@ tests :
 
     - name:  ovnMem-sbdb
       metricName : containerMemory
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: sbdb 
       metric_of_interest: value
@@ -196,7 +196,7 @@ tests :
 
     - name:  ovnMem-ovnk-controller
       metricName : containerMemory
-      jobName.keyword: udn-density-l2-pods
+      jobName: udn-density-l2-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovnkube-controller 
       metric_of_interest: value

--- a/examples/med-scale-udn-l3.yaml
+++ b/examples/med-scale-udn-l3.yaml
@@ -23,7 +23,7 @@ tests :
     - name:  podReadyLatency
       metricName: podLatencyQuantilesMeasurement
       quantileName: Ready
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       metric_of_interest: P99
       not: 
         jobConfig.name: "garbage-collection"
@@ -33,7 +33,7 @@ tests :
 
     - name:  ovsCPU
       metricName : cgroupCPUSeconds-Workers
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.id.keyword : /system.slice/ovs-vswitchd.service
       metric_of_interest: value
       agg:
@@ -44,7 +44,7 @@ tests :
 
     - name:  ovnkCPU-overall
       metricName : containerCPU
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       metric_of_interest: value
       agg:
@@ -56,7 +56,7 @@ tests :
 
     - name:  ovnCPU-ovncontroller
       metricName : containerCPU
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovn-controller 
       metric_of_interest: value
@@ -69,7 +69,7 @@ tests :
 
     - name:  ovnCPU-northd
       metricName : containerCPU
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: northd
       metric_of_interest: value
@@ -82,7 +82,7 @@ tests :
 
     - name:  ovnCPU-nbdb
       metricName : containerCPU
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: nbdb
       metric_of_interest: value
@@ -95,7 +95,7 @@ tests :
 
     - name:  ovnCPU-sbdb
       metricName : containerCPU
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: sbdb
       metric_of_interest: value
@@ -108,7 +108,7 @@ tests :
 
     - name:  ovnCPU-ovnk-controller
       metricName : containerCPU
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovnkube-controller
       metric_of_interest: value
@@ -121,7 +121,7 @@ tests :
 
     - name:  ovsMemory
       metricName : cgroupMemoryRSS-Workers
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.id.keyword : /system.slice/ovs-vswitchd.service
       metric_of_interest: value
       agg:
@@ -132,7 +132,7 @@ tests :
 
     - name:  ovnkMem-overall
       metricName : containerMemory
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       metric_of_interest: value
       agg:
@@ -144,7 +144,7 @@ tests :
 
     - name:  ovnMem-ovncontroller
       metricName : containerMemory
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovn-controller 
       metric_of_interest: value
@@ -157,7 +157,7 @@ tests :
 
     - name:  ovnMem-northd
       metricName : containerMemory
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: northd
       metric_of_interest: value
@@ -170,7 +170,7 @@ tests :
 
     - name:  ovnMem-nbdb
       metricName : containerMemory
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: nbdb 
       metric_of_interest: value
@@ -183,7 +183,7 @@ tests :
 
     - name:  ovnMem-sbdb
       metricName : containerMemory
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: sbdb 
       metric_of_interest: value
@@ -196,7 +196,7 @@ tests :
 
     - name:  ovnMem-ovnk-controller
       metricName : containerMemory
-      jobName: create-udn-l3
+      jobName: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovnkube-controller 
       metric_of_interest: value

--- a/examples/small-scale-udn-l3.yaml
+++ b/examples/small-scale-udn-l3.yaml
@@ -23,7 +23,7 @@ tests :
     - name:  podReadyLatency
       metricName: podLatencyQuantilesMeasurement
       quantileName: Ready
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       metric_of_interest: P99
       not: 
         jobConfig.name: "garbage-collection"
@@ -33,7 +33,7 @@ tests :
 
     - name:  ovsCPU
       metricName : cgroupCPUSeconds-Workers
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.id.keyword : /system.slice/ovs-vswitchd.service
       metric_of_interest: value
       agg:
@@ -44,7 +44,7 @@ tests :
 
     - name:  ovnkCPU-overall
       metricName : containerCPU
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       metric_of_interest: value
       agg:
@@ -56,7 +56,7 @@ tests :
 
     - name:  ovnCPU-ovncontroller
       metricName : containerCPU
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovn-controller 
       metric_of_interest: value
@@ -69,7 +69,7 @@ tests :
 
     - name:  ovnCPU-northd
       metricName : containerCPU
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: northd
       metric_of_interest: value
@@ -82,7 +82,7 @@ tests :
 
     - name:  ovnCPU-nbdb
       metricName : containerCPU
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: nbdb
       metric_of_interest: value
@@ -95,7 +95,7 @@ tests :
 
     - name:  ovnCPU-sbdb
       metricName : containerCPU
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: sbdb
       metric_of_interest: value
@@ -108,7 +108,7 @@ tests :
 
     - name:  ovnCPU-ovnk-controller
       metricName : containerCPU
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovnkube-controller
       metric_of_interest: value
@@ -121,7 +121,7 @@ tests :
 
     - name:  ovsMemory
       metricName : cgroupMemoryRSS-Workers
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.id.keyword : /system.slice/ovs-vswitchd.service
       metric_of_interest: value
       agg:
@@ -132,7 +132,7 @@ tests :
 
     - name:  ovnkMem-overall
       metricName : containerMemory
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       metric_of_interest: value
       agg:
@@ -144,7 +144,7 @@ tests :
 
     - name:  ovnMem-ovncontroller
       metricName : containerMemory
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovn-controller 
       metric_of_interest: value
@@ -157,7 +157,7 @@ tests :
 
     - name:  ovnMem-northd
       metricName : containerMemory
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: northd
       metric_of_interest: value
@@ -170,7 +170,7 @@ tests :
 
     - name:  ovnMem-nbdb
       metricName : containerMemory
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: nbdb 
       metric_of_interest: value
@@ -183,7 +183,7 @@ tests :
 
     - name:  ovnMem-sbdb
       metricName : containerMemory
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: sbdb 
       metric_of_interest: value
@@ -196,7 +196,7 @@ tests :
 
     - name:  ovnMem-ovnk-controller
       metricName : containerMemory
-      jobName.keyword: create-udn-l3
+      jobName.keyword: udn-density-l3-pods
       labels.namespace.keyword: openshift-ovn-kubernetes
       labels.container.keyword: ovnkube-controller 
       metric_of_interest: value


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
udn jobName in orion config is not same as https://github.com/kube-burner/kube-burner-ocp/blob/main/cmd/config/udn-density-pods/udn-density-pods.yml#L82

<!--- Describe your changes in detail -->

## Related Tickets & Documents
Discussing in slack thread https://redhat-internal.slack.com/archives/C05CDC19ZKJ/p1748336541088419

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
L3: https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/orion/102/console passed
```
05-28 11:23:33.483  time                       uuid                                  buildUrl                                                                                                                                                                                                                                timestamp    podReadyLatency_P99    ovsCPU_avg    ovnkCPU-overall_avg    ovnCPU-ovncontroller_avg    ovnCPU-northd_avg    ovnCPU-nbdb_avg    ovnCPU-sbdb_avg    ovnCPU-ovnk-controller_avg    ovsMemory_avg    ovnkMem-overall_avg    ovnMem-ovncontroller_avg    ovnMem-northd_avg    ovnMem-nbdb_avg    ovnMem-sbdb_avg    ovnMem-ovnk-controller_avg
05-28 11:23:33.483  -------------------------  ------------------------------------  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  -----------  ---------------------  ------------  ---------------------  --------------------------  -------------------  -----------------  -----------------  ----------------------------  ---------------  ---------------------  --------------------------  -------------------  -----------------  -----------------  ----------------------------
05-28 11:23:33.483  2025-05-25 03:25:03 +0000  f45ff41b-d782-4227-8669-4456f7774552  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-nightly-x86-udn-density-l3-24nodes/1926458339483455488                                                          1.74814e+09                  83500   6.90169e+08                9.30678                     13.3518              13.3546            1.92145            1.27242                       43.6318      8.69476e+08            1.33421e+08                 2.70455e+08          1.33898e+08        2.80815e+07        1.16238e+08                   4.93014e+08
05-28 11:23:33.484                                                                                                                                                                                                                                                                                                                      ·····················  ············  ·····················  ··························  ···················  ·················  ·················  ····························  ···············  ·····················  ··························  ···················  ·················  ·················  ····························  
05-28 11:23:33.484                                                                                                                                                                                                                                                                                                                                      -0.6%         +0.3%                 -21.5%                       -8.6%               -11.6%             -21.1%              +2.2%                         -7.8%            +5.7%                 -16.2%                       +1.3%                +0.6%              +0.3%              +0.6%                         +3.3%  
05-28 11:23:33.484                                                                                                                                                                                                                                                                                                                      ·····················  ············  ·····················  ··························  ···················  ·················  ·················  ····························  ···············  ·····················  ··························  ···················  ·················  ·················  ····························  
05-28 11:23:33.484  2025-05-26 11:59:44 +0000  1a84c177-8c0a-4904-8617-87dff0729f44  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/65318/rehearse-65318-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-nightly-x86-udn-density-l3-ipsec-24nodes/1926923922331144192  1.74826e+09                  83000   6.92036e+08                7.30695                     12.2038              11.8019            1.51559            1.30009                       40.2163      9.19033e+08            1.11751e+08                 2.74069e+08          1.3464e+08         2.81604e+07        1.16942e+08                   5.09199e+08
```
L2:  https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/orion/101/console passed
```
05-28 11:19:11.769  aws-small-scale-udn-density-l2-pods
05-28 11:19:11.769  ===================================
05-28 11:19:11.769  time                       uuid                                  buildUrl                                                                                                                                                                                                                                timestamp    podReadyLatency_P99    ovsCPU_avg    ovnkCPU-overall_avg    ovnCPU-ovncontroller_avg    ovnCPU-northd_avg    ovnCPU-nbdb_avg    ovnCPU-sbdb_avg    ovnCPU-ovnk-controller_avg    ovsMemory_avg    ovnkMem-overall_avg    ovnMem-ovncontroller_avg    ovnMem-northd_avg    ovnMem-nbdb_avg    ovnMem-sbdb_avg    ovnMem-ovnk-controller_avg
05-28 11:19:11.769  -------------------------  ------------------------------------  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  -----------  ---------------------  ------------  ---------------------  --------------------------  -------------------  -----------------  -----------------  ----------------------------  ---------------  ---------------------  --------------------------  -------------------  -----------------  -----------------  ----------------------------
05-28 11:19:11.770  2025-05-15 08:35:51 +0000  3c1ffefa-92ac-4c59-bd85-9e24b905e4d0  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/64943/rehearse-64943-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-nightly-x86-udn-density-l2-ipsec-24nodes/1922896123970719744   1.7473e+09                 114500   6.26702e+08                6.11421                     18.0681              12.2679           0.646927            1.03223                       22.2725      8.36773e+08            9.75135e+07                 2.26579e+08          1.14122e+08        2.33379e+07        9.85618e+07                   4.60138e+08
05-28 11:19:11.770                                                                                                                                                                                                                                                                                                                      ·····················  ············  ·····················  ··························  ···················  ·················  ·················  ····························  ···············  ·····················  ··························  ···················  ·················  ·················  ····························  
05-28 11:19:11.770                                                                                                                                                                                                                                                                                                                                      -3.5%        -42.3%                  +8.8%                       -8.5%                -2.2%              -2.1%              +1.1%                         -0.6%           -32.0%                 +22.2%                       +0.8%                +1.3%              +0.3%              +1.1%                         -0.3%  
05-28 11:19:11.770                                                                                                                                                                                                                                                                                                                      ·····················  ············  ·····················  ··························  ···················  ·················  ·················  ····························  ···············  ·····················  ··························  ···················  ·················  ·················  ····························  
05-28 11:19:11.770  2025-05-15 09:15:18 +0000  3d032868-838d-41c4-95e1-06d1d3626f04  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/64943/rehearse-64943-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-nightly-x86-udn-density-l2-24nodes/1922896052818546688         1.7473e+09                 110500   3.61453e+08                6.6521                      16.5387              12.004            0.633398            1.04329                       22.1407      5.69188e+08            1.19165e+08                 2.28478e+08          1.15652e+08        2.34098e+07        9.96669e+07                   4.5865e+08
```
