### PR TITLE
ack cpu bump for node density

### DIFF
--- a/ack/4.19_node-density_ack.yaml
+++ b/ack/4.19_node-density_ack.yaml
@@ -12,3 +12,12 @@ ack:
   - uuid: 6da3af3c-fe09-405f-9721-82ffcc03dec1 
     metric: ovnMem-ovncontroller_avg
     reason: ""
+  - uuid: bca2670e-588f-4e69-b9b0-1c3df1a8de2f
+    metric: apiserverCPU_avg
+    reason: "CPU bumps due to unintentional change in deletion strategy"
+  - uuid: bca2670e-588f-4e69-b9b0-1c3df1a8de2f
+    metric: ovnCPU_avg
+    reason: "CPU bumps due to unintentional change in deletion strategy"
+  - uuid: bca2670e-588f-4e69-b9b0-1c3df1a8de2f
+    metric: kubelet_avg
+    reason: "CPU bumps due to unintentional change in deletion strategy"

--- a/ack/4.20_node-density_ack.yaml
+++ b/ack/4.20_node-density_ack.yaml
@@ -6,4 +6,6 @@ ack:
   - uuid: 35dbe753-c8c6-4ecf-9070-83e45fede818
     metric: podReadyLatency_P99
     reason: "OCPBUG is opened https://issues.redhat.com/browse/OCPBUGS-59641"
-
+  - uuid: ffb0ec28-7d57-4ec3-8359-48b5bd65b502
+    metric: kubelet_avg
+    reason: "CPU bumps due to unintentional change in deletion strategy"

--- a/ack/4.21_node-density_ack.yaml
+++ b/ack/4.21_node-density_ack.yaml
@@ -6,3 +6,12 @@ ack:
   - uuid: ad775826-d6bf-4017-8efe-3350602868c5
     metric: podReadyLatency_P99
     reason: "podReadyLatency_P99 fluctuates between 2s and 3s, no obvious reason"
+  - uuid: ad49121c-0151-4479-9f30-7809473fe9e9
+    metric: apiserverCPU_avg
+    reason: "CPU bumps due to unintentional change in deletion strategy"
+  - uuid: ca5bf944-1229-4b12-8296-c975be0f0fb4
+    metric: ovnCPU_avg
+    reason: "CPU bumps due to unintentional change in deletion strategy"
+  - uuid: ca5bf944-1229-4b12-8296-c975be0f0fb4
+    metric: kubelet_avg
+    reason: "CPU bumps due to unintentional change in deletion strategy"

--- a/ack/4.22_node-density_ack.yaml
+++ b/ack/4.22_node-density_ack.yaml
@@ -1,1 +1,8 @@
 ---
+ack:
+  - uuid: 679b905a-318c-4b8c-a630-4b2dcc394d25
+    metric: ovnCPU_avg
+    reason: "CPU bumps due to unintentional change in deletion strategy"
+  - uuid: 679b905a-318c-4b8c-a630-4b2dcc394d25
+    metric: kubelet_avg
+    reason: "CPU bumps due to unintentional change in deletion strategy"


### PR DESCRIPTION
Based on the investigation, CPU bumps was due to an unintentional change in the deletion strategy

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

