### PR TITLE
[PERFSCALE-4163] OKD data plane config files

### DIFF
--- a/examples/okd-data-plane-data-path.yaml
+++ b/examples/okd-data-plane-data-path.yaml
@@ -1,0 +1,352 @@
+tests :
+  - name : okd-datapath-12nodes
+    metadata:
+      ocpVersion: {{ version }}
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6a.xlarge
+      masterNodesCount: 3
+      workerNodesType: m5.2xlarge
+      workerNodesCount: 9
+      benchmark.keyword: k8s-netperf
+      networkType: OVNKubernetes
+      stream: okd
+
+    metrics:
+    - name:  n2n-tput-64-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 64
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  n2n-tput-64-2p
+      parallelism: 2
+      profile: TCP_STREAM
+      messageSize: 64
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  n2n-tput-1024-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  n2n-tput-1024-2p
+      parallelism: 2
+      profile: TCP_STREAM
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  n2n-tput-4096-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 4096
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  n2n-tput-4096-2p
+      parallelism: 2
+      profile: TCP_STREAM
+      messageSize: 4096
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  n2n-tput-8192-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 8192
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  n2n-tput-8192-2p
+      parallelism: 2
+      profile: TCP_STREAM
+      messageSize: 8192
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  n2n-ltcy-1024-1p
+      parallelism: 1
+      profile: TCP_RR
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: latency
+      agg:
+        value: latency
+        agg_type: avg
+      direction: 1
+      threshold: 10
+
+    - name:  n2n-ltcy-1024-2p
+      parallelism: 2
+      profile: TCP_RR
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: true
+      acrossAZ: false
+      metric_of_interest: latency
+      agg:
+        value: latency
+        agg_type: avg
+      direction: 1
+      threshold: 10
+
+
+# p2p
+    - name:  p2p-tput-64-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 64
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2p-tput-64-2p
+      parallelism: 2
+      profile: TCP_STREAM
+      messageSize: 64
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2p-tput-1024-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2p-tput-1024-2p
+      parallelism: 2
+      profile: TCP_STREAM
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2p-tput-4096-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 4096
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2p-tput-4096-2p
+      parallelism: 2
+      profile: TCP_STREAM
+      messageSize: 4096
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2p-tput-8192-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 8192
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2p-tput-8192-2p
+      parallelism: 2
+      profile: TCP_STREAM
+      messageSize: 8192
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2p-ltcy-1024-1p
+      parallelism: 1
+      profile: TCP_RR
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: latency
+      agg:
+        value: latency
+        agg_type: avg
+      direction: 1
+      threshold: 10
+
+    - name:  p2p-ltcy-1024-2p
+      parallelism: 2
+      profile: TCP_RR
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: latency
+      agg:
+        value: latency
+        agg_type: avg
+      direction: 1
+      threshold: 10
+
+#p2s
+    - name:  p2s-tput-64-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 64
+      driver.keyword: netperf
+      hostNetwork: false
+      service: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2s-tput-1024-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: false
+      service: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2s-tput-4096-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 4096
+      driver.keyword: netperf
+      hostNetwork: false
+      service: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2s-tput-8192-1p
+      parallelism: 1
+      profile: TCP_STREAM
+      messageSize: 8192
+      driver.keyword: netperf
+      hostNetwork: false
+      service: true
+      acrossAZ: false
+      metric_of_interest: throughput
+      agg:
+        value: throughput
+        agg_type: avg
+      threshold: 10
+
+    - name:  p2s-ltcy-1024-1p
+      parallelism: 1
+      profile: TCP_RR
+      messageSize: 1024
+      driver.keyword: netperf
+      hostNetwork: false
+      service: true
+      acrossAZ: false
+      metric_of_interest: latency
+      agg:
+        value: latency
+        agg_type: avg
+      direction: 1
+      threshold: 10


