### PR TITLE
Adding build url with underscore

### DIFF
--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -160,22 +160,18 @@ class Matcher:
         all_hits = self.query_index(s,return_all=True)
         uuids_docs = []
         for hit in all_hits:
+            uuid_doc = {
+                        self.uuid_field: hit.to_dict()["_source"][self.uuid_field],
+                        self.version_field: hit.to_dict()["_source"][self.version_field]
+                    }
             if "buildUrl" in hit["_source"]:
-                uuids_docs.append(
-                    {
-                        self.uuid_field: hit.to_dict()["_source"][self.uuid_field],
-                        "buildUrl": hit.to_dict()["_source"]["buildUrl"],
-                        self.version_field: hit.to_dict()["_source"][self.version_field],
-                    }
-                )
+                uuid_doc["buildUrl"] = hit.to_dict()["_source"]["buildUrl"]
+            elif "build_url" in hit["_source"]:
+                uuid_doc["buildUrl"] = hit.to_dict()["_source"]["build_url"]
             else:
-                uuids_docs.append(
-                    {
-                        self.uuid_field: hit.to_dict()["_source"][self.uuid_field],
-                        "buildUrl": "http://bogus-url",
-                        self.version_field: hit.to_dict()["_source"][self.version_field],
-                    }
-                )
+                uuid_doc["buildUrl"] = "http://bogus-url"
+
+            uuids_docs.append(uuid_doc)
         return uuids_docs
 
     def match_kube_burner(self, uuids: List[str],


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Our telemetry data was using underscores instead of camel case so to keep with the same keys I added build_url to our data. Want orion to still be able to give the build url using a slightly different key. 

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Properly prints build urls
```
time                       uuid                                  ocpVersion    buildUrl                                                                                                                                                                                                                                                                      podReadyLatency_P99    apiserverCPU_avg    ovnCPU_avg    etcdCPU_avg    etcdDisk_avg
-------------------------  ------------------------------------  ------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ---------------------  ------------------  ------------  -------------  --------------
2025-08-29 18:47:07 +0000  79604845-a11d-48de-8978-8806e1d5cc82  4.19.9        https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68575/rehearse-68575-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-azure-4.20-nightly-multi-loaded-upgrade-from-4.19-multi-loaded-upgrade-417to418-24nodes/1961464337784639488                  14000             9.31491       2.5317         4.95794       0.0234448
2025-09-08 00:09:26 +0000  36b1eeff-c538-403e-8072-e00d21e6f8df  4.19.10       https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68575/rehearse-68575-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-azure-4.20-nightly-multi-loaded-upgrade-from-4.19-multi-loaded-upgrade-419to420-24nodes/1964803184392146944                  14000             8.87065       2.44553        4.9134        0.0248908
2025-09-11 18:06:48 +0000  6f40c621-6df3-4d81-9a2c-dd37a39b6994  4.19.11       https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68575/rehearse-68575-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-azure-4.20-nightly-multi-loaded-upgrade-from-4.19-multi-loaded-upgrade-419to420-24nodes/1966165501918842880                  14000             8.81901       2.31665        4.73926       0.058083
2025-09-12 23:40:09 +0000  6b3bd98d-a3d7-4d3c-ab54-22e44781958f  4.19.11       https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68575/rehearse-68575-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-azure-4.20-nightly-multi-loaded-upgrade-from-4.19-multi-loaded-upgrade-419to420-24nodes/1966609267964252160                  14000             9.07292       2.30767        4.87926       0.0264555
2025-09-16 00:04:22 +0000  869eeddc-c5fb-4bc2-b4f9-ed4ac72937a8  4.19.11       https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68575/rehearse-68575-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-azure-4.20-nightly-multi-loaded-upgrade-from-4.19-multi-loaded-upgrade-419to420-24nodes/1967703252149473280                  14000             8.98539       2.30139        5.02837       0.0383901
2025-09-17 06:36:51 +0000  2e1fd09b-cc67-49c2-a948-943baa622db8  4.19.12       https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68575/rehearse-68575-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-azure-4.20-nightly-multi-loaded-upgrade-from-4.19-multi-loaded-upgrade-419to420-24nodes/1968161651702108160                  14000             8.9235        2.25812        5.1489        0.0235673
2025-09-18 19:13:45 +0000  be99ae47-04de-4980-8fa3-5ed393d6efdd  4.19.12       https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68575/rehearse-68575-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-azure-4.20-nightly-multi-loaded-upgrade-from-4.19-multi-loaded-upgrade-419to420-24nodes/1968717147827867648                  14000             9.46167       2.4034         4.6269        0.0272874
```