### PR TITLE
add new instantaneous ovs metrics and update udn acks

### DIFF
--- a/ack/4.20_udn-l3_ack.yaml
+++ b/ack/4.20_udn-l3_ack.yaml
@@ -19,5 +19,8 @@ ack:
     metric: ovnMem-sbdb_avg
     reason: kube-burner change on how we calculate metrics
   - uuid: fe9521f8-71b8-4ad4-b190-4e03269ebd24
-    metric: ovnMem-ovnk-controller_av
+    metric: ovnMem-ovnk-controller_avg
     reason: kube-burner change on how we calculate metrics
+  - uuid: 7d80399d-f455-4134-b631-d1712c42413e
+    metric: ovnMem-nbdb_avg
+    reason: https://issues.redhat.com/browse/OCPBUGS-60650

--- a/examples/small-scale-udn-l3.yaml
+++ b/examples/small-scale-udn-l3.yaml
@@ -45,6 +45,18 @@ tests :
       direction: 1
       threshold: 10
 
+    - name: ovsVswitchdCPU
+      metricName: cgroupCPU
+      labels.id.keyword: /system.slice/ovs-vswitchd.service
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
     - name:  ovnkCPU-overall
       metricName : containerCPU
       jobName.keyword: udn-density-l3-pods
@@ -132,6 +144,18 @@ tests :
       metricName : cgroupMemoryRSS-Workers
       jobName.keyword: udn-density-l3-pods
       labels.id.keyword : /system.slice/ovs-vswitchd.service
+      metric_of_interest: value
+      agg:
+        value: mem
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name: ovsVswitchdMemory
+      metricName: cgroupMemoryRSS
+      labels.id.keyword: /system.slice/ovs-vswitchd.service
       metric_of_interest: value
       agg:
         value: mem


### PR DESCRIPTION
This now tracks the regression for instantaneous ovs cpu/mem, ensuring we catch issues that were previously missed
What we missed:  https://issues.redhat.com/browse/OCPBUGS-55825

Updated acks 
[nbdb cpu regression in 4.20 udn  ](https://privatebin.corp.redhat.com/?b13c117991abd20d#7uCipbjhXnrG2shstdbFNXWMgr6iPoNSWmedHsd4D13X)

Tested: [Sample orion output](https://privatebin.corp.redhat.com/?4d8c6bbd6d27ff76#GVPXKxTzmkVNHva3hg2QhNKHvYpo9jha4NoencdGVXfr)