### PR DESCRIPTION
```
> VERSION=4.19 orion --config examples/okd-data-plane-data-path.yaml --lookback 60d  --hunter-analyze --es-server=xyz --metadata-index=ospst-perf-scale-ci-* --benchmark-index=ospst-k8s-netperf-*
2025-09-19 17:24:43,014 - Orion      - INFO - file: main.py - line: 134 - 🏹 Starting Orion in command-line mode
2025-09-19 17:24:43,029 - Orion      - INFO - file: utils.py - line: 288 - The test okd-datapath-12nodes has started
2025-09-19 17:24:43,029 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-perf-scale-ci-*
2025-09-19 17:24:43,718 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-perf-scale-ci-*
2025-09-19 17:24:45,220 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-tput-64-1p
2025-09-19 17:24:45,221 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:45,561 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-tput-64-2p
2025-09-19 17:24:45,561 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:45,745 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-tput-1024-1p
2025-09-19 17:24:45,746 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:45,928 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-tput-1024-2p
2025-09-19 17:24:45,929 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:46,112 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-tput-4096-1p
2025-09-19 17:24:46,112 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:46,296 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-tput-4096-2p
2025-09-19 17:24:46,296 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:46,476 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-tput-8192-1p
2025-09-19 17:24:46,476 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:46,659 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-tput-8192-2p
2025-09-19 17:24:46,660 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:46,845 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-ltcy-1024-1p
2025-09-19 17:24:46,846 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:47,030 - Orion      - INFO - file: utils.py - line: 70 - Collecting n2n-ltcy-1024-2p
2025-09-19 17:24:47,031 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:47,215 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-tput-64-1p
2025-09-19 17:24:47,216 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:47,568 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-tput-64-2p
2025-09-19 17:24:47,568 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:47,755 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-tput-1024-1p
2025-09-19 17:24:47,756 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:47,937 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-tput-1024-2p
2025-09-19 17:24:47,937 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:48,122 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-tput-4096-1p
2025-09-19 17:24:48,123 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:48,307 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-tput-4096-2p
2025-09-19 17:24:48,308 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:48,486 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-tput-8192-1p
2025-09-19 17:24:48,486 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:48,671 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-tput-8192-2p
2025-09-19 17:24:48,672 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:48,849 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-ltcy-1024-1p
2025-09-19 17:24:48,850 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:49,027 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2p-ltcy-1024-2p
2025-09-19 17:24:49,027 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:49,209 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2s-tput-64-1p
2025-09-19 17:24:49,209 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:49,383 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2s-tput-1024-1p
2025-09-19 17:24:49,384 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:49,559 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2s-tput-4096-1p
2025-09-19 17:24:49,559 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:49,734 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2s-tput-8192-1p
2025-09-19 17:24:49,734 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:49,914 - Orion      - INFO - file: utils.py - line: 70 - Collecting p2s-ltcy-1024-1p
2025-09-19 17:24:49,914 - Orion      - INFO - file: matcher.py - line: 73 - Executing query against index: ospst-k8s-netperf-*
2025-09-19 17:24:50,152 - Orion      - INFO - file: run_test.py - line: 98 - Comparison algorithm: EDivisive
okd-datapath-12nodes
====================
time                       uuid                                  ocpVersion                           buildUrl                                                                                                                                                              n2n-tput-64-1p_avg    n2n-tput-64-2p_avg    n2n-tput-1024-1p_avg    n2n-tput-1024-2p_avg    n2n-tput-4096-1p_avg    n2n-tput-4096-2p_avg    n2n-tput-8192-1p_avg    n2n-tput-8192-2p_avg    n2n-ltcy-1024-1p_avg    n2n-ltcy-1024-2p_avg    p2p-tput-64-1p_avg    p2p-tput-64-2p_avg    p2p-tput-1024-1p_avg    p2p-tput-1024-2p_avg    p2p-tput-4096-1p_avg    p2p-tput-4096-2p_avg    p2p-tput-8192-1p_avg    p2p-tput-8192-2p_avg    p2p-ltcy-1024-1p_avg    p2p-ltcy-1024-2p_avg    p2s-tput-64-1p_avg    p2s-tput-1024-1p_avg    p2s-tput-4096-1p_avg    p2s-tput-8192-1p_avg    p2s-ltcy-1024-1p_avg
-------------------------  ------------------------------------  -----------------------------------  ------------------------------------------------------------------------------------------------------------------------------------------------------------------  --------------------  --------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  --------------------  --------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  --------------------  ----------------------  ----------------------  ----------------------  ----------------------
2025-07-27 03:28:06 +0000  a9d3fbc4-ee36-49eb-83c6-e02ad3155c4b  4.19.0-0.okd-scos-2025-07-25-180307  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-okd-x86-data-path-9nodes/1949259273854783488               523.216               1022.36                 4967.25                 9865.22                 4966.46                 9834.41                 4967.62                 9933.6                    381.8                   386.2               521.518              1023.8                   4932.26                 9856.91                 4933.38                 9514.42                 4933.28                 9758.47                   756.7                   745.8               518.116                 4933.08                 4933.24                 4933.21                   778
2025-08-03 03:24:59 +0000  b314186b-5d57-40f2-9571-2961e205d82f  4.19.0-0.okd-scos-2025-08-02-020354  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-okd-x86-data-path-9nodes/1951795757149327360               562.71                1066.66                 4966.65                 9829.44                 4967.24                 9716.44                 4967.34                 9933.98                   534.2                   560.6               519.245              1016.93                  4933.56                 9858.76                 4933.27                 9722.44                 4933.9                  9866.75                   709.7                   710                 523.626                 4934.2                  4933.34                 4934.37                   714
2025-09-07 03:25:17 +0000  09df368b-f0bf-4bf9-998b-b7e6721aef70  4.19.0-0.okd-scos-2025-09-05-050428  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-okd-x86-data-path-9nodes/1964479202489012224               522.582               1030.14                 4965.01                 9929.16                 4965.78                 9931.98                 4966.45                 9860.61                   805.2                   804                 507.193              1006.06                  4933.89                 9732.22                 4934.75                 9583.47                 4934.71                 8809.76                   402.9                   400.2               508.282                 4933.57                 4934.94                 4934.83                   413.2
2025-09-14 03:26:21 +0000  c96b1776-b5e4-4ddf-9d97-9c034504c9f8  4.19.0-0.okd-scos-2025-09-12-195655  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-okd-x86-data-path-9nodes/1967015969729548288               531.612               1051.48                 4967.48                 9933.84                 4967.23                 9741.63                 4967.56                 9650.64                   439.6                   436                 507.364               991.858                 4930.8                  8877.06                 4933.47                 8881.91                 4934.51                 9633.44                   362                     363.8               506.772                 4927.88                 4933.69                 4934.12                   376.6
```