### PR TITLE
Adding k8s-netperf config

### DIFF
--- a/examples/k8s-netperf-p2p.yml
+++ b/examples/k8s-netperf-p2p.yml
@@ -1,0 +1,237 @@
+tests :
+  - name : k8s-netperf
+    metadata:
+      upstreamJob.keyword: {{ upstreamJob }}
+      ocpVersion: "{{ version }}"
+    metrics : 
+    # Pod-2-pod TCP Stream Tests
+    - name: p2p-tcp-stream-64-1p
+      profile: TCP_STREAM
+      messageSize: 64
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-tcp-stream-64-2p
+      profile: TCP_STREAM
+      messageSize: 64
+      parallelism: 2
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-tcp-stream-1024-1p
+      profile: TCP_STREAM
+      messageSize: 1024
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-tcp-stream-1024-2p
+      profile: TCP_STREAM
+      messageSize: 1024
+      parallelism: 2
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-tcp-stream-4096-1p
+      profile: TCP_STREAM
+      messageSize: 4096
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-tcp-stream-4096-2p
+      profile: TCP_STREAM
+      messageSize: 4096
+      parallelism: 2
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-tcp-stream-8192-1p
+      profile: TCP_STREAM
+      messageSize: 8192
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-tcp-stream-8192-2p
+      profile: TCP_STREAM
+      messageSize: 8192
+      parallelism: 2
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    # Pod-2-pod UDP Stream Tests
+    - name: p2p-udp-stream-64-1p
+      profile: UDP_STREAM
+      messageSize: 64
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-udp-stream-64-2p
+      profile: UDP_STREAM
+      messageSize: 64
+      parallelism: 2
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-udp-stream-1024-1p
+      profile: UDP_STREAM
+      messageSize: 1024
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-udp-stream-1024-2p
+      profile: UDP_STREAM
+      messageSize: 1024
+      parallelism: 2
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-udp-stream-4096-1p
+      profile: UDP_STREAM
+      messageSize: 4096
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-udp-stream-4096-2p
+      profile: UDP_STREAM
+      messageSize: 4096
+      parallelism: 2
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-udp-stream-8192-1p
+      profile: UDP_STREAM
+      messageSize: 8192
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2p-udp-stream-8192-2p
+      profile: UDP_STREAM
+      messageSize: 8192
+      parallelism: 2
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    # Pod-2-pod TCP Request/Response Tests
+    - name: p2p-tcp-rr-64-1p
+      profile: TCP_RR
+      messageSize: 1024
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: latency
+      direction: 1
+      threshold: 20
+
+    - name: p2p-tcp-rr-1024-2p
+      profile: TCP_RR
+      messageSize: 1024
+      parallelism: 2
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: latency
+      direction: 1
+      threshold: 20
+
+    # Pod-2-pod TCP Connection Request/Response Tests
+    - name: p2p-tcp-crr-1024-1p
+      profile: TCP_CRR
+      messageSize: 1024
+      parallelism: 1
+      driver.keyword: netperf
+      service: false
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: latency
+      direction: 1
+      threshold: 20

