### PR TITLE
Refactor: New input-vars flag to set arbitrary variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,15 @@ Orion stands as a powerful command-line tool/daemon designed for identifying reg
 ## Quick Start
 
 ### Podman
+
 ```bash
 $ podman build -f Dockerfile -t orion
-# Needed env vars.
-# ES/OpenSearch Server where the results live
- $ export ES_SERVER='my-opensearch.perf.com'
- # Version of OpenShift
- $ export version=4.19
- # Index where the benchmark data is stored
- $ export es_benchmark_index=ripsaw-kube-burner*
- # Index where you store the run metadata
- $ export es_metadata_index=perf_scale_ci*
- $ podman run --env-host orion orion cmd --config orion/examples/trt-external-payload-node-density.yaml --hunter-analyze
+$ podman run orion orion cmd --config examples/trt-external-payload-node-density.yaml --hunter-analyze --input-vars='{"version": "4.19"}' --es-server='https://my-opensearch.perf.com' --benchmark-index=ripsaw-kube-burner-* --metadata-index=perf_scale_ci* --lookback=15d
  ```
 
 
 ### Installation
+
 ```bash
 $ git clone <repository_url>
 $ python3.11 -m venv venv
@@ -29,12 +22,34 @@ $ pip install -r requirements.txt
 $ pip install .
 ```
 
+Using `uv`
+
+```bash
+$ uv venv --python 3.11
+$ source .venv/bin/activate
+$ uv pip install -r requirements.txt
+$ uv pip install .
+``
+
+
+
+
 ### Basic Usage
+
+Trigger hunter analysis using data from the 15 latest days 
+
 ```bash
 # Command-line mode
-$ orion cmd --hunter-analyze
+$ orion cmd --config examples/trt-external-payload-node-density.yaml --hunter-analyze --input-vars='{"version": "4.19"}' --es-server='htts://my-opensearch.perf.com' --benchmark-index=ripsaw-kube-burner-* --metadata-index=perf_scale_ci* --lookback=15d
+2025-08-12 10:45:31,965 - Orion      - INFO - file: main.py - line: 136 - 🏹 Starting Orion in command-line mode                                                                              2025-08-12 10:45:31,971 - Orion      - INFO - file: utils.py - line: 317 - The test payload-node-density has started                                                            
+2025-08-12 10:45:31,971 - Matcher    - INFO - file: matcher.py - line: 75 - Executing query against index: perf_scale_ci*                                                                     2025-08-12 10:45:33,179 - Matcher    - INFO - file: matcher.py - line: 75 - Executing query against index: perf_scale_ci*                                                      
+2025-08-12 10:45:33,441 - Matcher    - INFO - file: matcher.py - line: 75 - Executing query against index: ripsaw-kube-burner-*                                                               2025-08-12 10:45:33,715 - Orion      - INFO - file: utils.py - line: 67 - Collecting podReadyLatency                                                                            
+2025-08-12 10:45:33,716 - Matcher    - INFO - file: matcher.py - line: 75 - Executing query against index: ripsaw-kube-burner-*                                                               2025-08-12 10:45:33,896 - Orion      - INFO - file: utils.py - line: 67 - Collecting apiserverCPU                                                                               
+2025-08-12 10:45:33,897 - Matcher    - INFO - file: matcher.py - line: 75 - Executing query against index: ripsaw-kube-burner-*                                                               2025-08-12 10:45:34,697 - Orion      - INFO - file: utils.py - line: 67 - Collecting ovnCPU                                                                                                   
+etc.
+```
 
-# Daemon mode
+### Daemon mode
 $ orion daemon
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,8 +7,6 @@ Orion uses YAML configuration files to define tests, metadata, and metrics. Here
 ```yaml
 tests:
   - name: test-name
-    index: index-pattern
-    benchmarkIndex: benchmark-index-pattern
     metadata:
       # metadata filters
     metrics:
@@ -20,8 +18,6 @@ tests:
 ```yaml
 tests:
   - name: payload-cluster-density-v2
-    index: ospst-perf-scale-ci-*
-    benchmarkIndex: ospst-ripsaw-kube-burner*
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,6 +42,49 @@ Specify a custom configuration file:
 orion cmd --config /path/to/config.yaml --hunter-analyze
 ```
 
+The configuration file can be a Jinja2 template, environment variables and variables passed through the `--input-vars` flag are accessible in the Jinja2 template: `{{ random_var }}`. For example
+
+Considering the following config file:
+
+```yaml
+tests:
+  - name: metal-perfscale-cpt-node-density
+    metadata:
+      platform: BareMetal
+      clusterType: self-managed
+      masterNodesType.keyword: ""
+      masterNodesCount: 3
+      workerNodesType.keyword: ""
+      workerNodesCount: 4
+      benchmark.keyword: node-density
+      ocpVersion: {{ version }}
+      networkType: OVNKubernetes
+      not:
+        stream: okd
+    metrics:
+    - name: podReadyLatency
+      metricName: podLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PodLatency]"
+      threshold: 10
+```
+
+The variable `version` can be passed through the `--input-vars` flag as follows:
+
+```shell
+$ orion cmd --config /path/to/config.yaml --input-vars='{"version": "4.20"}' --hunter-analyze
+# Or using env vars
+$ VERSION=4.20 orion cmd --config /path/to/config.yaml --hunter-analyze
+```
+
+> **info**
+>> Variables pased from the `--input-vars` take precedence over environment variables
+>> Environment variable name are lowercased
+
 ### Output Options
 Control where and how results are saved:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -206,8 +206,6 @@ orion cmd --ack ack.yaml --hunter-analyze
 ```yaml
 tests:
   - name: cpu-monitoring
-    index: performance-index-*
-    benchmarkIndex: benchmark-data-*
     metadata:
       platform: AWS
       ocpVersion: 4.17
@@ -228,8 +226,6 @@ tests:
 ```yaml
 tests:
   - name: pod-latency-check
