### PR TITLE
Metal ingress

### DIFF
--- a/examples/metal-perfscale-cpt-ingress.yaml
+++ b/examples/metal-perfscale-cpt-ingress.yaml
@@ -86,3 +86,10 @@ tests:
       agg:
         value: p95_lat_us
         agg_type: avg
+
+    - name: http_avg_cpu_usage_router_pods
+      config.termination: http
+      metric_of_interest: infra_metrics.avg_cpu_usage_router_pods
+      agg:
+        value: infra_metrics.avg_cpu_usage_router_pods
+        agg_type: avg


### PR DESCRIPTION
Ingress regression detection for BM runs:
```
> VERSION=4.19 orion --config examples/metal-perfscale-cpt-ingress.yaml --lookback 15d  --hunter-analyze --es-server=$ES_SERVER  --metadata-index=ospst-perf-scale-ci-* --benchmark-index=ospst-ingress-performance*
2026-02-06 12:42:02,876 - Orion      - INFO - file: main.py - line: 161 - 🏹 Starting Orion in command-line mode
2026-02-06 12:42:02,883 - Orion      - INFO - file: utils.py - line: 661 - Duration to subtract: 15 days, 0:00:00
2026-02-06 12:42:02,883 - Orion      - INFO - file: utils.py - line: 664 - Start timestamp: 2026-02-06 11:42:02.692054+00:00
2026-02-06 12:42:02,883 - Orion      - INFO - file: utils.py - line: 302 - The test metal-perfscale-cpt-ingress-perf has started
2026-02-06 12:42:02,883 - Orion      - INFO - file: utils.py - line: 209 - organization is empty removed from metadata for it to not affect the matching process
2026-02-06 12:42:02,883 - Orion      - INFO - file: utils.py - line: 212 - repository is empty removed from metadata for it to not affect the matching process
2026-02-06 12:42:02,883 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-perf-scale-ci-*
2026-02-06 12:42:03,758 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-perf-scale-ci-*
2026-02-06 12:42:07,755 - Orion      - INFO - file: utils.py - line: 69 - Collecting passthrough_avg_rps
2026-02-06 12:42:07,756 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-ingress-performance*
2026-02-06 12:42:08,264 - Orion      - INFO - file: utils.py - line: 69 - Collecting passthrough_avg_lat
2026-02-06 12:42:08,264 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-ingress-performance*
2026-02-06 12:42:08,631 - Orion      - INFO - file: utils.py - line: 69 - Collecting http_avg_rps
2026-02-06 12:42:08,631 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-ingress-performance*
2026-02-06 12:42:08,811 - Orion      - INFO - file: utils.py - line: 69 - Collecting http_avg_lat
2026-02-06 12:42:08,811 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-ingress-performance*
2026-02-06 12:42:08,990 - Orion      - INFO - file: utils.py - line: 69 - Collecting reencrypt_avg_rps
2026-02-06 12:42:08,990 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-ingress-performance*
2026-02-06 12:42:09,170 - Orion      - INFO - file: utils.py - line: 69 - Collecting reencrypt_avg_lat
2026-02-06 12:42:09,170 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-ingress-performance*
2026-02-06 12:42:10,773 - Orion      - INFO - file: utils.py - line: 69 - Collecting edge_avg_rps
2026-02-06 12:42:10,773 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-ingress-performance*
2026-02-06 12:42:10,954 - Orion      - INFO - file: utils.py - line: 69 - Collecting edge_avg_lat
2026-02-06 12:42:10,954 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: ospst-ingress-performance*
2026-02-06 12:42:11,147 - Orion      - INFO - file: run_test.py - line: 247 - Comparison algorithm: EDivisive
2026-02-06 12:42:11,156 - Orion      - INFO - file: run_test.py - line: 302 - No changepoint detected: algorithm reported no regression (test=metal-perfscale-cpt-ingress-perf, points=11)
metal-perfscale-cpt-ingress-perf
================================
time                       uuid                                  ocpVersion                            passthrough_avg_rps_avg    passthrough_avg_lat_avg    http_avg_rps_avg    http_avg_lat_avg    reencrypt_avg_rps_avg    reencrypt_avg_lat_avg    edge_avg_rps_avg    edge_avg_lat_avg  buildUrl
-------------------------  ------------------------------------  ----------------------------------  -------------------------  -------------------------  ------------------  ------------------  -----------------------  -----------------------  ------------------  ------------------  -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2026-01-24 04:42:28 +0000  bc78340e-f1fe-4999-b39d-82479dcc6e6d  4.19.0-0.nightly-2026-01-23-052208                1.62878e+06                    2284.31    948487                       4536.2                    608040                  8040.2               757914             4794.75  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-daily-virt-6nodes/2014858399610572800
2026-01-25 04:41:55 +0000  384ed06d-bcb4-41e4-bebe-a0fc496999e5  4.19.0-0.nightly-2026-01-24-165010                1.64404e+06                    2256.43         1.03278e+06             3669.69                   608038                  7816.85              757858             4788.81  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-daily-virt-6nodes/2015220798213591040
2026-01-27 04:45:49 +0000  033b233d-572b-4642-bc66-994435653389  4.19.0-0.nightly-2026-01-24-230611                1.6321e+06                     2258.5     991300                       3980.17                   610883                  8826.58              759237             4785.93  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-daily-virt-6nodes/2015945607742492672
2026-01-27 09:28:02 +0000  83879c71-2417-4d0c-8177-78f3c63afc28  4.19.0-0.nightly-2026-01-24-230611                1.63912e+06                    2258.86         1.02623e+06             3866.46                   609802                  8511.99              762294             4750.16  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-weekly-6nodes/2016013680906342400
2026-01-28 04:42:51 +0000  9e055fdc-71e9-49d7-9db3-29eb68e088aa  4.19.0-0.nightly-2026-01-24-230611                1.6196e+06                     2295.74    978253                       4497.23                   613413                  8236.46              751286             4850.3   https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-daily-virt-6nodes/2016307808823152640
2026-01-29 04:45:12 +0000  e75d41ac-1b1a-45fb-9517-5b61224719b7  4.19.0-0.nightly-2026-01-26-174424                1.63957e+06                    2264.2     902521                       5013.67                   603178                  8633.38              733780             4987.48  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-daily-virt-6nodes/2016670266884624384
2026-01-31 04:52:12 +0000  48ced855-ae50-4cae-9ecf-729deea1f1db  4.19.0-0.nightly-2026-01-29-015550                1.64106e+06                    2243.27         1.03105e+06             3727.08                   608134                  8348.98              775594             4674.45  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-daily-virt-6nodes/2017395044301934592
2026-02-02 04:41:48 +0000  23740f5e-ab5b-486e-8d5f-773905899f34  4.19.0-0.nightly-2026-02-01-082259                1.62922e+06                    2261.63         1.00872e+06             3786.89                   611078                  8823                 768144             4719.77  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-daily-virt-6nodes/2018119827859705856
2026-02-03 04:43:21 +0000  d376ace3-ec01-4005-b436-47d6a5523ec4  4.19.0-0.nightly-2026-02-02-102221                1.63098e+06                    2266.11    995363                       3790.34                   604808                  8694.75              767787             4729.55  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-daily-virt-6nodes/2018482241004376064
2026-02-03 09:28:02 +0000  c9247486-d20a-488a-b5b7-9253f4f68de2  4.19.0-0.nightly-2026-02-02-184123                1.64732e+06                    2235.04    974548                       4739.07                   610066                  7641.33              761795             4769.07  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-weekly-6nodes/2018550314629599232
2026-02-04 04:45:31 +0000  3d8acc11-067d-4fef-8f47-995f7e3cfc47  4.19.0-0.nightly-2026-02-02-184123                1.65023e+06                    2251.4          1.00391e+06             4078.31                   610934                  7848.08              754416             4830.99  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.19-nightly-x86-daily-virt-6nodes/2018844613426548736
```
