### PR TITLE
[PERFSCALE-4163] OKD control plane config files

### DIFF
--- a/examples/okd-control-plane-cluster-density.yaml
+++ b/examples/okd-control-plane-cluster-density.yaml
@@ -1,5 +1,5 @@
 tests :
-  - name : node-density-heavy-24nodes
+  - name : okd-cluster-density-6nodes
     metadata:
       ocpVersion: {{ version }}
       platform: AWS

--- a/examples/okd-control-plane-cluster-density.yaml
+++ b/examples/okd-control-plane-cluster-density.yaml
@@ -1,0 +1,91 @@
+tests :
+  - name : node-density-heavy-24nodes
+    metadata:
+      ocpVersion: {{ version }}
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6a.xlarge
+      masterNodesCount: 3
+      workerNodesType: m6a.xlarge
+      workerNodesCount: 6
+      benchmark.keyword: cluster-density-v2
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      stream: okd
+
+    metrics:
+    - name:  podReadyLatency
+      metricName: podLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PerfScale]"
+      direction: 1
+      threshold: 10
+
+    - name:  apiserverCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-kube-apiserver
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+
+    - name: multusCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-multus
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: multus]"
+      direction: 1
+
+    - name: monitoringCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-monitoring
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: monitoring]"
+      direction: 1
+
+    - name:  ovnCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+
+    - name:  etcdCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-etcd
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+
+    - name: kubelet
+      metricName : kubeletCPU
+      metric_of_interest: value
+      labels:
+        - "[Jira: Node]"
+      agg:
+        value: cpu
+        agg_type: avg
+      direction: 1

--- a/examples/okd-control-plane-crd-scale.yaml
+++ b/examples/okd-control-plane-crd-scale.yaml
@@ -1,0 +1,39 @@
+tests :
+  - name : okd-crd-scale-6nodes
+    metadata:
+      ocpVersion: {{ version }}
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6a.xlarge
+      masterNodesCount: 3
+      workerNodesType: m6a.xlarge
+      workerNodesCount: 6
+      benchmark.keyword: crd-scale
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      stream: okd
+
+    metrics:
+    - name:  apiserverCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-kube-apiserver
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name:  etcdCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-etcd
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10

--- a/examples/okd-control-plane-node-density-cni.yaml
+++ b/examples/okd-control-plane-node-density-cni.yaml
@@ -1,0 +1,274 @@
+tests :
+  - name : okd-node-density-cni-6nodes
+    metadata:
+      ocpVersion: {{ version }}
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6a.xlarge
+      masterNodesCount: 3
+      workerNodesType: m6a.xlarge
+      workerNodesCount: 6
+      benchmark.keyword: node-density-cni
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      stream: okd
+
+    metrics:
+    - name:  podReadyLatency
+      metricName: podLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PerfScale]"
+      direction: 1
+      threshold: 10
+
+    - name:  serviceReadyLatency
+      metricName: serviceLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PerfScale]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovsCPU
+      metricName : cgroupCPUSeconds-Workers
+      labels.id.keyword : /system.slice/ovs-vswitchd.service
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnkCPU-overall
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnCPU-ovncontroller
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: ovn-controller
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnCPU-northd
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: northd
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnCPU-nbdb
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: nbdb
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnCPU-sbdb
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: sbdb
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnCPU-ovnk-controller
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: ovnkube-controller
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovsMemory
+      metricName : cgroupMemoryRSS-Workers
+      labels.id.keyword : /system.slice/ovs-vswitchd.service
+      metric_of_interest: value
+      agg:
+        value: mem
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnkMem-overall
+      metricName : containerMemory
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      metric_of_interest: value
+      agg:
+        value: mem
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnMem-ovncontroller
+      metricName : containerMemory
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: ovn-controller
+      metric_of_interest: value
+      agg:
+        value: mem
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnMem-northd
+      metricName : containerMemory
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: northd
+      metric_of_interest: value
+      agg:
+        value: mem
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnMem-nbdb
+      metricName : containerMemory
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: nbdb
+      metric_of_interest: value
+      agg:
+        value: mem
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnMem-sbdb
+      metricName : containerMemory
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: sbdb
+      metric_of_interest: value
+      agg:
+        value: mem
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  ovnMem-ovnk-controller
+      metricName : containerMemory
+      labels.namespace.keyword: openshift-ovn-kubernetes
+      labels.container.keyword: ovnkube-controller
+      metric_of_interest: value
+      agg:
+        value: mem
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name:  apiserverCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-kube-apiserver
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: multusCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-multus
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: multus]"
+      direction: 1
+      threshold: 10
+
+    - name: monitoringCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-monitoring
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: monitoring]"
+      direction: 1
+      threshold: 10
+
+    - name:  etcdCPU
+      metricName : containerCPU
+      labels.namespace.keyword: openshift-etcd
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: kubelet
+      metricName : kubeletCPU
+      metric_of_interest: value
+      labels:
+        - "[Jira: Node]"
+      agg:
+        value: cpu
+        agg_type: avg
+      direction: 1
+      threshold: 10