--- a/examples/k8s-netperf-p2s.yml
+++ b/examples/k8s-netperf-p2s.yml
@@ -1,0 +1,129 @@
+tests :
+  - name : k8s-netperf
+    metadata:
+      upstreamJob.keyword: {{ upstreamJob }}
+      ocpVersion: "{{ version }}"
+    metrics : 
+     # Pod-2-service TCP Stream Tests
+    - name: p2s-tcp-stream-64-1p
+      profile: TCP_STREAM
+      messageSize: 64
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2s-tcp-stream-1024-1p
+      profile: TCP_STREAM
+      messageSize: 1024
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2s-tcp-stream-4096-1p
+      profile: TCP_STREAM
+      messageSize: 4096
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2s-tcp-stream-8192-1p
+      profile: TCP_STREAM
+      messageSize: 8192
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    # Pod-2-service UDP Stream Tests
+    - name: p2s-udp-stream-64-1p
+      profile: UDP_STREAM
+      messageSize: 64
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2s-udp-stream-1024-1p
+      profile: UDP_STREAM
+      messageSize: 1024
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2s-udp-stream-4096-1p
+      profile: UDP_STREAM
+      messageSize: 4096
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    - name: p2s-udp-stream-8192-1p
+      profile: UDP_STREAM
+      messageSize: 8192
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: throughput
+      direction: -1
+      threshold: 20
+
+    # Pod-2-service TCP Request/Response Tests
+    - name: p2s-tcp-rr-1024-1p
+      profile: TCP_RR
+      messageSize: 1024
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: latency
+      direction: 1
+      threshold: 20
+
+    # Pod-2-service TCP Connection Request/Response Tests
+    - name: p2s-tcp-crr-1024-1p
+      profile: TCP_CRR
+      messageSize: 1024
+      parallelism: 1
+      driver.keyword: netperf
+      service: true
+      hostNetwork: false
+      acrossAZ: false
+      metric_of_interest: latency
+      direction: 1
+      threshold: 20

--- a/examples/trt-external-payload-node-density.yaml
+++ b/examples/trt-external-payload-node-density.yaml
@@ -29,6 +29,16 @@ tests :
       direction: 1
       threshold: 10
 
+    - name: elapsedTime
+      metricName: jobSummary
+      metric_of_interest: elapsedTime
+      not:
+        jobConfig.name: garbage-collection
+      labels:
+        - "[Jira: PerfScale]"
+      direction: 1
+      threshold: 10
+
     - name: containersStartedLatency
       metricName: podLatencyQuantilesMeasurement
       quantileName: ContainersStarted


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Example configuration for k8s-netperf workloads, including RR and CRR profiles, which are not very stable

## Examples

###  pod 2 pod

