### PR TITLE
Fixing non-cpt run collection with version

### DIFF
--- a/pkg/utils.py
+++ b/pkg/utils.py
@@ -264,9 +264,12 @@ class Utils:
         test = match.get_results("", uuids, {})
         if len(test) == 0:
             return {}
+
+        # Fingerprint / metadata index code path
         if "ocpVersion" in test[0]:
             return {run[self.uuid_field]: run["ocpVersion"] for run in test}
 
+        # No Fingerprint / Metatdata index used. Benchmark result index path
         result = {}
         for uuid in uuids :
             test = match.get_results("", [uuid], {})


### PR DESCRIPTION

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Temp fix, need a solution with scan/scroll in fmatch to really fix the issue. When we query the benchmark index for metadata, we get a ton of results returned.

