### PR TITLE
Remove breaking netobsrv test

### DIFF
--- a/test.bats
+++ b/test.bats
@@ -266,12 +266,6 @@ setup() {
   VERSION=$before_version
 }
 
-@test "orion with netobserv configs " {
-  BENCHMARK_INDEX="prod-netobserv-datapoints*"
-  curl -s https://raw.githubusercontent.com/openshift-eng/ocp-qe-perfscale-ci/refs/heads/netobserv-perf-tests/scripts/queries/netobserv-orion-node-density-heavy.yaml -w %{http_code} -o /tmp/netobserv-node-density-heavy-ospst.yaml
-  run_cmd orion --config "/tmp/netobserv-node-density-heavy-ospst.yaml" --lookback 45d --hunter-analyze --es-server=${ES_SERVER} --metadata-index=${METADATA_INDEX} --benchmark-index=${BENCHMARK_INDEX} --input-vars='{"workers": 25}'
-}
-
 @test "orion with quay config " {
   export quay_image_push_pull_index="quay-push-pull*"
   export quay_load_test_index="quay-vegeta-results*"


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

CI tests should configurations available in the repository, they never should use an external configuration file, that's counterproductive and error prone. This test is currently broken.

```shell
 $ curl  https://raw.githubusercontent.com/openshift-eng/ocp-qe-perfscale-ci/refs/heads/netobserv-perf-tests/scripts/queries/netobserv-orion-node-density-heavy.yaml
404: Not Found
```

If there's interest in testing the configuration, you can either upload it to this repo or test it from the `netobserv-perf-tests` by using a specific orion release.

/cc @memodi 

