### PR TITLE
ack recent ovn regression in 4.20, 4.21 and 4.22

### DIFF
--- a/ack/4.20_node-density-cni_ack.yaml
+++ b/ack/4.20_node-density-cni_ack.yaml
@@ -15,7 +15,13 @@ ack:
   - uuid: 6ce3a213-8481-4282-84ce-af2368ba3051 
     metric: ovnkCPU-overall_avg 
     reason: "old cpu spike"
-  - uuid: 6ce3a213-8481-4282-84ce-af2368ba3051 
-    metric: ovnCPU-ovnk-controller_avg 
+  - uuid: 6ce3a213-8481-4282-84ce-af2368ba3051
+    metric: ovnCPU-ovnk-controller_avg
     reason: "old cpu spike"
+  - uuid: fb6be24f-ab09-4302-87f4-56634145ad9d
+    metric: kubelet_avg
+    reason: "https://issues.redhat.com/browse/OCPBUGS-74474"
+  - uuid: fb6be24f-ab09-4302-87f4-56634145ad9d
+    metric: ovsCPU-Workers_avg
+    reason: "https://issues.redhat.com/browse/OCPBUGS-74474"
 

--- a/ack/4.21_node-density-cni_ack.yaml
+++ b/ack/4.21_node-density-cni_ack.yaml
@@ -18,6 +18,15 @@ ack:
   - uuid: 10c07387-55e9-4721-a5c8-8ab006297be1 
     metric: ovnCPU-ovncontroller_avg 
     reason: "old CPU spike"
-  - uuid: 10c07387-55e9-4721-a5c8-8ab006297be1 
+  - uuid: 10c07387-55e9-4721-a5c8-8ab006297be1
     metric: ovnCPU-ovnk-controller_avg
     reason: "old CPU spike"
+  - uuid: 3a6b3569-356a-4895-9877-4b722ca0844f
+    metric: kubelet_avg
+    reason: "https://issues.redhat.com/browse/OCPBUGS-74474"
+  - uuid: 3a6b3569-356a-4895-9877-4b722ca0844f
+    metric: ovsCPU-Workers_avg
+    reason: "https://issues.redhat.com/browse/OCPBUGS-74474"
+  - uuid: 3a6b3569-356a-4895-9877-4b722ca0844f
+    metric: ovnMem-ovncontroller_avg
+    reason: "https://issues.redhat.com/browse/OCPBUGS-74474"

--- a/ack/4.22_node-density-cni_ack.yaml
+++ b/ack/4.22_node-density-cni_ack.yaml
@@ -3,6 +3,15 @@ ack:
   - uuid: ade4d0f9-84d8-4edf-926a-4aa88ca14f61
     metric: ovnCPU-ovncontroller_avg
     reason: "Random CPU spike"
-  - uuid: fdbe9f2c-6408-4c8f-82aa-aecccd0029ea 
+  - uuid: fdbe9f2c-6408-4c8f-82aa-aecccd0029ea
     metric: ovnCPU-ovncontroller_avg
     reason: "Old CPU spike"
+  - uuid: 6ca8825c-3a47-4f0f-9cfe-b4a45986bd37
+    metric: podReadyLatency_P99
+    reason: "https://issues.redhat.com/browse/OCPBUGS-74474"
+  - uuid: 6ca8825c-3a47-4f0f-9cfe-b4a45986bd37
+    metric: ovsCPU-Workers_avg
+    reason: "https://issues.redhat.com/browse/OCPBUGS-74474"
+  - uuid: 6ca8825c-3a47-4f0f-9cfe-b4a45986bd37
+    metric: ovnMem-ovncontroller_avg
+    reason: "https://issues.redhat.com/browse/OCPBUGS-74474"


### PR DESCRIPTION
Ack node-density-cni regressions for 4.20, 4.21, 4.22                                                                                                                                                                                         
Tracking in https://issues.redhat.com/browse/OCPBUGS-74474    