### PR TITLE
Fix TypeError when comparing UUIDs with CMR algorithm

### DIFF
--- a/orion/algorithms/cmr/cmr.py
+++ b/orion/algorithms/cmr/cmr.py
@@ -100,7 +100,8 @@ class CMR(Algorithm):
                 data2[column] = [mean]
             else:
                 column_list = dF[column].tolist()
-                non_numeric_joined_list = ','.join(column_list)
+                # Convert each item to string to handle lists, UUIDs, and other non-string types
+                non_numeric_joined_list = ','.join(str(item) for item in column_list)
                 data2[column] = [non_numeric_joined_list]
             i += 1
         df2 = pd.DataFrame(data2)


### PR DESCRIPTION
## Summary
Fixes #217

When comparing two UUIDs (or other non-string data) with the CMR algorithm, the `combine_and_average_runs` method was failing with:
```
TypeError: sequence item 0: expected str instance, list found
```

## Changes
- Modified `orion/algorithms/cmr/cmr.py` to convert each item to string before joining in the `combine_and_average_runs` method
- This allows the CMR algorithm to properly handle UUIDs, lists, and other non-string data types in non-numeric columns

## Test plan
- Tested with comparing two UUIDs using CMR algorithm
- Verified the error no longer occurs and output is generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)