### PR TITLE
Add exists clause for specific fields queries

### DIFF
--- a/orion/utils.py
+++ b/orion/utils.py
@@ -253,7 +253,7 @@ class Utils:
             match (Matcher): the fmatch instance
             timestamp_field (str): timestamp field in data
         """
-        test = match.get_results("", uuids, {}, timestamp_field=timestamp_field)
+        test = match.get_results("", uuids, {}, [self.version_field], timestamp_field=timestamp_field)
         if "." in self.version_field:
             return {
                 run[self.uuid_field]: match.dotDictFind(run, self.version_field)
@@ -274,7 +274,7 @@ class Utils:
             dict: dictionary of the metadata
         """
 
-        test = match.get_results("", uuids, {}, timestamp_field=timestamp_field)
+        test = match.get_results("", uuids, {}, ["buildUrl"], timestamp_field=timestamp_field)
         buildUrls = {run[self.uuid_field]: run["buildUrl"] for run in test}
         return buildUrls
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add exists clause for specific fields queries.
There are some methods that are querying ES for results and they expect in those results a specific field to be there, and if it is not there that method fails.

## Related Tickets & Documents

- Related Issue #228 
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
