### PR TITLE
update acks

### DIFF
--- a/ack/4.19_udn-l3_ack.yaml
+++ b/ack/4.19_udn-l3_ack.yaml
@@ -52,6 +52,26 @@ ack:
     metric: ovnMem-sbdb_avg
     reason: kube-burner change on how we calculate metrics
   - uuid: e27c61f2-6cdb-490d-bb6a-59a34048cfc1
-    metric: ovnMem-ovnk-controller_av
+    metric: ovnMem-ovnk-controller_avg
     reason: kube-burner change on how we calculate metrics
-
+  - uuid: cb90d90d-a33b-4639-a640-ace2996a708b
+    metric: ovnkMem-overall_avg
+    reason: job was w/o pause
+  - uuid: 00f7a823-5c56-430b-8e73-d5812d8bfe9f
+    metric: ovsCPU_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 00f7a823-5c56-430b-8e73-d5812d8bfe9f
+    metric: ovsMemory_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 00f7a823-5c56-430b-8e73-d5812d8bfe9f
+    metric: ovnkMem-overall_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 00f7a823-5c56-430b-8e73-d5812d8bfe9f
+    metric: ovnMem-northd_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 00f7a823-5c56-430b-8e73-d5812d8bfe9f
+    metric: ovnMem-nbdb_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 15c236e7-abff-4595-8e72-06bfd6115e21
+    metric: ovnMem-nbdb_avg
+    reason: https://issues.redhat.com/browse/OCPBUGS-60650

--- a/ack/4.20_udn-l3_ack.yaml
+++ b/ack/4.20_udn-l3_ack.yaml
@@ -24,3 +24,30 @@ ack:
   - uuid: 7d80399d-f455-4134-b631-d1712c42413e
     metric: ovnMem-nbdb_avg
     reason: https://issues.redhat.com/browse/OCPBUGS-60650
+  - uuid: 5af8de0e-83ab-48d2-b930-1547e1eee6e3
+    metric: ovnCPU-nbdb_avg
+    reason: job was w/o pause
+  - uuid: 5af8de0e-83ab-48d2-b930-1547e1eee6e3
+    metric: ovnCPU-sbdb_avg
+    reason: job was w/o pause
+  - uuid: c3f2ff7e-3f26-4b56-a29d-189570d7c14c
+    metric: ovsCPU_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: c3f2ff7e-3f26-4b56-a29d-189570d7c14c
+    metric: ovsMemory_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: c3f2ff7e-3f26-4b56-a29d-189570d7c14c
+    metric: ovnkMem-overall_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: c3f2ff7e-3f26-4b56-a29d-189570d7c14c
+    metric: ovnMem-northd_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: c3f2ff7e-3f26-4b56-a29d-189570d7c14c
+    metric: ovnMem-nbdb_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: c3f2ff7e-3f26-4b56-a29d-189570d7c14c
+    metric: ovnMem-sbdb_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: c3f2ff7e-3f26-4b56-a29d-189570d7c14c
+    metric: ovnMem-ovncontroller_avg
+    reason: shift from w/o pause to with pause in config

--- a/ack/4.21_udn-l3_ack.yaml
+++ b/ack/4.21_udn-l3_ack.yaml
@@ -1,1 +1,35 @@
 ---
+ack:
+  - uuid: 80e3e90d-d974-49fa-8e39-3e44afcbb408
+    metric: ovsCPU_avg 
+    reason: same nightly
+  - uuid: 80e3e90d-d974-49fa-8e39-3e44afcbb408
+    metric: ovsMemory_avg
+    reason: same nightly
+  - uuid: 80e3e90d-d974-49fa-8e39-3e44afcbb408
+    metric: ovnMem-ovncontroller_avg
+    reason: same nightly
+  - uuid: 80e3e90d-d974-49fa-8e39-3e44afcbb408
+    metric: ovnMem-northd_avg
+    reason: same nightly
+  - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
+    metric: ovsCPU_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
+    metric: ovsMemory_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
+    metric: ovnMem-ovncontroller_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
+    metric: ovnMem-northd_avg 
+    reason: shift from w/o pause to with pause in config
+  - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
+    metric: ovnMem-nbdb_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
+    metric: ovnMem-sbdb_avg
+    reason: shift from w/o pause to with pause in config
+  - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
+    metric: ovnkMem-overall_avg
+    reason: shift from w/o pause to with pause in config


### PR DESCRIPTION
**4.21**
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.21-nightly-x86-udn-density-l3-24nodes/1968133044447481856/artifacts/udn-density-l3-24nodes/openshift-qe-orion-udn-l3/build-log.txt
80e3e90d-d974-49fa-8e39-3e44afcbb408
same nightly

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.21-nightly-x86-udn-density-l3-pause-120nodes/1967997076012797952/artifacts/udn-density-l3-pause-120nodes/openshift-qe-orion-udn-l3/build-log.txt
60d9fb49-648e-4e26-ab4d-e8704f749e80
shift from w/o pause to with pause

**4.20**
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.20-nightly-x86-udn-density-l3-pause-120nodes/1967997073479438336/artifacts/udn-density-l3-pause-120nodes/openshift-qe-orion-udn-l3/build-log.txt
c3f2ff7e-3f26-4b56-a29d-189570d7c14c
shift from w/o pause to with pause

**4.19** 
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-nightly-x86-udn-density-l3-24nodes/1968133034381152256/artifacts/udn-density-l3-24nodes/openshift-qe-orion-udn-l3/build-log.txt
15c236e7-abff-4595-8e72-06bfd6115e21
ovn mem nbdb bug

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-nightly-x86-udn-density-l3-pause-120nodes/1968223687593168896/artifacts/udn-density-l3-pause-120nodes/openshift-qe-orion-udn-l3/build-log.txt
00f7a823-5c56-430b-8e73-d5812d8bfe9f
shift from w/o pause to with pause