### PR TITLE
make jobtype a var, defaults to periodic

### DIFF
--- a/examples/med-scale-udn-l2.yaml
+++ b/examples/med-scale-udn-l2.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: udn-density-pods 
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic OR pull
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
     # encrypted: true

--- a/examples/med-scale-udn-l3.yaml
+++ b/examples/med-scale-udn-l3.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: udn-density-pods 
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic OR pull
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
     # encrypted: true

--- a/examples/metal-perfscale-cpt-data-path.yaml
+++ b/examples/metal-perfscale-cpt-data-path.yaml
@@ -12,7 +12,7 @@ tests:
       benchmark.keyword: k8s-netperf
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic OR pull
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
 

--- a/examples/metal-perfscale-cpt-node-density-heavy.yaml
+++ b/examples/metal-perfscale-cpt-node-density-heavy.yaml
@@ -12,7 +12,7 @@ tests:
       benchmark.keyword: node-density-heavy
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic OR pull
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
 

--- a/examples/metal-perfscale-cpt-node-density.yaml
+++ b/examples/metal-perfscale-cpt-node-density.yaml
@@ -12,7 +12,7 @@ tests:
       benchmark.keyword: node-density
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic OR pull
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
 

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: virt-density
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic OR pull
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
 

--- a/examples/metal-perfscale-cpt-virt-udn-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-udn-density.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: virt-udn-density
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic OR pull
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
 

--- a/examples/small-scale-udn-l2.yaml
+++ b/examples/small-scale-udn-l2.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: udn-density-pods 
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic OR pull
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
     # encrypted: true

--- a/examples/small-scale-udn-l3.yaml
+++ b/examples/small-scale-udn-l3.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: udn-density-pods 
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic OR pull
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
     # encrypted: true

--- a/examples/trt-external-payload-cluster-density.yaml
+++ b/examples/trt-external-payload-cluster-density.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: cluster-density-v2
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
 

--- a/examples/trt-external-payload-crd-scale.yaml
+++ b/examples/trt-external-payload-crd-scale.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: crd-scale 
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
 

--- a/examples/trt-external-payload-node-density-cni.yaml
+++ b/examples/trt-external-payload-node-density-cni.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: node-density-cni
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
 

--- a/examples/trt-external-payload-node-density.yaml
+++ b/examples/trt-external-payload-node-density.yaml
@@ -12,7 +12,7 @@ tests :
       benchmark.keyword: node-density 
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
-      jobType: periodic
+      jobType: {{ jobtype | default('periodic') }}
       not:
         stream: okd
 

--- a/pkg/config.py
+++ b/pkg/config.py
@@ -44,7 +44,8 @@ def load_config(config: str, parameters: Dict= None) -> Dict[str, Any]:
     logger_instance.debug(f"Variables required by the template: {required_parameters}")
 
     # Check for missing variables
-    missing_vars = required_parameters - merged_parameters.keys()
+    optional_params_with_defaults = {"jobtype"}
+    missing_vars = required_parameters - merged_parameters.keys() - optional_params_with_defaults
     if missing_vars:
         logger_instance.error(f"Missing required parameters: {missing_vars}, use environment variables to set")
         sys.exit(1)


### PR DESCRIPTION
For jobs triggered by pull requests, we want to compare them against both periodic runs and previous PR runs to check for improvements.
In contrast, for CI (periodic) runs, we exclude PR runs from comparison to maintain consistency with our baseline.

