### PR TITLE
ack 4.22 node-density-cni kubelet_avg

### DIFF
--- a/ack/4.22_node-density-cni_ack.yaml
+++ b/ack/4.22_node-density-cni_ack.yaml
@@ -18,3 +18,6 @@ ack:
   - uuid: f7567913-9543-444c-9e1d-2203ce467696
     metric: kubelet_avg
     reason: "https://issues.redhat.com/browse/OCPBUGS-74474"
+  - uuid: 6ca8825c-3a47-4f0f-9cfe-b4a45986bd37
+    metric: kubelet_avg
+    reason: "EXTRA_FLAGS issue wrt node-density-cni test"


### PR DESCRIPTION
acking https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.22-nightly-x86-payload-control-plane-6nodes/2019118549015990272 