-    index: performance-index-*
-    benchmarkIndex: benchmark-data-*
     metadata:
       platform: AWS
       clusterType: self-managed
@@ -250,8 +246,6 @@ tests:
 ```yaml
 tests:
   - name: correlated-performance
-    index: performance-index-*
-    benchmarkIndex: benchmark-data-*
     metadata:
       platform: AWS
       ocpVersion: 4.17
@@ -283,8 +277,6 @@ tests:
 ```yaml
 tests:
   - name: full-stack-monitoring
-    index: performance-index-*
-    benchmarkIndex: benchmark-data-*
     threshold: 10  # Default threshold for all metrics
     metadata:
       platform: AWS

--- a/examples/chaos_tests.yaml
+++ b/examples/chaos_tests.yaml
@@ -15,7 +15,6 @@
 
 tests:
   - name: krkn-hub-*
-    index: krkn-telemetry*
     version: cluster_version
     uuid_field: run_uuid
     metadata:

--- a/examples/chaos_tests.yaml
+++ b/examples/chaos_tests.yaml
@@ -16,7 +16,6 @@
 tests:
   - name: krkn-hub-*
     index: krkn-telemetry*
-    benchmarkIndex: krkn-metrics*
     version: cluster_version
     uuid_field: run_uuid
     metadata:

--- a/examples/label-small-scale-cluster-density.yaml
+++ b/examples/label-small-scale-cluster-density.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : small-scale-cluster-density-v2
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       masterNodesType: m6a.xlarge

--- a/examples/med-scale-udn-l2.yaml
+++ b/examples/med-scale-udn-l2.yaml
@@ -1,8 +1,6 @@
 # This is a template file
 tests :
   - name : aws-med-scale-udn-density-l2-pods
-    index: {{ es_metadata_index }} 
-    benchmarkIndex: {{ es_benchmark_index }} 
     metadata:
       platform: AWS
       masterNodesType: m6a.4xlarge

--- a/examples/med-scale-udn-l3.yaml
+++ b/examples/med-scale-udn-l3.yaml
@@ -1,8 +1,6 @@
 # This is a template file
 tests :
   - name : aws-med-scale-udn-density-l3-pods
-    index: {{ es_metadata_index }} 
-    benchmarkIndex: {{ es_benchmark_index }} 
     metadata:
       platform: AWS
       masterNodesType: m6a.4xlarge

--- a/examples/metal-perfscale-cpt-data-path.yaml
+++ b/examples/metal-perfscale-cpt-data-path.yaml
@@ -1,7 +1,5 @@
 tests:
   - name: metal-perfscale-cpt-datapath
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: BareMetal
       clusterType: self-managed

--- a/examples/metal-perfscale-cpt-node-density-heavy.yaml
+++ b/examples/metal-perfscale-cpt-node-density-heavy.yaml
@@ -1,7 +1,5 @@
 tests:
   - name: metal-perfscale-cpt-node-density-heavy
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: BareMetal
       clusterType: self-managed

--- a/examples/metal-perfscale-cpt-node-density.yaml
+++ b/examples/metal-perfscale-cpt-node-density.yaml
@@ -1,7 +1,5 @@
 tests:
   - name: metal-perfscale-cpt-node-density
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: BareMetal
       clusterType: self-managed

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : metal-perfscale-cpt-virtdensity
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: BareMetal
       clusterType: self-managed

--- a/examples/metal-perfscale-cpt-virt-udn-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-udn-density.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : metal-perfscale-cpt-virtudndensity
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: BareMetal
       clusterType: self-managed

--- a/examples/netobserv-diff-meta-index.yaml
+++ b/examples/netobserv-diff-meta-index.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : {{ benchmark }} 
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/node_scenarios.yaml
+++ b/examples/node_scenarios.yaml
@@ -15,7 +15,6 @@
 tests:
   - name: krkn-hub-*
     index: krkn-telemetry*
-    benchmarkIndex: krkn-metrics*
     version: cluster_version
     uuid_field: run_uuid
     metadata:

--- a/examples/node_scenarios.yaml
+++ b/examples/node_scenarios.yaml
@@ -14,7 +14,6 @@
 
 tests:
   - name: krkn-hub-*
-    index: krkn-telemetry*
     version: cluster_version
     uuid_field: run_uuid
     metadata:

--- a/examples/olmv1.yaml
+++ b/examples/olmv1.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : olmv1-GCP
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: GCP
       clusterType: self-managed

--- a/examples/ols-load-generator.yaml
+++ b/examples/ols-load-generator.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : ols-load-generator-{{ ols_test_workers }}w-5m
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       olsTestWorkers: {{ ols_test_workers }}
       olsTestDuration: "5m"
@@ -384,8 +382,6 @@ tests :
       threshold: 10
 
   - name : ols-load-generator-{{ ols_test_workers }}w-10m
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       olsTestWorkers: {{ ols_test_workers }}
       olsTestDuration: "10m"
@@ -766,8 +762,6 @@ tests :
       threshold: 10
 
   - name : ols-load-generator-{{ ols_test_workers }}w-20m
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       olsTestWorkers: {{ ols_test_workers }}
       olsTestDuration: "20m"

--- a/examples/payload-scale.yaml
+++ b/examples/payload-scale.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : aws-small-scale-cluster-density-v2
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       clusterType: self-managed
@@ -54,8 +52,6 @@ tests :
         value: duration
         agg_type: avg
   - name : aws-payload-scale-node-density
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/pod_disruption_scenarios.yaml
+++ b/examples/pod_disruption_scenarios.yaml
@@ -14,7 +14,6 @@
 tests:
   - name: krkn-hub-*
     index: krkn-telemetry*
-    benchmarkIndex: krkn-metrics*
     version: cluster_version
     uuid_field: run_uuid
     metadata:

--- a/examples/pod_disruption_scenarios.yaml
+++ b/examples/pod_disruption_scenarios.yaml
@@ -13,7 +13,6 @@
 
 tests:
   - name: krkn-hub-*
-    index: krkn-telemetry*
     version: cluster_version
     uuid_field: run_uuid
     metadata:

--- a/examples/quay-load-test-stable-stage.yaml
+++ b/examples/quay-load-test-stable-stage.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : quay-load-test-stable-stage-image-push-pulls
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ quay_image_push_pull_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/quay-load-test-stable.yaml
+++ b/examples/quay-load-test-stable.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : quay-load-test-stable-apis
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ quay_load_test_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/quay-load-test-stable.yaml
+++ b/examples/quay-load-test-stable.yaml
@@ -2381,7 +2381,6 @@ tests :
       context: 10
 
   - name : quay-load-test-stable-image-push-pulls
-    index: {{ es_metadata_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/quay-load-test-stable.yaml
+++ b/examples/quay-load-test-stable.yaml
@@ -2382,7 +2382,6 @@ tests :
 
   - name : quay-load-test-stable-image-push-pulls
     index: {{ es_metadata_index }}
-    benchmarkIndex: {{ quay_image_push_pull_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/readout-control-plane-cdv2.yaml
+++ b/examples/readout-control-plane-cdv2.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : cluster-density-v2-24nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -39,8 +37,6 @@ tests :
         agg_type: avg
 
   - name : cluster-density-v2-120nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -76,8 +72,6 @@ tests :
         agg_type: avg
 
   - name : cluster-density-v2-249nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -113,8 +107,6 @@ tests :
         agg_type: avg
 
   - name : cdv2-kube-apiserver-etcd-249nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -162,8 +154,6 @@ tests :
         agg_type: avg
 
   - name : cd-v2-controller-manager-249nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -206,8 +196,6 @@ tests :
         agg_type: avg
 
   - name : cd-v2-api-request-latency-249nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -251,8 +239,6 @@ tests :
         agg_type: avg
 
   - name : cd-v2-etcd-latency-249nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS

--- a/examples/readout-control-plane-node-density.yaml
+++ b/examples/readout-control-plane-node-density.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : node-density-heavy-24nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -51,8 +49,6 @@ tests :
         agg_type: avg
 
   - name : node-density-24nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -83,8 +79,6 @@ tests :
         agg_type: avg
 
   - name : node-density-120nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -115,8 +109,6 @@ tests :
         agg_type: avg
 
   - name : node-density-249nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -147,8 +139,6 @@ tests :
         agg_type: avg
 
   - name : node-density-cni-24nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -179,8 +169,6 @@ tests :
         agg_type: avg
 
   - name : node-density-cni-120nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -211,8 +199,6 @@ tests :
         agg_type: avg
 
   - name : node-density-cni-249nodes
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS

--- a/examples/readout-ingress.yaml
+++ b/examples/readout-ingress.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : ingress-perf
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS

--- a/examples/readout-netperf-tcp.yaml
+++ b/examples/readout-netperf-tcp.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : k8s-netperf-tcp
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS

--- a/examples/small-rosa-control-plane-node-density.yaml
+++ b/examples/small-rosa-control-plane-node-density.yaml
@@ -1,6 +1,5 @@
 tests :
   - name : node-density-heavy-24nodes
-    index: {{ es_metadata_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -48,7 +47,6 @@ tests :
         agg_type: avg
 
   - name : node-density-24nodes
-    index: {{ es_metadata_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -79,7 +77,6 @@ tests :
         agg_type: avg
 
   - name : node-density-120nodes
-    index: {{ es_metadata_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -110,7 +107,6 @@ tests :
         agg_type: avg
 
   - name : node-density-cni-24nodes
-    index: {{ es_metadata_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -141,7 +137,6 @@ tests :
         agg_type: avg
 
   - name : node-density-cni-120nodes
-    index: {{ es_metadata_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS

--- a/examples/small-rosa-control-plane-node-density.yaml
+++ b/examples/small-rosa-control-plane-node-density.yaml
@@ -1,7 +1,6 @@
 tests :
   - name : node-density-heavy-24nodes
     index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -50,7 +49,6 @@ tests :
 
   - name : node-density-24nodes
     index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -82,7 +80,6 @@ tests :
 
   - name : node-density-120nodes
     index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -114,7 +111,6 @@ tests :
 
   - name : node-density-cni-24nodes
     index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS
@@ -146,7 +142,6 @@ tests :
 
   - name : node-density-cni-120nodes
     index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS

--- a/examples/small-scale-cluster-density-report.yaml
+++ b/examples/small-scale-cluster-density-report.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : small-scale-cluster-density-v2-report
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       ocpVersion: {{ version }}
       platform: AWS

--- a/examples/small-scale-cluster-density.yaml
+++ b/examples/small-scale-cluster-density.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : aws-small-scale-cluster-density-v2
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       masterNodesType: m6a.xlarge

--- a/examples/small-scale-node-density-cni.yaml
+++ b/examples/small-scale-node-density-cni.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : aws-small-scale-node-density-cni
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform.keyword: AWS
       masterNodesType.keyword: m6a.xlarge

--- a/examples/small-scale-udn-l2.yaml
+++ b/examples/small-scale-udn-l2.yaml
@@ -1,8 +1,6 @@
 # This is a template file
 tests :
   - name : aws-small-scale-udn-density-l2-pods
-    index: {{ es_metadata_index }} 
-    benchmarkIndex: {{ es_benchmark_index }} 
     metadata:
       platform: AWS
       masterNodesType: m6a.xlarge

--- a/examples/small-scale-udn-l3.yaml
+++ b/examples/small-scale-udn-l3.yaml
@@ -1,8 +1,6 @@
 # This is a template file
 tests :
   - name : aws-small-scale-udn-density-l3-pods
-    index: {{ es_metadata_index }} 
-    benchmarkIndex: {{ es_benchmark_index }} 
     metadata:
       platform: AWS
       masterNodesType: m6a.xlarge

--- a/examples/trt-external-payload-cluster-density.yaml
+++ b/examples/trt-external-payload-cluster-density.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : payload-cluster-density-v2
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/trt-external-payload-crd-scale.yaml
+++ b/examples/trt-external-payload-crd-scale.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : payload-crd-scale
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/trt-external-payload-node-density-cni.yaml
+++ b/examples/trt-external-payload-node-density-cni.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : payload-node-density-cni
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/trt-external-payload-node-density.yaml
+++ b/examples/trt-external-payload-node-density.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : payload-node-density
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/examples/trt-payload-cluster-density.yaml
+++ b/examples/trt-payload-cluster-density.yaml
@@ -1,7 +1,5 @@
 tests :
   - name : payload-cluster-density-v2
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
     metadata:
       platform: AWS
       clusterType: self-managed

--- a/main.py
+++ b/main.py
@@ -7,9 +7,9 @@ import logging
 import sys
 import warnings
 from typing import Any
+import json
 import click
 import uvicorn
-import json
 from orion.logger import SingletonLogger
 from orion.run_test import run
 from orion import constants as cnsts
@@ -21,8 +21,13 @@ warnings.filterwarnings(
 )
 
 class Dictionary(click.ParamType):
+    """Class to define a custom click type for dictionaries
+
+    Args:
+        click (ParamType):
+    """
     name = "dictionary"
-    def convert(self, value, param, ctx):
+    def convert(self, value: Any, param: Any, ctx: Any) -> dict:
         return json.loads(value)
 
 class MutuallyExclusiveOption(click.Option):
@@ -125,7 +130,7 @@ def cli(max_content_width=120):  # pylint: disable=unused-argument
 @click.option("--es-server", type=str, default="http://localhost:9200", help="Elasticsearch endpoint where test data is stored")
 @click.option("--benchmark-index", type=str, default="benchmark", help="Index where test data is stored")
 @click.option("--metadata-index", type=str, default="benchmark", help="Index where metadata is stored")
-@click.option("--input-vars", type=Dictionary(), default="", help='Arbitrary input variables to use in the config template, for example: {"version": "4.18"}')
+@click.option("--input-vars", type=Dictionary(), default="{}", help='Arbitrary input variables to use in the config template, for example: {"version": "4.18"}')
 def cmd_analysis(**kwargs):
     """
     Orion runs on command line mode, and helps in detecting regressions

--- a/main.py
+++ b/main.py
@@ -127,9 +127,9 @@ def cli(max_content_width=120):  # pylint: disable=unused-argument
 @click.option("--collapse", is_flag=True, help="Only outputs changepoints, previous and later runs in the xml format")
 @click.option("--node-count", default=False, help="Match any node iterations count")
 @click.option("--lookback-size", type=int, default=10000, help="Maximum number of entries to be looked back")
-@click.option("--es-server", type=str, default="http://localhost:9200", help="Elasticsearch endpoint where test data is stored")
-@click.option("--benchmark-index", type=str, default="benchmark", help="Index where test data is stored")
-@click.option("--metadata-index", type=str, default="benchmark", help="Index where metadata is stored")
+@click.option("--es-server", type=str, envvar="ES_SERVER", help="Elasticsearch endpoint where test data is stored, can be set via env var ES_SERVER", default="")
+@click.option("--benchmark-index", type=str, envvar="es_benchmark_index",  help="Index where test data is stored, can be set via env var es_benchmark_index", default="")
+@click.option("--metadata-index", type=str, envvar="es_metadata_index",  help="Index where metadata is stored, can be set via env var es_metadata_index", default="")
 @click.option("--input-vars", type=Dictionary(), default="{}", help='Arbitrary input variables to use in the config template, for example: {"version": "4.18"}')
 def cmd_analysis(**kwargs):
     """
@@ -143,6 +143,9 @@ def cmd_analysis(**kwargs):
     if len(kwargs["ack"]) > 1 :
         kwargs["ackMap"] = load_ack(kwargs["ack"])
     kwargs["config"] = load_config(kwargs["config"], kwargs["input_vars"])
+    if not kwargs["metadata_index"] or not kwargs["es_server"]:
+        logger.error("metadata-index and es-server flags must be provided")
+        sys.exit(1)
     output, regression_flag, regression_data = run(**kwargs)
     if not output:
         logger.error("Terminating test")

--- a/orion/algorithms/cmr/cmr.py
+++ b/orion/algorithms/cmr/cmr.py
@@ -25,8 +25,8 @@ class CMR(Algorithm):
             series: data series that contains attributes and full dataframe
             change_points_by_metric: list of ChangePoints
         """
-        logger_instance = SingletonLogger.getLogger("Orion")
-        logger_instance.info("Starting analysis using CMR")
+        logger = SingletonLogger.get_logger("Orion")
+        logger.info("Starting analysis using CMR")
         if not (pd.api.types.is_numeric_dtype(self.dataframe["timestamp"]) and self.dataframe["timestamp"].astype(int).min() > 1e9):
             self.dataframe["timestamp"] = pd.to_datetime(self.dataframe["timestamp"])
             self.dataframe["timestamp"] = self.dataframe["timestamp"].astype(int) // 10**9

--- a/orion/algorithms/isolationforest/isolationForest.py
+++ b/orion/algorithms/isolationforest/isolationForest.py
@@ -29,8 +29,8 @@ class IsolationForestWeightedMean(Algorithm):
         dataframe = self.dataframe.copy(deep=True)
         series = self.setup_series()
 
-        logger_instance = SingletonLogger.getLogger("Orion")
-        logger_instance.info("Starting analysis using Isolation Forest")
+        logger = SingletonLogger.get_logger("Orion")
+        logger.info("Starting analysis using Isolation Forest")
         metric_columns = self.metrics_config.keys()
         dataframe_with_metrics = dataframe[metric_columns]
         model = IsolationForest(contamination="auto", random_state=42)

--- a/orion/config.py
+++ b/orion/config.py
@@ -3,10 +3,8 @@
 Module file for config reading and loading
 """
 
-
-import os
 import sys
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 import jinja2
 import yaml

--- a/orion/config.py
+++ b/orion/config.py
@@ -8,93 +8,54 @@ import os
 import sys
 from typing import Any, Dict, Set
 
-from jinja2 import Environment, Template, meta
+import jinja2
 import yaml
 from orion.logger import SingletonLogger
 
 
-def load_config(config: str, parameters: Dict= None) -> Dict[str, Any]:
+def load_config(config_path: str, input_vars: Dict[str, Any]) -> Dict[str, Any]:
     """Loads config file
 
     Args:
-        config (str): path to config file
-        logger (Logger): logger
+    **kwargs: keyword arguments
+        config (str): file path to config file
 
     Returns:
         dict: dictionary of the config file
     """
-    env_vars = {k.lower(): v for k, v in os.environ.items()}
-    merged_parameters = {}
-    merged_parameters.update(env_vars)
-    if parameters:
-        merged_parameters.update(parameters)
-    logger_instance = SingletonLogger.getLogger("Orion")
+    logger = SingletonLogger.get_logger("Orion")
     try:
-        with open(config, "r", encoding="utf-8") as template_file:
+        with open(config_path, "r", encoding="utf-8") as template_file:
             template_content = template_file.read()
-            logger_instance.debug("The %s file has successfully loaded", config)
+            logger.debug("File %s loaded successfully", config_path)
     except FileNotFoundError as e:
-        logger_instance.error("Config file not found: %s", e)
+        logger.error("Config file not found: %s", e)
         sys.exit(1)
     except Exception as e:  # pylint: disable=broad-exception-caught
-        logger_instance.error("An error occurred: %s", e)
+        logger.error("An error occurred: %s", e)
         sys.exit(1)
-
-    required_parameters = get_template_variables(template_content)
-    logger_instance.debug(f"Variables required by the template: {required_parameters}")
-
-    # Check for missing variables
-    optional_params_with_defaults = {"jobtype"}
-    missing_vars = required_parameters - merged_parameters.keys() - optional_params_with_defaults
-    if missing_vars:
-        logger_instance.error(f"Missing required parameters: {missing_vars}, use environment variables to set")
+    template = jinja2.Template(template_content, undefined=jinja2.StrictUndefined)
+    try:
+        rendered_config_yaml = template.render(input_vars)
+    except jinja2.exceptions.UndefinedError as e:
+        logger.critical("Jinja rendering error: %s, define it through the input-variables flag", e)
         sys.exit(1)
-
-    template = Template(template_content)
-    rendered_config_yaml = template.render(merged_parameters)
     rendered_config = yaml.safe_load(rendered_config_yaml)
-    validate_correlations(rendered_config)
     return rendered_config
 
 def load_ack(ack: str) -> Dict[str,Any]:
     "Loads acknowledgment file content."
-    logger_instance = SingletonLogger.getLogger("Orion")
+    logger = SingletonLogger.get_logger("Orion")
     try:
         with open(ack, "r", encoding="utf-8") as template_file:
             template_content = template_file.read()
-            logger_instance.debug("The %s file has successfully loaded", ack)
+            logger.debug("The %s file has successfully loaded", ack)
     except FileNotFoundError as e:
-        logger_instance.error("Config file not found: %s", e)
+        logger.error("Config file not found: %s", e)
         sys.exit(1)
     except Exception as e:  # pylint: disable=broad-exception-caught
-        logger_instance.error("An error occurred: %s", e)
+        logger.error("An error occurred: %s", e)
         sys.exit(1)
 
     rendered_config = yaml.safe_load(template_content)
     return rendered_config
-
-def get_template_variables(template_content: str) -> Set[str]:
-    """Extracts all variables from the Jinja2 template content."""
-    env = Environment()
-    parsed_content = env.parse(template_content)
-    variables = meta.find_undeclared_variables(parsed_content)
-    return variables
-
-
-def validate_correlations(rendered_config):
-    """Validates that the metrics are not in another correlation"""
-    logger_instance = SingletonLogger.getLogger("Orion")
-    correlations = []
-    for test in rendered_config["tests"]:
-        for metric in test["metrics"]:
-            if "correlation" in metric.keys() and metric["correlation"] != "":
-                if metric["name"] in correlations:
-                    logger_instance.error("Correlation in test: %s: %s -> %s in conflict with another",
-                                        test["name"], metric["name"], metric["correlation"] )
-                    sys.exit(1)
-                if metric["correlation"] in correlations:
-                    logger_instance.error("Correlation in test %s: %s -> %s in conflict with another",
-                                        test["name"], metric["name"], metric["correlation"] )
-                    sys.exit(1)
-                correlations.append(metric["name"])
-                correlations.append(metric["correlation"])

--- a/orion/config.py
+++ b/orion/config.py
@@ -4,6 +4,7 @@ Module file for config reading and loading
 """
 
 import sys
+import os
 from typing import Any, Dict
 
 import jinja2
@@ -22,6 +23,8 @@ def load_config(config_path: str, input_vars: Dict[str, Any]) -> Dict[str, Any]:
         dict: dictionary of the config file
     """
     logger = SingletonLogger.get_logger("Orion")
+    env_vars = {k.lower(): v for k, v in os.environ.items()}
+    env_vars.update(input_vars)
     try:
         with open(config_path, "r", encoding="utf-8") as template_file:
             template_content = template_file.read()
@@ -34,7 +37,7 @@ def load_config(config_path: str, input_vars: Dict[str, Any]) -> Dict[str, Any]:
         sys.exit(1)
     template = jinja2.Template(template_content, undefined=jinja2.StrictUndefined)
     try:
-        rendered_config_yaml = template.render(input_vars)
+        rendered_config_yaml = template.render(env_vars)
     except jinja2.exceptions.UndefinedError as e:
         logger.critical("Jinja rendering error: %s, define it through the input-variables flag", e)
         sys.exit(1)

--- a/orion/daemon.py
+++ b/orion/daemon.py
@@ -14,7 +14,7 @@ import orion.constants as cnsts
 from . import run_test
 
 app = FastAPI()
-logger_instance = SingletonLogger.getLogger("Orion")
+logger = SingletonLogger.get_logger("Orion")
 
 
 @app.get("/daemon/changepoint")

--- a/orion/logger.py
+++ b/orion/logger.py
@@ -37,7 +37,7 @@ class SingletonLogger:
         return logger
 
     @classmethod
-    def getLogger(cls, name: str) -> logging.Logger:
+    def get_logger(cls, name: str) -> logging.Logger:
         """Return logger in instance
 
         Args:

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -6,11 +6,7 @@ import logging
 from datetime import datetime
 from typing import List, Dict, Any
 
-# pylint: disable=import-error
 from elasticsearch import Elasticsearch
-
-
-# pylint: disable=import-error
 import pandas as pd
 from elasticsearch_dsl import Search, Q
 from elasticsearch_dsl.response import Response
@@ -18,7 +14,6 @@ from orion.logger import SingletonLogger
 
 
 class Matcher:
-    # pylint: disable=too-many-instance-attributes
     """
     A class used to match or interact with an Elasticsearch index for performance scale testing.
 
@@ -31,6 +26,7 @@ class Matcher:
         uuid_field (str): Name of the field containing the UUID.
     """
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         index: str = "ospst-perf-scale-ci",
@@ -44,7 +40,6 @@ class Matcher:
         self.search_size = 10000
         self.logger = SingletonLogger(debug=level, name="Matcher")
         self.es = Elasticsearch([es_url], timeout=30, verify_certs=verify_certs)
-        self.data = None
         self.version_field = version_field
         self.uuid_field = uuid_field
 
@@ -76,6 +71,7 @@ class Matcher:
         self.logger.debug("Executing query \r\n%s", search.to_dict())
         return search.execute()
 
+    # pylint: disable=too-many-locals
     def get_uuid_by_metadata(
         self,
         meta: Dict[str, Any],
@@ -97,7 +93,7 @@ class Matcher:
             Similar to a car manufacturer's warranty limits.
 
         Returns:
-            List[Dict[str, str]]: _description_
+            List[Dict[str, str]]: List of dictionaries with uuid, buildURL and ocpVersion as keys
         """
         must_clause = []
         must_not_clause = []
@@ -139,9 +135,8 @@ class Matcher:
             .extra(size=lookback_size)
         )
         result = self.query_index(s)
-        hits = result.hits.hits
         uuids_docs = []
-        for hit in hits:
+        for hit in result.hits.hits:
             if "buildUrl" in hit["_source"]:
                 uuids_docs.append(
                     {

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -1,8 +1,6 @@
 """metadata matcher"""
 
 # pylint: disable = invalid-name, invalid-unary-operand-type, no-member
-import os
-import logging
 from datetime import datetime
 from typing import List, Dict, Any
 
@@ -19,8 +17,7 @@ class Matcher:
 
     Attributes:
         index (str): Name of the Elasticsearch index to interact with.
-        level (int): Logging level (e.g., logging.INFO).
-        es_url (str): Elasticsearch endpoint, can be specified by the environment variable ES_SERVER
+        es_url (str): Elasticsearch endpoint
         verify_certs (bool): Whether to verify SSL certificates when connecting to Elasticsearch.
         version_field (str): Name of the field containing the OpenShift version.
         uuid_field (str): Name of the field containing the UUID.
@@ -30,16 +27,15 @@ class Matcher:
     def __init__(
         self,
         index: str = "ospst-perf-scale-ci",
-        level: int = logging.INFO,
-        es_url: str = os.getenv("ES_SERVER"),
+        es_server: str = "https://localhost:9200",
         verify_certs: bool = True,
         version_field: str = "ocpVersion",
         uuid_field: str = "uuid"
     ):
         self.index = index
         self.search_size = 10000
-        self.logger = SingletonLogger(debug=level, name="Matcher")
-        self.es = Elasticsearch([es_url], timeout=30, verify_certs=verify_certs)
+        self.logger = SingletonLogger.get_logger("Orion")
+        self.es = Elasticsearch([es_server], timeout=30, verify_certs=verify_certs)
         self.version_field = version_field
         self.uuid_field = uuid_field
 

--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -47,7 +47,7 @@ def run(**kwargs: dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
             - Test output (dict): Test JSON output
             - regression flag (bool): Test result
     """
-    logger_instance = SingletonLogger.getLogger("Orion")
+    logger = SingletonLogger.get_logger("Orion")
     config = kwargs["config"]
     sippy_pr_search = kwargs["sippy_pr_search"]
     result_output = {}

--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -65,8 +65,7 @@ def run(**kwargs: dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
         utils = Utils(uuid_field, version_field)
         matcher = Matcher(
             index=kwargs["metadata_index"],
-            level=logger.level,
-            es_url=kwargs["es_server"],
+            es_server=kwargs["es_server"],
             verify_certs=False,
             version_field=version_field,
             uuid_field=uuid_field

--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -29,16 +29,17 @@ def get_algorithm_type(kwargs):
         algorithm_name = None
     return algorithm_name
 
+# pylint: disable=too-many-locals
 def run(**kwargs: dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
     """run method to start the tests
 
     Args:
       **kwargs: keyword arguments
-        config (_type_): file path to config file
+        config (str): file path to config file
         es_server (str): elasticsearch endpoint
-        output_path (_type_): output path to save the data
-        hunter_analyze (_type_): changepoint detection through hunter. defaults to True
-        output_format (_type_): output to be table or json
+        output_path (str): output path to save the data
+        hunter_analyze (bool): changepoint detection through hunter. defaults to True
+        output_format (str): output to be table or json
         lookback (str): lookback in days
 
     Returns:

--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -3,7 +3,7 @@ run test
 """
 import sys
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 from orion.matcher import Matcher
 from orion.logger import SingletonLogger
 from orion.algorithms import AlgorithmFactory
@@ -29,24 +29,29 @@ def get_algorithm_type(kwargs):
         algorithm_name = None
     return algorithm_name
 
-def run(**kwargs: dict[str, Any]) -> dict[str, Any]: #pylint: disable = R0914
+def run(**kwargs: dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
     """run method to start the tests
 
     Args:
+      **kwargs: keyword arguments
         config (_type_): file path to config file
+        es_server (str): elasticsearch endpoint
         output_path (_type_): output path to save the data
         hunter_analyze (_type_): changepoint detection through hunter. defaults to True
         output_format (_type_): output to be table or json
+        lookback (str): lookback in days
 
     Returns:
-        _type_: _description_
+        tuple:
+            - Test output (dict): Test JSON output
+            - regression flag (bool): Test result
     """
     logger_instance = SingletonLogger.getLogger("Orion")
-    config_map = kwargs["configMap"]
+    config = kwargs["config"]
     sippy_pr_search = kwargs["sippy_pr_search"]
     result_output = {}
     regression_flag = False
-    for test in config_map["tests"]:
+    for test in config["tests"]:
         # Create fingerprint Matcher
 
         version_field = "ocpVersion"
@@ -57,11 +62,10 @@ def run(**kwargs: dict[str, Any]) -> dict[str, Any]: #pylint: disable = R0914
             uuid_field=test["uuid_field"]
 
         utils = Utils(uuid_field, version_field)
-        datasource = utils.get_datasource(config_map)
         matcher = Matcher(
-            index=test["index"],
-            level=logger_instance.level,
-            es_url=datasource,
+            index=kwargs["metadata_index"],
+            level=logger.level,
+            es_url=kwargs["es_server"],
             verify_certs=False,
             version_field=version_field,
             uuid_field=uuid_field
@@ -80,9 +84,9 @@ def run(**kwargs: dict[str, Any]) -> dict[str, Any]: #pylint: disable = R0914
 
         algorithm_name = get_algorithm_type(kwargs)
         if algorithm_name is None:
-            logger_instance.error("No algorithm configured")
+            logger.error("No algorithm configured")
             return None, None, None
-        logger_instance.info("Comparison algorithm: %s", algorithm_name)
+        logger.info("Comparison algorithm: %s", algorithm_name)
 
         algorithmFactory = AlgorithmFactory()
         algorithm = algorithmFactory.instantiate_algorithm(

--- a/test.bats
+++ b/test.bats
@@ -60,7 +60,7 @@ setup() {
       }
     }
   }' | jq -r '.aggregations.distinct_versions.buckets[0].key')
-  export version=$(echo "$LATEST_VERSION" | cut -d. -f1,2)
+  export VERSION=$(echo "$LATEST_VERSION" | cut -d. -f1,2)
 
   CHAOS_LATEST_VERSION=$(curl -s -X POST "$ES_SERVER/krkn-telemetry*/_search" \
   -H "Content-Type: application/json" \

--- a/test.bats
+++ b/test.bats
@@ -6,7 +6,7 @@
 run_cmd(){
   echo "$@"
   set +e
-  ${@}
+  "${@}"
   EXIT_CODE=$?
   set -e
 
@@ -23,9 +23,9 @@ run_cmd(){
 
 setup() {
   # Make a note of daemon PID
-  export ES_SERVER="$QE_ES_SERVER"
-  export es_metadata_index="perf_scale_ci*"
-  export es_benchmark_index="ripsaw-kube-burner*"
+  ES_SERVER="$QE_ES_SERVER"
+  METADATA_INDEX="perf_scale_ci*"
+  BENCHMARK_INDEX="ripsaw-kube-burner*"
   LATEST_VERSION=$(curl -s -X POST "$ES_SERVER/perf_scale_ci*/_search" \
   -H "Content-Type: application/json" \
   -d '{
@@ -127,16 +127,16 @@ setup() {
 
 }
 
-@test "orion cmd label small scale cluster density with hunter-analyze " {
-  run_cmd orion cmd --config "examples/label-small-scale-cluster-density.yaml" --lookback 5d --hunter-analyze
+@test "orion cmd label small scale cluster density with hunter-analyze" {
+  run_cmd orion cmd --config "examples/label-small-scale-cluster-density.yaml" --lookback 5d --hunter-analyze --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
-@test "orion cmd payload scale " {
-  run_cmd orion cmd --config "examples/payload-scale.yaml" --lookback 5d --hunter-analyze
+@test "orion cmd payload scale" {
+  run_cmd orion cmd --config "examples/payload-scale.yaml" --lookback 5d --hunter-analyze --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
-@test "orion cmd payload scale without lookback period " {
-  run_cmd orion cmd --config "examples/payload-scale.yaml" --hunter-analyze
+@test "orion cmd payload scale without lookback period" {
+  run_cmd orion cmd --config "examples/payload-scale.yaml" --hunter-analyze --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
 @test "orion cmd readout control plane cdv2 with text output " {
@@ -151,37 +151,36 @@ setup() {
   run_cmd orion cmd --config "examples/small-rosa-control-plane-node-density.yaml" --hunter-analyze --output-format json --save-output-path=output.json --node-count True
 }
 
-@test "orion cmd readout netperf tcp with junit output " {
-  export es_benchmark_index="k8s-netperf"
-  run_cmd orion cmd --config "examples/readout-netperf-tcp.yaml" --output-format junit --hunter-analyze --save-output-path=output.xml
+@test "orion cmd readout netperf tcp with junit output" {
+  run_cmd orion cmd --config "examples/readout-netperf-tcp.yaml" --output-format junit --hunter-analyze --save-output-path=output.xml --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=k8s-netperf --input-vars='{"version": "'${VERSION}'"}'
 }
 
-@test "orion cmd virt-density " {
-  run_cmd orion cmd --config examples/metal-perfscale-cpt-virt-density.yaml --lookback 15d --hunter-analyze
+@test "orion cmd virt-density" {
+  run_cmd orion cmd --config examples/metal-perfscale-cpt-virt-density.yaml --lookback 15d --hunter-analyze --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
-@test "orion cmd small scale cluster density with anomaly detection " {
-  run_cmd orion cmd --config "examples/small-scale-cluster-density.yaml" --lookback 5d --anomaly-detection
+@test "orion cmd small scale cluster density with anomaly detection" {
+  run_cmd orion cmd --config "examples/small-scale-cluster-density.yaml" --lookback 5d --anomaly-detection --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
-@test "orion cmd small scale node density cni anomaly detection with a window " {
-  run_cmd orion cmd --config "examples/small-scale-node-density-cni.yaml" --anomaly-detection --anomaly-window 3
+@test "orion cmd small scale node density cni anomaly detection with a window" {
+  run_cmd orion cmd --config "examples/small-scale-node-density-cni.yaml" --anomaly-detection --anomaly-window 3 --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
-@test "orion cmd trt external payload cluster density anomaly detection with a minimum percentage " {
-  run_cmd orion cmd --config "examples/trt-external-payload-cluster-density.yaml" --anomaly-detection --anomaly-window 3 --min-anomaly-percent 5
+@test "orion cmd trt external payload cluster density anomaly detection with a minimum percentage" {
+  run_cmd orion cmd --config "examples/trt-external-payload-cluster-density.yaml" --anomaly-detection --anomaly-window 3 --min-anomaly-percent 5 --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
-@test "orion cmd trt external payload crd scale with default anomaly detection " {
-  run_cmd orion cmd --config "examples/trt-external-payload-crd-scale.yaml" --anomaly-detection
+@test "orion cmd trt external payload crd scale with default anomaly detection" {
+  run_cmd orion cmd --config "examples/trt-external-payload-crd-scale.yaml" --anomaly-detection --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
-@test "orion cmd trt external payload node density " {
-  run_cmd orion cmd --config "examples/trt-external-payload-node-density.yaml" --hunter-analyze
+@test "orion cmd trt external payload node density" {
+  run_cmd orion cmd --config "examples/trt-external-payload-node-density.yaml" --hunter-analyze --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
-@test "orion cmd trt external payload cluster density " {
-  run_cmd orion cmd --config "examples/trt-payload-cluster-density.yaml" --hunter-analyze
+@test "orion cmd trt external payload cluster density" {
+  run_cmd orion cmd --config "examples/trt-payload-cluster-density.yaml" --hunter-analyze --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"version": "'${VERSION}'"}'
 }
 
 @test "orion cmd chaos tests " {
@@ -214,7 +213,7 @@ setup() {
   version=$before_version
 }
 
-@test "orion daemon small scale cluster density with anomaly detection " {
+@test "orion daemon small scale cluster density with anomaly detection" {
   orion daemon --port 8080 &
   DAEMON_PID=$!
   echo "Orion daemon started with PID $DAEMON_PID"
@@ -225,7 +224,7 @@ setup() {
   fi
 }
 
-@test "orion daemon small scale node density cni with changepoint detection " {
+@test "orion daemon small scale node density cni with changepoint detection" {
   orion daemon --port 8080 &
   DAEMON_PID=$!
   echo "Orion daemon started with PID $DAEMON_PID"
@@ -236,7 +235,7 @@ setup() {
   fi
 }
 
-@test "orion daemon trt payload cluster density with version parameter " {
+@test "orion daemon trt payload cluster density with version parameter" {
   orion daemon --port 8080 &
   DAEMON_PID=$!
   echo "Orion daemon started with PID $DAEMON_PID"
@@ -247,10 +246,9 @@ setup() {
   fi
 }
 
-@test "orion cmd with netobserv configs " {
+@test "orion cmd with netobserv configs" {
   curl -s https://raw.githubusercontent.com/openshift-eng/ocp-qe-perfscale-ci/refs/heads/netobserv-perf-tests/scripts/queries/netobserv-orion-node-density-heavy.yaml -w %{http_code} -o /tmp/netobserv-node-density-heavy-ospst.yaml
-  export WORKERS=25
-  run_cmd orion cmd --config "/tmp/netobserv-node-density-heavy-ospst.yaml" --lookback 5d --hunter-analyze
+  run_cmd orion cmd --config "/tmp/netobserv-node-density-heavy-ospst.yaml" --lookback 5d --hunter-analyze --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"workers": 25}'
 }
 
 


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

We should stop using environment variables, for different reasons, like:

- They are confusing, they often clash with other variables and code logic unexpectedly
- They can be set anywhere throughout the code, which makes debugging more difficult
- A regular cmd flag has better traceability imo and makes easier to recognize the parameters used to run a test

For this reason I'm proposing to stop using them and shifting to a regular flag like `--input-vars` , which expects a arbitrary JSON data and loads it into a dictionary, allowing to introduce different data types such as strings, numbers, arrays, etc.


## Related Tickets & Documents

- Related Issue Follow-up of #173

## Caveats

No backwards compatible. ⚠️ , environment variables need to be passed from the input-vars flag