--- a/examples/okd-control-plane-node-density-cni.yaml
+++ b/examples/okd-control-plane-node-density-cni.yaml
@@ -25,17 +25,6 @@ tests :
       direction: 1
       threshold: 10
 
-    - name:  serviceReadyLatency
-      metricName: serviceLatencyQuantilesMeasurement
-      quantileName: Ready
-      metric_of_interest: P99
-      not:
-        jobConfig.name: "garbage-collection"
-      labels:
-        - "[Jira: PerfScale]"
-      direction: 1
-      threshold: 10
-
     - name:  ovsCPU
       metricName : cgroupCPUSeconds-Workers
       labels.id.keyword : /system.slice/ovs-vswitchd.service

--- a/examples/okd-control-plane-node-density.yaml
+++ b/examples/okd-control-plane-node-density.yaml
@@ -1,5 +1,5 @@
 tests :
-  - name : node-density-heavy-24nodes
+  - name : okd-node-density-6nodes
     metadata:
       ocpVersion: {{ version }}
       platform: AWS

--- a/examples/okd-control-plane-node-density.yaml
+++ b/examples/okd-control-plane-node-density.yaml
@@ -1,0 +1,66 @@
+tests :
+  - name : node-density-heavy-24nodes
+    metadata:
+      ocpVersion: {{ version }}
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6a.xlarge
+      masterNodesCount: 3
+      workerNodesType: m6a.xlarge
+      workerNodesCount: 6
+      benchmark.keyword: node-density
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      stream: okd
+
+    metrics:
+    - name:  podReadyLatency
+      metricName: podLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PerfScale]"
+      direction: 1
+      threshold: 10
+
+    - name:  cpu-kubelet
+      metricName.keyword: cpu-kubelet
+      metric_of_interest: value
+      labels:
+        - "[Jira: Node]"
+      agg:
+        value: cpu-kubelet
+        agg_type: avg
+      direction: 1
+      threshold: 10
+
+    - name:  max-memory-kubelet
+      metricName.keyword: max-memory-kubelet
+      metric_of_interest: value
+      labels:
+        - "[Jira: Node]"
+      agg:
+        value: max-memory-kubelet
+        agg_type: avg
+      direction: 1
+      threshold: 10
+
+    - name:  cpu-crio
+      metricName.keyword: cpu-crio
+      metric_of_interest: value
+      agg:
+        value: cpu-crio
+        agg_type: avg
+      direction: 1
+      threshold: 10
+
+    - name:  max-memory-crio
+      metricName.keyword: max-memory-crio
+      metric_of_interest: value
+      agg:
+        value: max-memory-crio
+        agg_type: avg
+      direction: 1
+      threshold: 10


