### PR TITLE
Adding uuid field for tabular output

### DIFF
--- a/orion/algorithms/algorithm.py
+++ b/orion/algorithms/algorithm.py
@@ -14,10 +14,10 @@ import orion.constants as cnsts
 from orion.utils import json_to_junit
 
 
-class Algorithm(ABC):
+class Algorithm(ABC): # pylint: disable = too-many-arguments, too-many-instance-attributes
     """Generic Algorithm class for algorithm factory"""
 
-    def __init__(  # pylint: disable = too-many-arguments
+    def __init__(
         self,
         matcher: Matcher,
         dataframe: pd.DataFrame,
@@ -25,6 +25,7 @@ class Algorithm(ABC):
         options: dict,
         metrics_config: dict[str, dict],
         version_field: str = "ocpVersion",
+        uuid_field: str = "uuid"
     ) -> None:
         self.matcher = matcher
         self.dataframe = dataframe
@@ -33,6 +34,7 @@ class Algorithm(ABC):
         self.options = options
         self.metrics_config = metrics_config
         self.regression_flag = False
+        self.uuid_field = uuid_field
 
     def output_json(self) -> Tuple[str, str, bool]:
         """Method to output json output
@@ -114,6 +116,7 @@ class Algorithm(ABC):
             test_name=test_name,
             data_json=data_json,
             metrics_config=self.metrics_config,
+            uuid_field=self.uuid_field
         )
         return test_name, data_junit, self.regression_flag
 
@@ -166,7 +169,7 @@ class Algorithm(ABC):
         attributes = {
             column: self.dataframe[column]
             for column in self.dataframe.columns
-            if column in ["uuid", "buildUrl", self.version_field]
+            if column in [self.uuid_field, "buildUrl", self.version_field]
         }
         series = Series(
             test_name=self.test["name"],

--- a/orion/algorithms/algorithmFactory.py
+++ b/orion/algorithms/algorithmFactory.py
@@ -12,7 +12,17 @@ from .cmr import CMR
 class AlgorithmFactory: # pylint: disable= too-few-public-methods, too-many-arguments, line-too-long
     """Algorithm Factory to choose algorithm
     """
-    def instantiate_algorithm(self, algorithm: str, matcher: Matcher, dataframe:pd.DataFrame, test: dict, options: dict, metrics_config: dict[str,dict], version_field: str = "ocpVersion"):
+    def instantiate_algorithm(  # pylint: disable = too-many-arguments
+            self,
+            algorithm: str,
+            matcher: Matcher,
+            dataframe:pd.DataFrame,
+            test: dict,
+            options: dict,
+            metrics_config: dict[str,dict],
+            version_field: str = "ocpVersion",
+            uuid_field: str = "uuid"
+        ):
         """Algorithm instantiation method
 
         Args:
@@ -28,9 +38,9 @@ class AlgorithmFactory: # pylint: disable= too-few-public-methods, too-many-argu
             Algorithm : Algorithm
         """
         if algorithm == cnsts.EDIVISIVE:
-            return EDivisive(matcher, dataframe, test, options, metrics_config, version_field)
+            return EDivisive(matcher, dataframe, test, options, metrics_config, version_field, uuid_field)
         if algorithm == cnsts.ISOLATION_FOREST:
-            return IsolationForestWeightedMean(matcher, dataframe, test, options, metrics_config, version_field)
+            return IsolationForestWeightedMean(matcher, dataframe, test, options, metrics_config, version_field, uuid_field)
         if algorithm == cnsts.CMR:
-            return CMR(matcher, dataframe, test, options, metrics_config, version_field)
+            return CMR(matcher, dataframe, test, options, metrics_config, version_field, uuid_field)
         raise ValueError("Invalid algorithm called")

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -334,6 +334,9 @@ class Matcher:
             list: List of parsed results
         """
         res = []
+        if "aggregations" not in data:
+            return res
+
         stamps = data.aggregations.time.buckets
         agg_buckets = data.aggregations.uuid.buckets
 

--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -106,6 +106,7 @@ def run(**kwargs: dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
                 kwargs,
                 metrics_config,
                 version_field,
+                uuid_field
             )
         # This is env is only present in prow ci
         prow_job_id = os.getenv("PROW_JOB_ID")

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -501,7 +501,7 @@ class Utils:
 
 # pylint: disable=too-many-locals
 def json_to_junit(
-    test_name: str, data_json: Dict[Any, Any], metrics_config: Dict[Any, Any]
+    test_name: str, data_json: Dict[Any, Any], metrics_config: Dict[Any, Any], uuid_field: str
 ) -> str:
     """Convert json to junit format
 
@@ -536,7 +536,7 @@ def json_to_junit(
             failures_count += 1
             failure = ET.SubElement(testcase, "failure")
             failure.text = (
-                "\n" + generate_tabular_output(data_json, metric_name=metric) + "\n"
+                "\n" + generate_tabular_output(data_json, metric_name=metric, uuid_field=uuid_field) + "\n"
             )
 
     testsuite.set("failures", str(failures_count))
@@ -558,7 +558,7 @@ def generate_tabular_output(data: list, metric_name: str, uuid_field: str = "uui
     """
     records = []
     create_record = lambda record: {  # pylint: disable = C3001
-        "uuid": record[uuid_field],
+        uuid_field: record[uuid_field],
         "timestamp": datetime.fromtimestamp(record["timestamp"], timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         ),

--- a/test.bats
+++ b/test.bats
@@ -78,6 +78,13 @@ setup() {
               }
             }
           }
