### PR TITLE
move sippy err messages to debug

### DIFF
--- a/orion/utils.py
+++ b/orion/utils.py
@@ -453,7 +453,7 @@ class Utils:
         url = base_url + filter_url
         response = requests.get(url, timeout=30)
         if response.status_code != 200:
-            self.logger.error("Failed to get diff between %s and %s in sippy", base_version, new_version)
+            self.logger.debug("Failed to get diff between %s and %s in sippy", base_version, new_version)
             return []
         return self.process_sippy_pr_list(response.json())
 
@@ -495,7 +495,7 @@ class Utils:
         url = f"{base_url}?{urllib.parse.urlencode(params)}"
         response = requests.get(url, timeout=30)
         if response.status_code != 200:
-            self.logger.error("Failed to search for PRs in sippy for version %s", version)
+            self.logger.debug("Failed to search for PRs in sippy for version %s", version)
             return []
         return self.process_sippy_pr_list(response.json())
 


### PR DESCRIPTION
-o json should only give out json as its output

the orion-mcp server cannot parse the below message

```
Running command: ['orion', '--lookback', '15d', '--hunter-analyze', '--config', '/orion/examples/small-scale-udn-l3.yaml', '-o', 'json']
Orion return code: 2
Orion stdout: 2025-09-12 16:37:03,686 - Orion      - ERROR - file: utils.py - line: 498 - Failed to search for PRs in sippy for version 4.19.0-0.nightly-2025-09-11-104048
2025-09-12 16:37:03,741 - Orion      - ERROR - file: utils.py - line: 498 - Failed to search for PRs in sippy for version 4.19.0-0.nightly-2025-09-10-184745
2025-09-12 16:37:03,793 - Orion      - ERROR - file: utils.py - line: 498 - Failed to search for PRs in sippy for version 4.19.0-0.nightly-2025-09-06-192226
2025-09-12 16:37:03,844 - Orion      - ERROR - file: utils.py - line: 498 - Failed to search for PRs in sippy for version 4.19.0-0.nightly-2025-09-06-192226
2025-09-12 16:37:03,894 - Orion      - ERROR - file: utils.py - line: 498 - Failed to search for PRs in sippy for version 4.19.0-0.nightly-2025-09-06-192226
```

and returns
```
{
error:
"Failed to fetch Orion metrics: Error processing result for /orion/examples/trt-external-payload-cluster-density.yaml: Error : Extra data: line 1 column 5 (char 4)"
}
```
this should resolve it

Tested locally, works!
