### PR TITLE
metal-data-path | only raise alert for decrease in performance in tput

### DIFF
--- a/examples/metal-perfscale-cpt-data-path.yaml
+++ b/examples/metal-perfscale-cpt-data-path.yaml
@@ -26,6 +26,7 @@ tests:
       hostNetwork: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -39,6 +40,7 @@ tests:
       hostNetwork: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -52,6 +54,7 @@ tests:
       hostNetwork: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -65,6 +68,7 @@ tests:
       hostNetwork: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -78,6 +82,7 @@ tests:
       hostNetwork: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -91,6 +96,7 @@ tests:
       hostNetwork: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -104,6 +110,7 @@ tests:
       hostNetwork: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -117,6 +124,7 @@ tests:
       hostNetwork: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -160,6 +168,7 @@ tests:
       hostNetwork: false
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -173,6 +182,7 @@ tests:
       hostNetwork: false
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -186,6 +196,7 @@ tests:
       hostNetwork: false
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -199,6 +210,7 @@ tests:
       hostNetwork: false
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -212,6 +224,7 @@ tests:
       hostNetwork: false
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -225,6 +238,7 @@ tests:
       hostNetwork: false
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -238,6 +252,7 @@ tests:
       hostNetwork: false
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -251,6 +266,7 @@ tests:
       hostNetwork: false
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -294,6 +310,7 @@ tests:
       service: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -308,6 +325,7 @@ tests:
       service: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -322,6 +340,7 @@ tests:
       service: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg
@@ -336,6 +355,7 @@ tests:
       service: true
       acrossAZ: true
       metric_of_interest: throughput
+      direction: -1
       agg:
         value: throughput
         agg_type: avg


### PR DESCRIPTION
Removes the alert after the enabling of LACP
