### PR TITLE
Add new cgroup metrics intended to test on pre-merge PRs

### DIFF
--- a/examples/pre-merge-payload-cluster-density.yaml
+++ b/examples/pre-merge-payload-cluster-density.yaml
@@ -31,6 +31,7 @@ tests :
 
     - name:  ovsCPU
       metricName : cgroupCPU
+      labels.id.keyword : /system.slice/ovs-vswitchd.service
       metric_of_interest: value
       agg:
         value: cpu
@@ -42,6 +43,7 @@ tests :
 
     - name:  ovsMemory
       metricName : cgroupMemoryRSS 
+      labels.id.keyword : /system.slice/ovs-vswitchd.service
       metric_of_interest: value
       agg:
         value: mem


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

Add a new yaml file to add new cgroup metrics intended detect OVS CPU/Mem spike on pre-merge PRs

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