Pod 2 pod TCP_STREAM
```shell
$ orion --config examples/k8s-netperf-p2p.yml --lookback 90d --hunter-analyze  --input-vars='{"version": "4.20*","upstreamJob": "periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.20-nightly-x86-data-path-9nodes"}'  --metadata-index ospst-perf-scale-ci* --es-server=$ES_SERVER    --benchmark-index ospst-k8s-netperf-* --display ""
2026-01-20 12:36:11,135 - Orion      - INFO - file: main.py - line: 159 - 🏹 Starting Orion in command-line mode
2026-01-20 12:36:11,145 - Orion      - INFO - file: utils.py - line: 659 - Duration to subtract: 90 days, 0:00:00
2026-01-20 12:36:11,145 - Orion      - INFO - file: utils.py - line: 662 - Start timestamp: 2026-01-20 11:36:10.974792+00:00
2026-01-20 12:36:11,145 - Orion      - INFO - file: utils.py - line: 301 - The test k8s-netperf has started
2026-01-20 12:36:11,145 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-perf-scale-ci*
2026-01-20 12:36:12,228 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-perf-scale-ci*
2026-01-20 12:36:24,855 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-stream-64-1p
2026-01-20 12:36:24,856 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:25,553 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-stream-64-2p
2026-01-20 12:36:25,553 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:25,919 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-stream-1024-1p
2026-01-20 12:36:25,919 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:26,805 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-stream-1024-2p
2026-01-20 12:36:26,805 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:27,712 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-stream-4096-1p
2026-01-20 12:36:27,713 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:28,055 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-stream-4096-2p
2026-01-20 12:36:28,055 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:29,149 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-stream-8192-1p
2026-01-20 12:36:29,150 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:29,720 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-stream-8192-2p
2026-01-20 12:36:29,721 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:30,222 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-udp-stream-64-1p
2026-01-20 12:36:30,223 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:30,850 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-udp-stream-64-2p
2026-01-20 12:36:30,850 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:31,464 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-udp-stream-1024-1p
2026-01-20 12:36:31,464 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:32,012 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-udp-stream-1024-2p
2026-01-20 12:36:32,013 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:32,523 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-udp-stream-4096-1p
2026-01-20 12:36:32,524 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:33,036 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-udp-stream-4096-2p
2026-01-20 12:36:33,037 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:33,571 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-udp-stream-8192-1p
2026-01-20 12:36:33,571 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:34,085 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-udp-stream-8192-2p
2026-01-20 12:36:34,085 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:34,597 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-rr-64-1p
2026-01-20 12:36:34,597 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:35,107 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-rr-1024-2p
2026-01-20 12:36:35,107 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:35,765 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2p-tcp-crr-1024-1p
2026-01-20 12:36:35,765 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:36:36,341 - Orion      - INFO - file: run_test.py - line: 176 - Comparison algorithm: EDivisive
k8s-netperf
===========
time                       uuid                                  ocpVersion                            p2p-tcp-stream-64-1p_throughput    p2p-tcp-stream-64-2p_throughput    p2p-tcp-stream-1024-1p_throughput    p2p-tcp-stream-1024-2p_throughput    p2p-tcp-stream-4096-1p_throughput    p2p-tcp-stream-4096-2p_throughput    p2p-tcp-stream-8192-1p_throughput    p2p-tcp-stream-8192-2p_throughput    p2p-udp-stream-64-1p_throughput    p2p-udp-stream-64-2p_throughput    p2p-udp-stream-1024-1p_throughput    p2p-udp-stream-1024-2p_throughput    p2p-udp-stream-4096-1p_throughput    p2p-udp-stream-4096-2p_throughput    p2p-udp-stream-8192-1p_throughput    p2p-udp-stream-8192-2p_throughput    p2p-tcp-rr-64-1p_latency    p2p-tcp-rr-1024-2p_latency    p2p-tcp-crr-1024-1p_latency
-------------------------  ------------------------------------  ----------------------------------  ---------------------------------  ---------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  ---------------------------------  ---------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  --------------------------  ----------------------------  -----------------------------
2025-11-01 06:24:16 +0000  99db027d-1d73-416b-9459-c0a5092e9886  4.20.0-0.nightly-2025-10-30-114955                            531.334                            1035.32                              4932.18                              8748.32                              4933.59                              9757.98                              4934.54                              9602.86                            106.64                             199.178                             1645.45                               3046.64                              4310.5                               8145.07                              4937.24                              9864.7                        653.8                         658                           1761.2
2025-11-08 06:20:17 +0000  fe2b96dc-d07f-4568-9c35-096bef87d182  4.20.0-0.nightly-2025-11-06-175730                            512.55                             1008.22                              4932.73                              9563.56                              4934.26                              9732.97                              4933.81                              9588.38                            102.666                            193.626                             1568.63                               2954.05                              4346.8                               8196.6                               4931.52                              9839.81                       591                           591                           1586.4
2025-11-15 06:22:22 +0000  75714be0-efae-423b-a916-4c79d866c81b  4.20.0-0.nightly-2025-11-14-130157                            514.83                             1014.89                              4933.66                              9863.6                               4934.09                              9630.26                              4934.28                              9866.46                             98.574                            186.018                             1538.72                               2891.65                              4402.46                              8181.69                              4925.9                               9831.27                       602.2                         626.6                         1693.2
2025-11-22 06:23:36 +0000  6248a4cd-884b-4dd0-8cd3-2b268269e702  4.20.0-0.nightly-2025-11-21-171914                            514.864                            1008.01                              4933.45                              9863.26                              4933.71                              9776.6                               4934.29                              9867.51                             96.002                            181.926                             1485.12                               2809.28                              4104.27                              7835.39                              4932.25                              9829.97                       606.6                         618.4                         1671.2
2025-12-01 06:26:06 +0000  0246f309-f8a5-47e1-a1db-58079a20ac2d  4.20.0-0.nightly-2025-11-30-073929                            508.088                            1009.04                              4933.21                              9503.6                               4934.67                              9492.02                              4934.71                              9868.32                            100.408                            190.152                             1547.01                               2945.05                              4221.02                              8084.25                              4933.87                              2667.98                       292.8                         313.8                         1037.6
2025-12-08 06:23:38 +0000  ed48e88a-babd-441e-92de-c06a8c7d9ac5  4.20.0-0.nightly-2025-12-04-021057                            518.074                            1014.7                               4934.61                              9834.29                              4934.51                              9610.34                              4935.09                              9755.38                             64.308                            123.592                              999.972                              1917.75                              3550.48                              6660.7                               4919.31                              9516.56                       248.2                         252                            760.4
2025-12-15 06:23:58 +0000  4c497709-e972-4192-8261-e28d4ecbb72f  4.20.0-0.nightly-2025-12-11-233406                            517.96                             1003.79                              4932.55                              9597.51                              4933.84                              9478.13                              4933.9                               9764.08                             99.542                            189.812                             1545.49                               2955.09                              4229.78                              8191.58                              4593.5                               2668.14                       913                           843.8                         2218.8
2025-12-22 06:24:24 +0000  8218c8b1-a0c0-478e-af04-9a77ed98193f  4.20.0-0.nightly-2025-12-21-182710                            511.994                            1009.54                              4934.02                              9739.47                              4934.43                              9771.81                              4933.63                              9867.62                             99.28                             188.508                             1554.49                               2930.87                              4006.51                              7773.43                              4930.58                              9834.28                       612.6                         615.6                         1661.6
2026-01-08 06:34:47 +0000  40c354f0-b10b-4390-9ce6-e129ed707fe2  4.20.0-0.nightly-2026-01-05-230502                            518.32                             1022.58                              4932.63                              9859.92                              4933.75                              8723.33                              4933.34                              9751.9                             100.164                            188.208                             1550.81                               2908.19                              4096.2                               7830.33                              4927.18                              9830.32                       920.6                         895.6                         2252.8

```

