### PR TITLE
the _analyze methods do not transform the timestamp if it has already…

### DIFF
--- a/pkg/algorithms/cmr/cmr.py
+++ b/pkg/algorithms/cmr/cmr.py
@@ -27,8 +27,9 @@ class CMR(Algorithm):
         """
         logger_instance = SingletonLogger.getLogger("Orion")
         logger_instance.info("Starting analysis using CMR")
-        self.dataframe["timestamp"] = pd.to_datetime(self.dataframe["timestamp"])
-        self.dataframe["timestamp"] = self.dataframe["timestamp"].astype(int) // 10**9
+        if not (pd.api.types.is_numeric_dtype(self.dataframe["timestamp"]) and self.dataframe["timestamp"].astype(int).min() > 1e9):
+            self.dataframe["timestamp"] = pd.to_datetime(self.dataframe["timestamp"])
+            self.dataframe["timestamp"] = self.dataframe["timestamp"].astype(int) // 10**9
 
         if len(self.dataframe.index) == 1:
             series= self.setup_series()

--- a/pkg/algorithms/edivisive/edivisive.py
+++ b/pkg/algorithms/edivisive/edivisive.py
@@ -1,6 +1,7 @@
 """EDivisive Algorithm from hunter"""
 
 # pylint: disable = line-too-long
+from fmatch.logrus import SingletonLogger
 from typing import Dict, List
 import pandas as pd
 from hunter.series import ChangePoint
@@ -16,8 +17,9 @@ class EDivisive(Algorithm):
 
 
     def _analyze(self):
-        self.dataframe["timestamp"] = pd.to_datetime(self.dataframe["timestamp"])
-        self.dataframe["timestamp"] = self.dataframe["timestamp"].astype(int) // 10**9
+        if not (pd.api.types.is_numeric_dtype(self.dataframe["timestamp"]) and self.dataframe["timestamp"].astype(int).min() > 1e9):
+            self.dataframe["timestamp"] = pd.to_datetime(self.dataframe["timestamp"])
+            self.dataframe["timestamp"] = self.dataframe["timestamp"].astype(int) // 10**9
         series = self.setup_series()
         change_points_by_metric = series.analyze().change_points
 

--- a/pkg/algorithms/edivisive/edivisive.py
+++ b/pkg/algorithms/edivisive/edivisive.py
@@ -1,7 +1,6 @@
 """EDivisive Algorithm from hunter"""
 
 # pylint: disable = line-too-long
-from fmatch.logrus import SingletonLogger
 from typing import Dict, List
 import pandas as pd
 from hunter.series import ChangePoint

--- a/pkg/algorithms/isolationforest/isolationForest.py
+++ b/pkg/algorithms/isolationforest/isolationForest.py
@@ -23,8 +23,9 @@ class IsolationForestWeightedMean(Algorithm):
         Returns:
             pd.Dataframe, pd.Dataframe: _description_
         """
-        self.dataframe["timestamp"] = pd.to_datetime(self.dataframe["timestamp"])
-        self.dataframe["timestamp"] = self.dataframe["timestamp"].astype(int) // 10**9
+        if not (pd.api.types.is_numeric_dtype(self.dataframe["timestamp"]) and self.dataframe["timestamp"].astype(int).min() > 1e9):
+            self.dataframe["timestamp"] = pd.to_datetime(self.dataframe["timestamp"])
+            self.dataframe["timestamp"] = self.dataframe["timestamp"].astype(int) // 10**9
         dataframe = self.dataframe.copy(deep=True)
         series = self.setup_series()
 


### PR DESCRIPTION
… been done.

## Type of change

- [X] Bug fix

## Description

Timestamp is not correct since the systematic edition of an XML (see https://github.com/cloud-bulldozer/orion/commit/9256e13aa96b126ec1aa9c60bd8342997b2b2389)
For example:
```
================================
time                       uuid                                  ocpVersion                          buildUrl                                                                                                                                                                 podReadyLatency_P99    apiserverCPU_avg    multusCPU_avg    monitoringCPU_avg    ovnCPU_avg    etcdCPU_avg    etcdDisk_avg    kubelet_avg
-------------------------  ------------------------------------  ----------------------------------  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------  ---------------------  ------------------  ---------------  -------------------  ------------  -------------  --------------  -------------
1970-01-01 00:00:01 +0000  25cf3d2f-706a-440a-ae70-29c827a54d1a  4.19.0-0.nightly-2025-07-19-011940  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-weekly-6nodes/1947522343853101056                   2000             13.9249          2.61798              1.42639        13.679        13.4311      0.00110661         92.306

```
It was coming from the _analyze method of the Algorithm classes, which was called twice now that an XML is always generated, the timestamp conversion from Nano to Second was applied twice.
I added a check to see if the conversion has already been made.

