### PR TITLE
Fix timestamp standardization logic

### DIFF
--- a/pkg/constants.py
+++ b/pkg/constants.py
@@ -4,17 +4,9 @@ pkg.constants
 Module for storing constants across orion.
 """
 
-import re
-
 EDIVISIVE="EDivisive"
 ISOLATION_FOREST="IsolationForest"
 JSON="json"
 TEXT="text"
 JUNIT="junit"
 CMR="cmr"
-# Matches ISO 8601 datetime strings with nanosecond precision
-NANO_SECONDS_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T"
-                        r"\d{2}:\d{2}:\d{2}\."
-                        r"\d{9}Z$")
-# Matches Unix epoch timestamps in seconds
-EPOCH_TIMESTAMP_PATTERN = re.compile(r"^\d{10}$")

--- a/pkg/utils.py
+++ b/pkg/utils.py
@@ -18,7 +18,6 @@ from fmatch.matcher import Matcher
 from fmatch.logrus import SingletonLogger
 import pandas as pd
 import pyshorteners
-from pkg.constants import NANO_SECONDS_PATTERN, EPOCH_TIMESTAMP_PATTERN
 
 
 class Utils:
@@ -118,7 +117,7 @@ class Utils:
                 aggregated_metric_data, columns=[self.uuid_field, timestamp_field, aggregation_name],
                 timestamp_field=timestamp_field
             )
-            aggregated_df[timestamp_field] = aggregated_df[timestamp_field].apply(self.standardize)
+            aggregated_df[timestamp_field] = aggregated_df[timestamp_field].apply(self.standardize_timestamp)
 
         aggregated_df = aggregated_df.drop_duplicates(subset=[self.uuid_field], keep="first")
         aggregated_metric_name = f"{metric['name']}_{aggregation_type}"
@@ -131,32 +130,22 @@ class Utils:
             )
         return aggregated_df, aggregated_metric_name
 
-    def standardize(self, timestamp: Any) -> str:
+    def standardize_timestamp(self, timestamp: Any) -> str:
         """Method to standardize timestamp formats
 
         Args:
             timestamp Any: timestamp object with various formats 
 
         Returns:
-            str: _description_
+            str: standard timestamp in format %Y-%m-%dT%H:%M:%S
         """
         if timestamp is None:
             return timestamp
-        dt = None
-        if isinstance(timestamp, str):
-            if NANO_SECONDS_PATTERN.match(timestamp):
-                return timestamp
-            if EPOCH_TIMESTAMP_PATTERN.match(timestamp):
-                # Convert Unix epoch timestamp
-                dt = pd.to_datetime(timestamp, unit='s', utc=True)
-            else:
-                raise ValueError(f"Unrecognized or invalid timestamp format: {timestamp}")
+        if timestamp.isnumeric():
+            dt = pd.to_datetime(timestamp, unit='s', utc=True)
         else:
-            # Original logic for other timestamp formats
             dt = pd.to_datetime(timestamp, utc=True)
-
-        ns = f"{dt.microsecond:06d}000"
-        return dt.strftime(f"%Y-%m-%dT%H:%M:%S.{ns}Z")
+        return dt.replace(tzinfo=None).isoformat(timespec="seconds")
 
     def process_standard_metric(
         self,
@@ -187,7 +176,7 @@ class Utils:
                 standard_metric_data, columns=[self.uuid_field, timestamp_field, metric_value_field],
                 timestamp_field=timestamp_field
             )
-            standard_metric_df[timestamp_field] = standard_metric_df[timestamp_field].apply(self.standardize)
+            standard_metric_df[timestamp_field] = standard_metric_df[timestamp_field].apply(self.standardize_timestamp)
         standard_metric_name = f"{metric['name']}_{metric_value_field}"
         standard_metric_df = standard_metric_df.rename(
             columns={metric_value_field: standard_metric_name}


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

The current logic does not work well. There're cases where nanoseconds are rounded up and the number of characters is different than expected, that's causing an exception, as demonstrated below.

```shell
ES_BENCHMARK_INDEX=ripsaw-kube-burner-* ES_METADATA_INDEX=perf_scale_ci-* VERSION=4.19 orion cmd --node-count true --config examples/trt-external-payload-node-density.yaml --lookback 7d --hunter-analyze --output-format junit --save-output-path=junit.xml 
2025-07-16 10:15:38,951 - Orion      - INFO - file: orion.py - line: 127 - 🏹 Starting Orion in command-line mode
2025-07-16 10:15:38,956 - Orion      - INFO - file: utils.py - line: 300 - The test payload-node-density has started
2025-07-16 10:15:38,956 - Matcher    - INFO - file: matcher.py - line: 69 - Executing query against index=perf_scale_ci-*
2025-07-16 10:15:39,776 - Orion      - INFO - file: utils.py - line: 68 - Collecting podReadyLatency
2025-07-16 10:15:39,777 - Matcher    - INFO - file: matcher.py - line: 69 - Executing query against index=ripsaw-kube-burner-*
                                    uuid                       timestamp   P99
6   a78166ef-10ca-4e54-a33e-a27c33ef6046  2025-07-09T11:35:39.310554224Z  2000
5   e0184c07-a7aa-4f23-9392-10004919d870  2025-07-09T16:44:57.305382528Z  2000
2   95063810-8f02-46d4-81ed-c3cb55532003  2025-07-10T01:29:20.132420062Z  2000
7   f38d41f0-c2d8-4a41-b2f4-f2ba5d24532a  2025-07-10T08:56:34.709604955Z  2000
9   031ded13-b71f-411b-9942-3f38e3a02a05  2025-07-10T14:53:16.896691037Z  2000
10  9f56ce94-7992-4e99-8b12-8e2409b720b7  2025-07-11T16:52:48.305344765Z  2000
11  2cd160d7-9bfd-4a3b-b4c4-ceb5257b6d3c  2025-07-12T01:14:08.515275603Z  2000
0   9d86b3bb-63c0-48d9-aff6-672841e53746  2025-07-12T08:44:15.464758923Z  2000
13  f7ecd7ce-5014-4cd9-9ff7-8b99a177b23c  2025-07-12T15:15:20.010061674Z  2000
1   1a802192-5976-4b49-a9b6-4024128ad78e  2025-07-12T22:59:07.930433708Z  2000
8   3b4fa45e-99e1-426d-9911-d78a069e7a0d   2025-07-13T06:04:59.26986282Z  2000   <-- This one
14  233913f1-d4f8-4ac3-baae-ccefbfe83b81  2025-07-14T02:16:38.340690643Z  2000
12  e53366f2-7861-4117-9175-640fbabf0fb0  2025-07-14T09:54:11.561010616Z  2000
4   0f60ff85-4139-4566-acb7-e614743a834b  2025-07-14T17:20:43.489683292Z  2000
15  d586a9fa-00f3-4e9e-be67-2d7424b88b68  2025-07-15T05:17:26.804359437Z  2000
3   283976b3-2893-4387-bd1b-ada53e9eddd0  2025-07-15T10:56:56.001059874Z  2000
2025-07-16 09:40:19,391 - Orion      - ERROR - file: utils.py - line: 88 - Couldn't get metrics podReadyLatency, exception Unrecognized or invalid timestamp format: 2025-07-13T06:04:59.26986282Z                                            

```

By using _isnumeric()_  we can check if the timestamp is in epoch, and then parse it, I've checked that rest of timestamps can be parsed with the standard pandas.to_datetime() method. i.e:

```python
>>> ts = "2025-07-15T10:56:56.001059874Z"
>>> pandas.to_datetime(ts,utc=True)
Timestamp('2025-07-15 10:56:56.001059874+0000', tz='UTC')
>>> short_ts = "2025-07-13T06:04:59.26986282Z"
>>> pandas.to_datetime(short_ts,utc=True)
Timestamp('2025-07-13 06:04:59.269862820+0000', tz='UTC')
```

And last but not least, this PR is also removing the nanoseconds conversion, in my opinion this conversion is not necessary, a second precision is more than enough for a comparison framework like this, this change simplifies the logic and makes it less error prone.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