+        ],
+        "filter": [
+          {
+            "match_phrase": {
+              "scenarios.scenario_type.keyword": "node_scenarios"
+            }
+          }
         ]
       }
     },
@@ -91,6 +98,7 @@ setup() {
     }
   }' | jq -r '.aggregations.distinct_versions.buckets[0].key')
   export chaos_version=$(echo "$CHAOS_LATEST_VERSION" | cut -d'.' -f1,2)
+  echo "chaos version $chaos_version"
 
   OLS_LATEST_VERSION=$(curl -s -X POST "$ES_SERVER/perf_scale_ci*/_search" \
   -H "Content-Type: application/json" \
@@ -191,7 +199,7 @@ setup() {
 
 @test "orion chaos tests " {
   before_version=$version
-  scenario_type="pvc_scenarios" cloud_infrastructure="aws" cloud_type="self-managed" total_node_count="9" node_instance_type="m6a.xlarge" network_plugins="OVNKubernetes" scenario_file="*pvc_scenario.yaml" run_cmd orion --config "examples/chaos_tests.yaml" --lookback 45d --es-server=${ES_SERVER} --metadata-index=${KRKEN_METADATA_INDEX} --benchmark-index=${KRKN_BENCHMARK_INDEX} --input-vars='{"version": "'${chaos_version}'"}'
+  scenario_type="pvc_scenarios" cloud_infrastructure="aws" cloud_type="self-managed" total_node_count="9" node_instance_type="m6a.xlarge" network_plugins="OVNKubernetes" scenario_file="*pvc_scenario.yaml" run_cmd orion --config "examples/chaos_tests.yaml" --lookback 45d --es-server=${ES_SERVER} --metadata-index=${KRKEN_METADATA_INDEX} --benchmark-index=${KRKN_BENCHMARK_INDEX} --input-vars='{"version": "'${chaos_version}'"}' --output-format text
   VERSION=$before_version
 }
 
@@ -205,7 +213,7 @@ setup() {
 @test "orion pod disruption scenarios " {
   before_version=$version
   VERSION=$chaos_version
-  scenario_type="pod_disruption_scenarios" cloud_infrastructure="AWS" cloud_type="self-managed" total_node_count="9" node_instance_type="*xlarge*" network_plugins="OVNKubernetes" scenario_file="*pod_scenario.yaml" run_cmd orion --config "examples/pod_disruption_scenarios.yaml" --lookback 45d --es-server=${ES_SERVER} --metadata-index=${KRKEN_METADATA_INDEX} --benchmark-index=${KRKN_BENCHMARK_INDEX}
+  scenario_type="pod_disruption_scenarios" cloud_infrastructure="AWS" cloud_type="self-managed" total_node_count="9" node_instance_type="*xlarge*" network_plugins="OVNKubernetes" scenario_file="*pod_scenario.yaml" run_cmd orion --config "examples/pod_disruption_scenarios.yaml" --lookback 45d --es-server=${ES_SERVER} --metadata-index=${KRKEN_METADATA_INDEX} --benchmark-index=${KRKN_BENCHMARK_INDEX} --hunter-analyze
   VERSION=$before_version
 }
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In generate_tabular_output it was expecting a uuid but none was passed from the caller function. Adding uuid field to it and adding other output options for chaos scenario tests for catching this in the future 

 

## Related Tickets & Documents

- Related Issue #
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/68318/rehearse-68318-periodic-ci-redhat-chaos-prow-scripts-main-cr-4.19-nightly-krkn-hub-node-orion/1960056053794082816/artifacts/krkn-hub-node-orion/redhat-chaos-orion-node-tests-control-plane/build-log.txt
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