### PR DESCRIPTION
```
$ VERSION=4.19 orion --config examples/okd-control-plane-node-density-cni.yaml --lookback 60d  --hunter-analyze --es-server=xx --metadata-index=xx --benchmark-index=xx
2025-09-14 10:12:46,836 - Orion      - INFO - file: main.py - line: 134 - 🏹 Starting Orion in command-line mode
2025-09-14 10:12:46,848 - Orion      - INFO - file: utils.py - line: 288 - The test okd-node-density-cni-6nodes has started
2025-09-14 10:12:46,849 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: perf_scale_ci-*
2025-09-14 10:12:48,084 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: perf_scale_ci-*
2025-09-14 10:12:49,341 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:50,704 - Orion      - INFO - file: utils.py - line: 70 - Collecting podReadyLatency
2025-09-14 10:12:50,704 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:50,972 - Orion      - INFO - file: utils.py - line: 70 - Collecting serviceReadyLatency
2025-09-14 10:12:50,973 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:51,086 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovsCPU
2025-09-14 10:12:51,087 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:51,263 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnkCPU-overall
2025-09-14 10:12:51,263 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:52,290 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnCPU-ovncontroller
2025-09-14 10:12:52,290 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:52,607 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnCPU-northd
2025-09-14 10:12:52,607 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:52,906 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnCPU-nbdb
2025-09-14 10:12:52,906 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:53,111 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnCPU-sbdb
2025-09-14 10:12:53,111 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:53,319 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnCPU-ovnk-controller
2025-09-14 10:12:53,320 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:53,509 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovsMemory
2025-09-14 10:12:53,510 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:53,702 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnkMem-overall
2025-09-14 10:12:53,703 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:54,393 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnMem-ovncontroller
2025-09-14 10:12:54,394 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:54,873 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnMem-northd
2025-09-14 10:12:54,873 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:55,239 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnMem-nbdb
2025-09-14 10:12:55,240 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:55,798 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnMem-sbdb
2025-09-14 10:12:55,798 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:56,216 - Orion      - INFO - file: utils.py - line: 70 - Collecting ovnMem-ovnk-controller
2025-09-14 10:12:56,216 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:56,406 - Orion      - INFO - file: utils.py - line: 70 - Collecting apiserverCPU
2025-09-14 10:12:56,406 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:56,655 - Orion      - INFO - file: utils.py - line: 70 - Collecting multusCPU
2025-09-14 10:12:56,655 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:56,997 - Orion      - INFO - file: utils.py - line: 70 - Collecting monitoringCPU
2025-09-14 10:12:56,997 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:57,747 - Orion      - INFO - file: utils.py - line: 70 - Collecting etcdCPU
2025-09-14 10:12:57,748 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:58,041 - Orion      - INFO - file: utils.py - line: 70 - Collecting kubelet
2025-09-14 10:12:58,041 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ripsaw-kube-burner-*
2025-09-14 10:12:58,413 - Orion      - INFO - file: run_test.py - line: 98 - Comparison algorithm: EDivisive
okd-node-density-cni-6nodes
===========================
time                       uuid                                  ocpVersion                           buildUrl                                                                                                                                                                  podReadyLatency_P99    serviceReadyLatency_P99    ovsCPU_avg    ovnkCPU-overall_avg    ovnCPU-ovncontroller_avg    ovnCPU-northd_avg    ovnCPU-nbdb_avg    ovnCPU-sbdb_avg    ovnCPU-ovnk-controller_avg    ovsMemory_avg    ovnkMem-overall_avg    ovnMem-ovncontroller_avg    ovnMem-northd_avg    ovnMem-nbdb_avg    ovnMem-sbdb_avg    ovnMem-ovnk-controller_avg    apiserverCPU_avg    multusCPU_avg    monitoringCPU_avg    etcdCPU_avg    kubelet_avg
-------------------------  ------------------------------------  -----------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------  ---------------------  -------------------------  ------------  ---------------------  --------------------------  -------------------  -----------------  -----------------  ----------------------------  ---------------  ---------------------  --------------------------  -------------------  -----------------  -----------------  ----------------------------  ------------------  ---------------  -------------------  -------------  -------------
2025-08-18 02:12:27 +0000  84b16bb3-4e2d-4ba6-9147-6909623bf374  4.19.0-0.okd-scos-2025-08-16-053317  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-okd-x86-control-plane-6nodes/1957231311269662720                   4000                        nan   9.57761e+07                4.41402                     3.54098              2.38102           0.802791           0.956287                       27.4635      1.02053e+08            5.57135e+07                 3.2101e+07           2.66602e+07        1.08326e+07        1.92243e+07                   3.25065e+08            10.0251           1.09712             0.932273        6.60211        20.1645
2025-08-25 02:08:30 +0000  2178377c-3e62-4ea9-84a7-0652baa1d9a1  4.19.0-0.okd-scos-2025-08-22-102022  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-okd-x86-control-plane-6nodes/1959768107463479296                   4000                        nan   7.92381e+07                4.94583                     3.53073              2.11344           0.781331           0.94337                        32.5588      9.60898e+07            5.62917e+07                 3.32541e+07          2.67667e+07        1.08728e+07        1.90186e+07                   3.28934e+08             9.47654          1.26106             0.960506        5.95364        21.5687
2025-09-01 02:13:32 +0000  81a87c9c-a5a5-4da6-b31f-001fafd6de50  4.19.0-0.okd-scos-2025-08-31-163045  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-okd-x86-control-plane-6nodes/1962304753136308224                   4000                        nan   9.60628e+07                4.9673                      3.70688              2.11555           0.759468           0.939155                       32.4993      9.93438e+07            5.56021e+07                 3.42479e+07          2.35264e+07        1.16303e+07        1.83802e+07                   3.24332e+08             8.57065          1.26491             1.11012         6.13997        21.4919
```