### PR TITLE
add OLMv1 example for GCP

### DIFF
--- a/examples/olmv1.yaml
+++ b/examples/olmv1.yaml
@@ -1,0 +1,126 @@
+tests :
+  - name : olmv1-GCP
+    index: {{ es_metadata_index }}
+    benchmarkIndex: {{ es_benchmark_index }}
+    metadata:
+      platform: GCP
+      clusterType: self-managed
+      masterNodesType: e2-custom-6-16384
+      masterNodesCount: 3
+      workerNodesType: e2-standard-4
+      workerNodesCount: 3
+      benchmark.keyword: olm
+      ocpVersion: {{ version }}
+      not:
+        stream: okd
+    metrics : 
+    - name: catalogdMemory_GCP
+      metricName: catalogd_memory_peak_usage_5m
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: controllerMemory_GCP
+      metricName: operator-controller_memory_peak_usage_5m
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name:  catalogdCPU_GCP
+      metricName : catalogd_cpu_usage_cores
+      metric_of_interest: value
+      labels.namespace.keyword: openshift-catalogd
+      not: 
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name:  controllerCPU_GCP
+      metricName : operator-controller_cpu_usage_cores
+      metric_of_interest: value
+      labels.namespace.keyword: openshift-operator-controller
+      not: 
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: catalogdDisk_GCP
+      metricName: catalogd_disk_usage
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: controllerDisk_GCP
+      metricName: controller_disk_usage
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: catalogd_5xx_error_GCP
+      metricName: catalogd_http_5xx_error_count
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: catalog_error_rate_GCP
+      metricName: clustercatalog_error_rate
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: extension_error_rate_GCP
+      metricName: clusterextension_error_rate
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: catalogd_workqueue_latency_GCP
+      metricName: catalogd-clustercatalog_workqueue_latency_p99
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: extension_workqueue_latency_GCP
+      metricName: clusterextension_workqueue_latency_p99
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: controller_reconcile_p99_GCP
+      metricName: operator-controller-controller_reconcile_p99
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"
+    - name: catalogd_reconcile_p99_GCP
+      metricName: catalogd-controller_reconcile_p99
+      metric_of_interest: value
+      quantileName: Ready
+      not: 
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: OpenShift Bugs]"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As title, add `OLM` example. However, 

- Got the `No UUID present for given metadata` failure. Which `metadata` I should use for local testing? Thanks!

```console
export ES_SERVER=https://$ES_USERNAME:$ES_PASSWORD@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com
export ES_PASSWORD=xxx
export ES_USERNAME=xxx
export es_metadata_index='perf_scale_ci-*'
export es_benchmark_index='ripsaw-kube-burner-*'
export version=4.19

(venv) jiazha-mac:orion jiazha$ orion cmd --config examples/olmv1.yaml --lookback 7d --hunter-analyze --output-format junit --save-output-path=junit.xml --debug
2025-07-17 18:36:32,861 - Orion      - INFO - file: orion.py - line: 127 - 🏹 Starting Orion in command-line mode
2025-07-17 18:36:32,862 - Orion      - DEBUG - file: config.py - line: 35 - The examples/olmv1.yaml file has successfully loaded
2025-07-17 18:36:32,863 - Orion      - DEBUG - file: config.py - line: 44 - Variables required by the template: {'es_metadata_index', 'es_benchmark_index', 'version'}
2025-07-17 18:36:32,865 - Orion      - INFO - file: utils.py - line: 310 - The test olmv1 has started
2025-07-17 18:36:32,865 - Orion      - DEBUG - file: utils.py - line: 216 - metadata{'platform': 'GCP', 'masterNodesType': 'm6a.xlarge', 'masterNodesCount': 3, 'workerNodesType': 'm6a.xlarge', 'workerNodesCount': 3, 'benchmark.keyword': 'olm', 'ocpVersion': '4.19', 'not': {'stream': 'okd'}}
2025-07-17 18:36:32,865 - Matcher    - INFO - file: matcher.py - line: 69 - Executing query against index=perf_scale_ci-*
2025-07-17 18:36:32,865 - Matcher    - DEBUG - file: matcher.py - line: 70 - Executing query 
{'query': {'bool': {'must': [{'match': {'platform': 'GCP'}}, {'match': {'masterNodesType': 'm6a.xlarge'}}, {'match': {'masterNodesCount': 3}}, {'match': {'workerNodesType': 'm6a.xlarge'}}, {'match': {'workerNodesCount': 3}}, {'match': {'benchmark.keyword': 'olm'}}], 'must_not': [{'match': {'stream': 'okd'}}], 'filter': [{'wildcard': {'ocpVersion': {'value': '4.19*'}}}, {'range': {'timestamp': {'gt': '2025-07-10T10:36:32Z'}}}]}}, 'sort': [{'timestamp': {'order': 'desc'}}], 'size': 10000}
2025-07-17 18:36:34,308 - Orion      - INFO - file: utils.py - line: 342 - No UUID present for given metadata
```

- Got the `400` error when specifying the UUID.
```console
(venv) jiazha-mac:orion jiazha$ orion cmd --config examples/olmv1.yaml --lookback 7d --hunter-analyze --output-format junit --save-output-path=junit.xml --uuid d78ce842-24a5-442c-b2a2-307af4786b1e 
2025-07-17 18:24:07,917 - Orion      - INFO - file: orion.py - line: 127 - 🏹 Starting Orion in command-line mode
2025-07-17 18:24:07,920 - Orion      - INFO - file: utils.py - line: 310 - The test olmv1 has started
2025-07-17 18:24:07,921 - Matcher    - INFO - file: matcher.py - line: 69 - Executing query against index=perf_scale_ci-*
Traceback (most recent call last):
  File "/Users/jiazha/goproject/orion/venv/bin/orion", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/orion.py", line 131, in cmd_analysis
    output, regression_flag = run(**kwargs)
                              ^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/pkg/runTest.py", line 69, in run
    fingerprint_matched_df, metrics_config = utils.process_test(
                                             ^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/pkg/utils.py", line 324, in process_test
    else self.get_metadata_with_uuid(options["uuid"], match)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/pkg/utils.py", line 428, in get_metadata_with_uuid
    test = match.get_metadata_by_uuid(uuid)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/fmatch/matcher.py", line 56, in get_metadata_by_uuid
    res = self.query_index(index, s)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/fmatch/matcher.py", line 71, in query_index
    return search.execute()
           ^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/elasticsearch_dsl/search.py", line 723, in execute
    self, es.search(index=self._index, **params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/elasticsearch/client/utils.py", line 168, in _wrapped
    return func(*args, params=params, headers=headers, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/elasticsearch/client/__init__.py", line 1670, in search
    return self.transport.perform_request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/elasticsearch/transport.py", line 415, in perform_request
    raise e
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/elasticsearch/transport.py", line 381, in perform_request
    status, headers_response, data = connection.perform_request(
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/elasticsearch/connection/http_urllib3.py", line 275, in perform_request
    self._raise_error(response.status, raw_data)
  File "/Users/jiazha/goproject/orion/venv/lib/python3.11/site-packages/elasticsearch/connection/base.py", line 330, in _raise_error
    raise HTTP_EXCEPTIONS.get(status_code, TransportError)(
elasticsearch.exceptions.RequestError: RequestError(400, 'parsing_exception', '[match] query does not support [value]')
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