###  pod 2 service

```
$ orion --config examples/k8s-netperf-p2s.yml --lookback 90d --hunter-analyze  --input-vars='{"version": "4.20*","upstreamJob": "periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.20-nightly-x86-data-path-9nodes"}'  --metadata-index ospst-perf-scale-ci* --es-server=$ES_SERVER    --benchmark-index ospst-k8s-netperf-* --display ""
2026-01-20 12:34:59,847 - Orion      - INFO - file: main.py - line: 159 - 🏹 Starting Orion in command-line mode
2026-01-20 12:34:59,853 - Orion      - INFO - file: utils.py - line: 659 - Duration to subtract: 90 days, 0:00:00
2026-01-20 12:34:59,853 - Orion      - INFO - file: utils.py - line: 662 - Start timestamp: 2026-01-20 11:34:59.680486+00:00
2026-01-20 12:34:59,853 - Orion      - INFO - file: utils.py - line: 301 - The test k8s-netperf has started
2026-01-20 12:34:59,853 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-perf-scale-ci*
2026-01-20 12:35:00,983 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-perf-scale-ci*
2026-01-20 12:35:13,436 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-tcp-stream-64-1p
2026-01-20 12:35:13,437 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:14,191 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-tcp-stream-1024-1p
2026-01-20 12:35:14,191 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:14,544 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-tcp-stream-4096-1p
2026-01-20 12:35:14,544 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:14,897 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-tcp-stream-8192-1p
2026-01-20 12:35:14,897 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:15,315 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-udp-stream-64-1p
2026-01-20 12:35:15,316 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:16,340 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-udp-stream-1024-1p
2026-01-20 12:35:16,340 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:16,697 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-udp-stream-4096-1p
2026-01-20 12:35:16,697 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:17,054 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-udp-stream-8192-1p
2026-01-20 12:35:17,054 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:17,410 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-tcp-rr-1024-1p
2026-01-20 12:35:17,410 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:17,837 - Orion      - INFO - file: utils.py - line: 69 - Collecting p2s-tcp-crr-1024-1p
2026-01-20 12:35:17,837 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-k8s-netperf-*
2026-01-20 12:35:18,206 - Orion      - INFO - file: run_test.py - line: 176 - Comparison algorithm: EDivisive
k8s-netperf
===========
time                       uuid                                  ocpVersion                            p2s-tcp-stream-64-1p_throughput    p2s-tcp-stream-1024-1p_throughput    p2s-tcp-stream-4096-1p_throughput    p2s-tcp-stream-8192-1p_throughput    p2s-udp-stream-64-1p_throughput    p2s-udp-stream-1024-1p_throughput    p2s-udp-stream-4096-1p_throughput    p2s-udp-stream-8192-1p_throughput    p2s-tcp-rr-1024-1p_latency    p2s-tcp-crr-1024-1p_latency
-------------------------  ------------------------------------  ----------------------------------  ---------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  ---------------------------------  -----------------------------------  -----------------------------------  -----------------------------------  ----------------------------  -----------------------------
2025-11-01 06:24:16 +0000  99db027d-1d73-416b-9459-c0a5092e9886  4.20.0-0.nightly-2025-10-30-114955                            524.762                              4933.1                               4933.82                              4933.91                            106.728                              1642.86                              4337.07                              4936.58                         656.2                         1767.8
2025-11-08 06:20:17 +0000  fe2b96dc-d07f-4568-9c35-096bef87d182  4.20.0-0.nightly-2025-11-06-175730                            501.998                              4933.18                              4933.97                              4933.84                            102.906                              1565.33                              4380.32                              4928.15                         614.8                         1621.6
2025-11-15 06:22:22 +0000  75714be0-efae-423b-a916-4c79d866c81b  4.20.0-0.nightly-2025-11-14-130157                            505.918                              4934.06                              4933.93                              4933.35                             98.366                              1539.07                              4268.73                              4929.88                         595.2                         1701
2025-11-22 06:23:36 +0000  6248a4cd-884b-4dd0-8cd3-2b268269e702  4.20.0-0.nightly-2025-11-21-171914                            516.796                              4933.37                              4934.18                              4934.21                             95.638                              1486.13                              4072.55                              4934.69                         599.4                         1675.8
2025-12-01 06:26:06 +0000  0246f309-f8a5-47e1-a1db-58079a20ac2d  4.20.0-0.nightly-2025-11-30-073929                            511.37                               4933.81                              4934.38                              4935                                99.968                              1546.81                              4276.03                              4934.36                         288.6                         1067.6
2025-12-08 06:23:38 +0000  ed48e88a-babd-441e-92de-c06a8c7d9ac5  4.20.0-0.nightly-2025-12-04-021057                            511.698                              4933.94                              4935.1                               4934.3                              64.324                              1001.78                              3517.5                               4910.59                         251.8                          773.4
2025-12-15 06:23:58 +0000  4c497709-e972-4192-8261-e28d4ecbb72f  4.20.0-0.nightly-2025-12-11-233406                            514.916                              4930.85                              4933.56                              4934.33                             99.082                              1540.31                              4264.09                              4933.62                         885.2                         2247
2025-12-22 06:24:24 +0000  8218c8b1-a0c0-478e-af04-9a77ed98193f  4.20.0-0.nightly-2025-12-21-182710                            515.166                              4932.74                              4933.51                              4931.95                             99.92                               1547.49                              3939.73                              4929.81                         617.8                         1667
2026-01-08 06:34:47 +0000  40c354f0-b10b-4390-9ce6-e129ed707fe2  4.20.0-0.nightly-2026-01-05-230502                            522.21                               4927.18                              4932.68                              4933.82                            100.398                              1550.01                              4110.16                              4937.15                         923.2                         2239.8
```