### PR TITLE
Remove value field from agg:

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,6 @@ The `metricsFile` field allows you to load metrics from an separate file. This i
   labels.namespace.keyword: openshift-kube-apiserver
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
   labels:
     - "[Jira: kube-apiserver]"
@@ -247,7 +246,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -346,7 +344,6 @@ Orion supports aggregating metric values across multiple data points per test ru
   labels.namespace.keyword: openshift-kube-apiserver
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg  # Calculate average CPU usage
   threshold: 10
   direction: 1
@@ -359,7 +356,6 @@ Orion supports aggregating metric values across multiple data points per test ru
   metricName: api_requests
   metric_of_interest: request_id
   agg:
-    value: request_id
     agg_type: count  # Count number of requests
   threshold: 10
   direction: 1
@@ -380,7 +376,6 @@ Percentile aggregations are particularly useful for analyzing latency distributi
   metricName: api_response_time
   metric_of_interest: latency_ms
   agg:
-    value: latency_ms
     agg_type: percentiles
   # Calculates P50, P95, P99 by default
   # Reports P95 by default
@@ -395,7 +390,6 @@ Percentile aggregations are particularly useful for analyzing latency distributi
   metricName: api_response_time
   metric_of_interest: latency_ms
   agg:
-    value: latency_ms
     agg_type: percentiles
     percents: [50, 90, 95, 99, 99.9]  # Which percentiles to calculate
     target_percentile: 99              # Which percentile to report for regression detection
@@ -422,7 +416,6 @@ Percentile aggregations are particularly useful for analyzing latency distributi
   quantileName: Ready
   metric_of_interest: latency_seconds
   agg:
-    value: latency_seconds
     agg_type: percentiles
     percents: [50, 95, 99]
     target_percentile: 99

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -350,7 +350,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 0
         threshold: 15
@@ -392,7 +391,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 0
         threshold: 20
@@ -427,7 +425,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -437,7 +434,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -446,7 +442,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -455,7 +450,6 @@ tests:
         metricName.keyword: kubeletCPU
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Node]"

--- a/examples/chaos_tests.yaml
+++ b/examples/chaos_tests.yaml
@@ -42,5 +42,4 @@ tests:
         not:
           status_code: 200
         agg:
-          value: duration
           agg_type: sum

--- a/examples/label-small-scale-cluster-density.yaml
+++ b/examples/label-small-scale-cluster-density.yaml
@@ -30,7 +30,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -40,7 +39,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: ovnKubernetes]"
@@ -50,7 +48,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -59,7 +56,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
         labels:
           - "[Jira: etcd]"

--- a/examples/large-scale-cluster-density.yaml
+++ b/examples/large-scale-cluster-density.yaml
@@ -35,7 +35,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -47,7 +46,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -59,7 +57,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -71,7 +68,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -83,7 +79,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -96,7 +91,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -106,7 +100,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -118,7 +111,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -130,7 +122,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -142,7 +133,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/large-scale-node-density-cni.yaml
+++ b/examples/large-scale-node-density-cni.yaml
@@ -46,7 +46,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -58,7 +57,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -70,7 +68,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -82,7 +79,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -95,7 +91,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -105,7 +100,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -117,7 +111,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -130,7 +123,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -143,7 +135,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -156,7 +147,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -169,7 +159,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -182,7 +171,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -194,7 +182,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -206,7 +193,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -218,7 +204,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -230,7 +215,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -243,7 +227,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -256,7 +239,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -269,7 +251,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -282,7 +263,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -295,7 +275,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/large-scale-node-density.yaml
+++ b/examples/large-scale-node-density.yaml
@@ -44,7 +44,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -56,7 +55,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -68,7 +66,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -81,7 +78,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/large-scale-udn-l2.yaml
+++ b/examples/large-scale-udn-l2.yaml
@@ -40,7 +40,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -53,7 +52,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -67,7 +65,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -81,7 +78,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -95,7 +91,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -109,7 +104,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -123,7 +117,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -136,7 +129,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -149,7 +141,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -162,7 +153,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -175,7 +165,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -189,7 +178,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -203,7 +191,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -217,7 +204,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -231,7 +217,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -245,7 +230,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/large-scale-udn-l3.yaml
+++ b/examples/large-scale-udn-l3.yaml
@@ -40,7 +40,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -53,7 +52,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -67,7 +65,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -81,7 +78,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -95,7 +91,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -109,7 +104,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -123,7 +117,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -136,7 +129,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -149,7 +141,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -162,7 +153,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -175,7 +165,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -189,7 +178,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -203,7 +191,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -217,7 +204,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -231,7 +217,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -245,7 +230,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/med-scale-cluster-density.yaml
+++ b/examples/med-scale-cluster-density.yaml
@@ -35,7 +35,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -47,7 +46,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -59,7 +57,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -71,7 +68,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -83,7 +79,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -96,7 +91,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -106,7 +100,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -118,7 +111,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -130,7 +122,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -142,7 +133,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/med-scale-node-density-cni.yaml
+++ b/examples/med-scale-node-density-cni.yaml
@@ -46,7 +46,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -58,7 +57,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -70,7 +68,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -82,7 +79,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -95,7 +91,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -105,7 +100,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -117,7 +111,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -130,7 +123,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -143,7 +135,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -156,7 +147,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -169,7 +159,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -182,7 +171,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -194,7 +182,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -206,7 +193,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -218,7 +204,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -230,7 +215,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -243,7 +227,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -256,7 +239,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -269,7 +251,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -282,7 +263,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -295,7 +275,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/med-scale-node-density.yaml
+++ b/examples/med-scale-node-density.yaml
@@ -44,7 +44,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -56,7 +55,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -68,7 +66,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -81,7 +78,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/med-scale-udn-l2.yaml
+++ b/examples/med-scale-udn-l2.yaml
@@ -39,7 +39,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -52,7 +51,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -66,7 +64,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -80,7 +77,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -94,7 +90,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -108,7 +103,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -122,7 +116,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -135,7 +128,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -148,7 +140,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -161,7 +152,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -174,7 +164,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -188,7 +177,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -202,7 +190,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -216,7 +203,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -230,7 +216,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -244,7 +229,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/med-scale-udn-l3.yaml
+++ b/examples/med-scale-udn-l3.yaml
@@ -39,7 +39,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -52,7 +51,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -66,7 +64,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -80,7 +77,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -94,7 +90,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -108,7 +103,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -122,7 +116,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -135,7 +128,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -148,7 +140,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -161,7 +152,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -174,7 +164,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -188,7 +177,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -202,7 +190,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -216,7 +203,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -230,7 +216,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -244,7 +229,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/metal-perfscale-cpt-data-path.yaml
+++ b/examples/metal-perfscale-cpt-data-path.yaml
@@ -33,7 +33,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -47,7 +46,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -61,7 +59,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -75,7 +72,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -89,7 +85,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -103,7 +98,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -117,7 +111,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -131,7 +124,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -144,7 +136,6 @@ tests:
         acrossAZ: true
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10
@@ -158,7 +149,6 @@ tests:
         acrossAZ: true
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10
@@ -173,7 +163,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -187,7 +176,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -201,7 +189,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -215,7 +202,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -229,7 +215,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -243,7 +228,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -257,7 +241,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -271,7 +254,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -284,7 +266,6 @@ tests:
         acrossAZ: true
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10
@@ -298,7 +279,6 @@ tests:
         acrossAZ: true
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10
@@ -315,7 +295,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -330,7 +309,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -345,7 +323,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -360,7 +337,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -374,7 +350,6 @@ tests:
         acrossAZ: true
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/metal-perfscale-cpt-ingress.yaml
+++ b/examples/metal-perfscale-cpt-ingress.yaml
@@ -33,14 +33,12 @@ tests:
         metric_of_interest: total_avg_rps
         direction: -1
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: passthrough_p95_lat
         config.termination: passthrough
         metric_of_interest: p95_lat_us
         agg:
-          value: p95_lat_us
           agg_type: avg
 
       - name: http_avg_rps
@@ -49,14 +47,12 @@ tests:
         direction: -1
         config.tool: wrk
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: http_p95_lat
         config.termination: http
         metric_of_interest: p95_lat_us
         agg:
-          value: p95_lat_us
           agg_type: avg
 
       - name: reencrypt_avg_rps
@@ -64,14 +60,12 @@ tests:
         metric_of_interest: total_avg_rps
         direction: -1
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: reencrypt_p95_lat
         config.termination: reencrypt
         metric_of_interest: p95_lat_us
         agg:
-          value: p95_lat_us
           agg_type: avg
 
       - name: edge_avg_rps
@@ -80,19 +74,16 @@ tests:
         direction: -1
         config.tool: wrk
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: edge_p95_lat
         config.termination: edge
         metric_of_interest: p95_lat_us
         agg:
-          value: p95_lat_us
           agg_type: avg
 
       - name: http_avg_cpu_usage_router_pods
         config.termination: http
         metric_of_interest: infra_metrics.avg_cpu_usage_router_pods
         agg:
-          value: infra_metrics.avg_cpu_usage_router_pods
           agg_type: avg

--- a/examples/metal-perfscale-cpt-node-density-heavy.yaml
+++ b/examples/metal-perfscale-cpt-node-density-heavy.yaml
@@ -35,7 +35,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -46,7 +45,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -57,7 +55,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -68,7 +65,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -79,7 +75,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -89,7 +84,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -101,6 +95,5 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         threshold: 10

--- a/examples/metal-perfscale-cpt-node-density.yaml
+++ b/examples/metal-perfscale-cpt-node-density.yaml
@@ -44,7 +44,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -55,7 +54,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -66,7 +64,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -77,7 +74,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -88,7 +84,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -98,7 +93,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -110,6 +104,5 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         threshold: 10

--- a/examples/metal-perfscale-cpt-rds-core.yaml
+++ b/examples/metal-perfscale-cpt-rds-core.yaml
@@ -25,7 +25,6 @@ tests:
         labels:
           - "[Jira: PodReadyLatency]"
         agg:
-          value: P99
           agg_type: avg
         direction: 1
         threshold: 10
@@ -35,7 +34,6 @@ tests:
         labels:
           - "[Jira: kubelet_cpu_max_worker]"
         agg:
-          value: cpu
           agg_type: max
         direction: 1
         threshold: 10
@@ -45,7 +43,6 @@ tests:
         labels:
           - "[Jira: kubelet_cpu_avg_worker]"
         agg:
-          value: cpu-kubelet
           agg_type: avg
         direction: 1
         threshold: 10
@@ -55,7 +52,6 @@ tests:
         labels:
           - "[Jira: kubelet_mem_max_worker]"
         agg:
-          value: max-memory-kubelet
           agg_type: max
         direction: 1
         threshold: 10
@@ -65,7 +61,6 @@ tests:
         labels:
           - "[Jira: kubelet_mem_avg_worker]"
         agg:
-          value: memory-kubelet
           agg_type: avg
         direction: 1
         threshold: 10
@@ -75,7 +70,6 @@ tests:
         labels:
           - "[Jira: crio_cpu_max_worker]"
         agg:
-          value: max-cpu-crio
           agg_type: max
         direction: 1
         threshold: 10
@@ -85,7 +79,6 @@ tests:
         labels:
           - "[Jira: crio_cpu_avg_worker]"
         agg:
-          value: cpu-crio
           agg_type: avg
         direction: 1
         threshold: 10
@@ -95,7 +88,6 @@ tests:
         labels:
           - "[Jira: crio_mem_max_worker]"
         agg:
-          value: max-memory-crio
           agg_type: max
         direction: 1
         threshold: 10
@@ -105,7 +97,6 @@ tests:
         labels:
           - "[Jira: crio_mem_avg_worker]"
         agg:
-          value: memory-crio
           agg_type: avg
         direction: 1
         threshold: 10
@@ -115,7 +106,6 @@ tests:
         labels:
           - "[Jira: openshift_apiserver_cpu_avg]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -125,7 +115,6 @@ tests:
         labels:
           - "[Jira: openshift_apiserver_mem_max]"
         agg:
-          value: mem
           agg_type: max
         direction: 1
         threshold: 10
@@ -135,7 +124,6 @@ tests:
         labels:
           - "[Jira: openshift_apiserver_mem_avg]"
         agg:
-          value: mem
           agg_type: avg
         direction: 1
         threshold: 10
@@ -143,7 +131,6 @@ tests:
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          value: latency
           agg_type: max
         labels:
           - "[Jira: max-ro-apicalls-latency]"
@@ -153,7 +140,6 @@ tests:
         metricName.keyword: avg-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          value: latency
           agg_type: avg
         labels:
           - "[Jira: avg-ro-apicalls-latency]"
@@ -163,7 +149,6 @@ tests:
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          value: latency
           agg_type: max
         labels:
           - "[Jira: max-mutating-apicalls-latency]"
@@ -173,7 +158,6 @@ tests:
         metricName.keyword: avg-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          value: latency
           agg_type: avg
         labels:
           - "[Jira: avg-mutating-apicalls-latency]"
@@ -183,7 +167,6 @@ tests:
         metricName.keyword: max-cpu-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: max-cpu-etcd]"
@@ -193,7 +176,6 @@ tests:
         metricName.keyword: cpu-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: avg-cpu-etcd]"
@@ -203,7 +185,6 @@ tests:
         metricName.keyword: max-memory-etcd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: max-memory-etcd]"
@@ -213,7 +194,6 @@ tests:
         metricName.keyword: memory-etcd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: avg-memory-etcd]"
@@ -223,7 +203,6 @@ tests:
         metricName.keyword: 99thEtcdRoundTripTime
         metric_of_interest: value
         agg:
-          value: P99
           agg_type: avg
         labels:
           - "[Jira: 99thEtcdRoundTripTime]"
@@ -233,7 +212,6 @@ tests:
         metricName.keyword: 99thEtcdDiskWalFsync
         metric_of_interest: value
         agg:
-          value: P99
           agg_type: avg
         labels:
           - "[Jira: 99thEtcdDiskWalFsync]"
@@ -243,7 +221,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommit
         metric_of_interest: value
         agg:
-          value: P99
           agg_type: avg
         labels:
           - "[Jira: 99thEtcdDiskBackendCommit]"
@@ -255,7 +232,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: max-memory-masters]"
@@ -267,7 +243,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: avg-memory-masters]"
@@ -279,7 +254,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: max-memory-workers]"
@@ -291,7 +265,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: avg-memory-workers]"
@@ -303,7 +276,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: max-cpu-masters]"
@@ -315,7 +287,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: avg-cpu-masters]"
@@ -327,7 +298,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: max-cpu-workers]"
@@ -339,7 +309,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: avg-cpu-workers]"
@@ -349,7 +318,6 @@ tests:
         metricName.keyword: max-cpu-ovn-control-plane
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: Networking / ovs Maximum cpu-ovn-control-plane]"
@@ -359,7 +327,6 @@ tests:
         metricName.keyword: cpu-ovn-control-plane
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovs Average cpu-ovn-control-plane]"
@@ -369,7 +336,6 @@ tests:
         metricName.keyword: max-cpu-ovnkube-node
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: Networking / ovs Maximum cpu-ovnkube-node]"
@@ -379,7 +345,6 @@ tests:
         metricName.keyword: cpu-ovnkube-node
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovs Average cpu-ovnkube-node]"
@@ -389,7 +354,6 @@ tests:
         metricName.keyword: max-memory-ovn-control-plane
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovs Maximum memory-ovn-control-plane]"
@@ -399,7 +363,6 @@ tests:
         metricName.keyword: memory-ovn-control-plane
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovs Average memory-ovn-control-plane]"
@@ -409,7 +372,6 @@ tests:
         metricName.keyword: max-memory-ovnkube-node
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / Maximum memory-ovnkube-node]"
@@ -419,7 +381,6 @@ tests:
         metricName.keyword: memory-ovnkube-node
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / Average memory-ovnkube-node]"
@@ -430,7 +391,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -441,7 +401,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -452,7 +411,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -463,7 +421,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -474,7 +431,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -485,7 +441,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -495,7 +450,6 @@ tests:
         metricName.keyword: max-cpu-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: max-cpu-multus]"
@@ -505,7 +459,6 @@ tests:
         metricName.keyword: cpu-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: avg-cpu-multus]"

--- a/examples/metal-perfscale-cpt-virt-datapath.yaml
+++ b/examples/metal-perfscale-cpt-virt-datapath.yaml
@@ -35,7 +35,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -50,7 +49,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -65,7 +63,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -80,7 +77,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -95,7 +91,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -110,7 +105,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -125,7 +119,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -140,7 +133,6 @@ tests:
         metric_of_interest: throughput
         direction: -1
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -154,7 +146,6 @@ tests:
         virt: true
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10
@@ -169,7 +160,6 @@ tests:
         virt: true
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/metal-perfscale-cpt-virt-density-nomount.yaml
+++ b/examples/metal-perfscale-cpt-virt-density-nomount.yaml
@@ -36,7 +36,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -48,7 +47,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -60,7 +58,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -72,7 +69,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -84,7 +80,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -95,7 +90,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -107,7 +101,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         threshold: 10
         direction: 1

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -36,7 +36,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -48,7 +47,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -60,7 +58,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -72,7 +69,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -84,7 +80,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -95,7 +90,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -107,7 +101,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         threshold: 10
         direction: 1

--- a/examples/metal-perfscale-cpt-virt-udn-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-udn-density.yaml
@@ -36,7 +36,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -48,7 +47,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -60,7 +58,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -72,7 +69,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -84,7 +80,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -95,7 +90,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -107,7 +101,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         threshold: 10
         direction: 1

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -14,7 +14,6 @@
   labels.namespace.keyword: openshift-kube-apiserver
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
   labels:
     - "[Jira: kube-apiserver]"
@@ -26,7 +25,6 @@
   labels.namespace.keyword: openshift-ovn-kubernetes
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
   labels:
     - "[Jira: Networking / ovn-kubernetes]"
@@ -39,7 +37,6 @@
   labels:
     - "[Jira: Node]"
   agg:
-    value: cpu
     agg_type: avg
   direction: 1
   threshold: 10

--- a/examples/metrics/chaos-scenarios-metrics.yaml
+++ b/examples/metrics/chaos-scenarios-metrics.yaml
@@ -12,7 +12,6 @@
   not:
     status_code: 200
   agg:
-    value: duration
     agg_type: sum
 
 # ETCD Performance metrics
@@ -22,7 +21,6 @@
   metricName.keyword: 99thEtcdDiskBackendCommit
   metric_of_interest: value
   agg:
-    value: value
     agg_type: avg
 
 - name: etcd_99th_wal_fsync_duration
@@ -31,7 +29,6 @@
   metricName.keyword: 99thEtcdDiskWalFsync
   metric_of_interest: value
   agg:
-    value: value
     agg_type: avg
 
 - name: etcd_99th_round_trip_time
@@ -40,7 +37,6 @@
   metricName.keyword: 99thEtcdRoundTripTime
   metric_of_interest: value
   agg:
-    value: value
     agg_type: avg
 
 # API Server metrics
@@ -50,7 +46,6 @@
   metricName.keyword: APIInflightRequests
   metric_of_interest: value
   agg:
-    value: value
     agg_type: max
 
 # CPU Usage metrics
@@ -60,7 +55,6 @@
   metricName.keyword: cpu-cluster-usage-ratio
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_crio
@@ -69,7 +63,6 @@
   metricName.keyword: cpu-crio
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_etcd
@@ -78,7 +71,6 @@
   metricName.keyword: cpu-etcd
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_infra
@@ -87,7 +79,6 @@
   metricName.keyword: cpu-infra
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_kube_apiserver
@@ -96,7 +87,6 @@
   metricName.keyword: cpu-kube-apiserver
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_kube_controller_manager
@@ -105,7 +95,6 @@
   metricName.keyword: cpu-kube-controller-manager
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_kubelet
@@ -114,7 +103,6 @@
   metricName.keyword: cpu-kubelet
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_masters
@@ -123,7 +111,6 @@
   metricName.keyword: cpu-masters
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_multus
@@ -132,7 +119,6 @@
   metricName.keyword: cpu-multus
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_openshift_apiserver
@@ -141,7 +127,6 @@
   metricName.keyword: cpu-openshift-apiserver
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_openshift_controller_manager
@@ -150,7 +135,6 @@
   metricName.keyword: cpu-openshift-controller-manager
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_ovn_control_plane
@@ -159,7 +143,6 @@
   metricName.keyword: cpu-ovn-control-plane
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_ovnkube_node
@@ -168,7 +151,6 @@
   metricName.keyword: cpu-ovnkube-node
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_prometheus
@@ -177,7 +159,6 @@
   metricName.keyword: cpu-prometheus
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_router
@@ -186,7 +167,6 @@
   metricName.keyword: cpu-router
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 - name: cpu_workers
@@ -195,7 +175,6 @@
   metricName.keyword: cpu-workers
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
 
 # Max CPU metrics
@@ -205,7 +184,6 @@
   metricName.keyword: max-cpu-crio
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: max
 
 - name: max_cpu_infra
@@ -214,7 +192,6 @@
   metricName.keyword: max-cpu-infra
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: max
 
 - name: max_cpu_kube_controller_manager
@@ -223,7 +200,6 @@
   metricName.keyword: max-cpu-kube-controller-manager
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: max
 
 - name: max_cpu_kubelet
@@ -232,7 +208,6 @@
   metricName.keyword: max-cpu-kubelet
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: max
 
 - name: max_cpu_prometheus
@@ -241,7 +216,6 @@
   metricName.keyword: max-cpu-prometheus
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: max
 
 - name: max_cpu_workers
@@ -250,7 +224,6 @@
   metricName.keyword: max-cpu-workers
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: max
 
 # Memory Usage metrics
@@ -260,7 +233,6 @@
   metricName.keyword: memory-cluster-usage-ratio
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_crio
@@ -269,7 +241,6 @@
   metricName.keyword: memory-crio
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_etcd
@@ -278,7 +249,6 @@
   metricName.keyword: memory-etcd
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_infra
@@ -287,7 +257,6 @@
   metricName.keyword: memory-infra
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_kube_apiserver
@@ -296,7 +265,6 @@
   metricName.keyword: memory-kube-apiserver
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_kube_controller_manager
@@ -305,7 +273,6 @@
   metricName.keyword: memory-kube-controller-manager
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_kubelet
@@ -314,7 +281,6 @@
   metricName.keyword: memory-kubelet
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_masters
@@ -323,7 +289,6 @@
   metricName.keyword: memory-masters
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_multus
@@ -332,7 +297,6 @@
   metricName.keyword: memory-multus
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_openshift_apiserver
@@ -341,7 +305,6 @@
   metricName.keyword: memory-openshift-apiserver
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_openshift_controller_manager
@@ -350,7 +313,6 @@
   metricName.keyword: memory-openshift-controller-manager
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_ovn_control_plane
@@ -359,7 +321,6 @@
   metricName.keyword: memory-ovn-control-plane
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_ovnkube_node
@@ -368,7 +329,6 @@
   metricName.keyword: memory-ovnkube-node
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_prometheus
@@ -377,7 +337,6 @@
   metricName.keyword: memory-prometheus
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_router
@@ -386,7 +345,6 @@
   metricName.keyword: memory-router
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_sum_workers
@@ -395,7 +353,6 @@
   metricName.keyword: memory-sum-workers
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 - name: memory_workers
@@ -404,7 +361,6 @@
   metricName.keyword: memory-workers
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: avg
 
 # Max Memory metrics
@@ -414,7 +370,6 @@
   metricName.keyword: max-memory-crio
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: max
 
 - name: max_memory_infra
@@ -423,7 +378,6 @@
   metricName.keyword: max-memory-infra
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: max
 
 - name: max_memory_kube_controller_manager
@@ -432,7 +386,6 @@
   metricName.keyword: max-memory-kube-controller-manager
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: max
 
 - name: max_memory_kubelet
@@ -441,7 +394,6 @@
   metricName.keyword: max-memory-kubelet
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: max
 
 - name: max_memory_masters
@@ -450,7 +402,6 @@
   metricName.keyword: max-memory-masters
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: max
 
 - name: max_memory_prometheus
@@ -459,7 +410,6 @@
   metricName.keyword: max-memory-prometheus
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: max
 
 - name: max_memory_sum_infra
@@ -468,7 +418,6 @@
   metricName.keyword: max-memory-sum-infra
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: max
 
 - name: max_memory_sum_kubelet
@@ -477,7 +426,6 @@
   metricName.keyword: max-memory-sum-kubelet
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: max
 
 - name: max_memory_workers
@@ -486,7 +434,6 @@
   metricName.keyword: max-memory-workers
   metric_of_interest: value
   agg:
-    value: mem
     agg_type: max
 
 # Node CPU Seconds metrics
@@ -496,7 +443,6 @@
   metricName.keyword: nodeCPUSeconds-Infra
   metric_of_interest: value
   agg:
-    value: value
     agg_type: avg
 
 - name: node_cpu_seconds_masters
@@ -505,7 +451,6 @@
   metricName.keyword: nodeCPUSeconds-Masters
   metric_of_interest: value
   agg:
-    value: value
     agg_type: avg
 
 - name: node_cpu_seconds_workers
@@ -514,5 +459,4 @@
   metricName.keyword: nodeCPUSeconds-Workers
   metric_of_interest: value
   agg:
-    value: value
     agg_type: avg

--- a/examples/metrics/ols-load-generator-metrics.yaml
+++ b/examples/metrics/ols-load-generator-metrics.yaml
@@ -400,7 +400,6 @@
   metricName.keyword: avg-llm-call-failures
   metric_of_interest: value
   agg:
-    value: callFailures
     agg_type: avg
   direction: 1
   threshold: 10
@@ -409,7 +408,6 @@
   metricName.keyword: avg-llm-validation-errors
   metric_of_interest: value
   agg:
-    value: validationErrors
     agg_type: avg
   direction: 1
   threshold: 10
@@ -420,7 +418,6 @@
   labels.namespace.keyword: openshift-lightspeed
   metric_of_interest: value
   agg:
-    value: cpu
     agg_type: avg
   direction: 1
   threshold: 10
@@ -430,7 +427,6 @@
   labels.namespace.keyword: openshift-lightspeed
   metric_of_interest: value
   agg:
-    value: memory
     agg_type: avg
   direction: 1
   threshold: 10

--- a/examples/netobserv-diff-meta-index.yaml
+++ b/examples/netobserv-diff-meta-index.yaml
@@ -23,7 +23,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -33,7 +32,6 @@ tests:
         metricName.keyword: ovsVswitchdCPU
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -42,7 +40,6 @@ tests:
         metricName.keyword: ovsVswitchdMemory
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -51,7 +48,6 @@ tests:
         metricName.keyword: ovsVswitchdCPU
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -60,7 +56,6 @@ tests:
         metricName.keyword: ovsVswitchdMemory
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -70,7 +65,6 @@ tests:
         labels.namespace.keyword: openshift-netobserv
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -81,7 +75,6 @@ tests:
         labels.namespace.keyword: openshift-netobserv-privileged
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -92,7 +85,6 @@ tests:
         labels.namespace.keyword: openshift-netobserv
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -103,7 +95,6 @@ tests:
         labels.namespace.keyword: openshift-netobserv-privileged
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -114,7 +105,6 @@ tests:
         labels.namespace.keyword: openshift-netobserv
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -125,7 +115,6 @@ tests:
         labels.namespace.keyword: openshift-netobserv-privileged
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -136,7 +125,6 @@ tests:
         labels.namespace.keyword: openshift-netobserv
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -147,7 +135,6 @@ tests:
         labels.namespace.keyword: openshift-netobserv-privileged
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/netpol-24nodes.yaml
+++ b/examples/netpol-24nodes.yaml
@@ -50,7 +50,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -63,7 +62,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -76,7 +74,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -89,7 +86,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -102,7 +98,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -115,7 +110,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -128,7 +122,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -141,7 +134,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -154,7 +146,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -167,7 +158,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -180,7 +170,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -193,7 +182,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -206,7 +194,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -218,7 +205,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -231,7 +217,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -243,7 +228,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -255,7 +239,6 @@ tests:
         metricName.keyword: kubeletCPU
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Node]"
@@ -266,7 +249,6 @@ tests:
         metricName.keyword: kubeletMemory
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Node]"
@@ -279,7 +261,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -291,7 +272,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -303,7 +283,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
         labels:
           - "[Jira: etcd]"

--- a/examples/node_scenarios.yaml
+++ b/examples/node_scenarios.yaml
@@ -41,5 +41,4 @@ tests:
         metricName.keyword: affected_nodes_recovery
         metric_of_interest: ready_time
         agg:
-          value: ready_time
           agg_type: avg

--- a/examples/okd-control-plane-cluster-density.yaml
+++ b/examples/okd-control-plane-cluster-density.yaml
@@ -35,7 +35,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -46,7 +45,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -57,7 +55,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -68,7 +65,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -79,7 +75,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -91,6 +86,5 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1

--- a/examples/okd-control-plane-crd-scale.yaml
+++ b/examples/okd-control-plane-crd-scale.yaml
@@ -24,7 +24,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -36,7 +35,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"

--- a/examples/okd-control-plane-node-density-cni.yaml
+++ b/examples/okd-control-plane-node-density-cni.yaml
@@ -34,7 +34,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -47,7 +46,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -60,7 +58,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -73,7 +70,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -86,7 +82,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -99,7 +94,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -111,7 +105,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -123,7 +116,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -136,7 +128,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -149,7 +140,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -162,7 +152,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -175,7 +164,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -188,7 +176,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -200,7 +187,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -212,7 +198,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -224,7 +209,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -236,7 +220,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -249,7 +232,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/okd-control-plane-node-density.yaml
+++ b/examples/okd-control-plane-node-density.yaml
@@ -45,7 +45,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu-kubelet
           agg_type: avg
         direction: 1
         threshold: 10
@@ -56,7 +55,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: max-memory-kubelet
           agg_type: avg
         direction: 1
         threshold: 10
@@ -65,7 +63,6 @@ tests:
         metricName.keyword: cpu-crio
         metric_of_interest: value
         agg:
-          value: cpu-crio
           agg_type: avg
         direction: 1
         threshold: 10
@@ -74,7 +71,6 @@ tests:
         metricName.keyword: max-memory-crio
         metric_of_interest: value
         agg:
-          value: max-memory-crio
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/okd-data-plane-data-path.yaml
+++ b/examples/okd-data-plane-data-path.yaml
@@ -28,7 +28,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -41,7 +40,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -54,7 +52,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -67,7 +64,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -80,7 +76,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -93,7 +88,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -106,7 +100,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -119,7 +112,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -132,7 +124,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10
@@ -146,7 +137,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10
@@ -160,7 +150,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -173,7 +162,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -186,7 +174,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -199,7 +186,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -212,7 +198,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -225,7 +210,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -238,7 +222,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -251,7 +234,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -264,7 +246,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10
@@ -278,7 +259,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10
@@ -294,7 +274,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -308,7 +287,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -322,7 +300,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -336,7 +313,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
         threshold: 10
 
@@ -350,7 +326,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/olmv1.yaml
+++ b/examples/olmv1.yaml
@@ -37,7 +37,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: OLM]"
@@ -48,7 +47,6 @@ tests:
         not:
           jobConfig.name: "garbage-collection"
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: OLM]"

--- a/examples/payload-scale.yaml
+++ b/examples/payload-scale.yaml
@@ -28,7 +28,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
 
       - name: ovnCPU
@@ -36,7 +35,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
 
       - name: etcdCPU
@@ -44,14 +42,12 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
 
       - name: etcdDisk
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
   - name: aws-payload-scale-node-density
     metadata:
@@ -79,7 +75,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
 
       - name: ovnCPU
@@ -87,7 +82,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
 
       - name: etcdCPU
@@ -95,13 +89,11 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
 
       - name: etcdDisk
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
 

--- a/examples/pod_disruption_scenarios.yaml
+++ b/examples/pod_disruption_scenarios.yaml
@@ -39,7 +39,6 @@ tests:
         metric_of_interest: total_recovery_time
         type: recovered
         agg:
-          value: total_recovery_time
           agg_type: avg
       - name: affected_rescheduled
         threshold: 15
@@ -48,7 +47,6 @@ tests:
         metric_of_interest: pod_rescheduling_time
         type: recovered
         agg:
-          value: pod_rescheduling_time
           agg_type: avg
       - name: affected_readiness
         threshold: 15
@@ -57,5 +55,4 @@ tests:
         metric_of_interest: pod_readiness_time
         type: recovered
         agg:
-          value: pod_readiness_time
           agg_type: avg

--- a/examples/quay-load-test-stable-stage.yaml
+++ b/examples/quay-load-test-stable-stage.yaml
@@ -20,7 +20,6 @@ tests:
         targets: image_pulls
         metric_of_interest: success_count
         agg:
-          value: success
           agg_type: sum
         direction: -1
         threshold: 10
@@ -30,7 +29,6 @@ tests:
         targets: image_pulls
         metric_of_interest: failure_count
         agg:
-          value: failure
           agg_type: sum
         direction: -1
         threshold: 10
@@ -40,7 +38,6 @@ tests:
         targets: image_pulls
         metric_of_interest: elapsed_time
         agg:
-          value: latency
           agg_type: max
         direction: 1
         threshold: 10
@@ -51,7 +48,6 @@ tests:
         targets: image_pushes
         metric_of_interest: success_count
         agg:
-          value: success
           agg_type: sum
         direction: -1
         threshold: 10
@@ -61,7 +57,6 @@ tests:
         targets: image_pushes
         metric_of_interest: failure_count
         agg:
-          value: failure
           agg_type: sum
         direction: -1
         threshold: 10
@@ -71,7 +66,6 @@ tests:
         targets: image_pushes
         metric_of_interest: elapsed_time
         agg:
-          value: latency
           agg_type: max
         direction: 1
         threshold: 10

--- a/examples/quay-load-test-stable.yaml
+++ b/examples/quay-load-test-stable.yaml
@@ -2403,7 +2403,6 @@ tests:
         targets: image_pulls
         metric_of_interest: success_count
         agg:
-          value: success
           agg_type: sum
         direction: -1
         threshold: 10
@@ -2413,7 +2412,6 @@ tests:
         targets: image_pulls
         metric_of_interest: failure_count
         agg:
-          value: failure
           agg_type: sum
         direction: -1
         threshold: 10
@@ -2423,7 +2421,6 @@ tests:
         targets: image_pulls
         metric_of_interest: elapsed_time
         agg:
-          value: latency
           agg_type: max
         direction: 1
         threshold: 10
@@ -2434,7 +2431,6 @@ tests:
         targets: image_pushes
         metric_of_interest: success_count
         agg:
-          value: success
           agg_type: sum
         direction: -1
         threshold: 10
@@ -2444,7 +2440,6 @@ tests:
         targets: image_pushes
         metric_of_interest: failure_count
         agg:
-          value: failure
           agg_type: sum
         direction: -1
         threshold: 10
@@ -2454,7 +2449,6 @@ tests:
         targets: image_pushes
         metric_of_interest: elapsed_time
         agg:
-          value: latency
           agg_type: max
         direction: 1
         threshold: 10

--- a/examples/readout-control-plane-cdv2.yaml
+++ b/examples/readout-control-plane-cdv2.yaml
@@ -28,13 +28,11 @@ tests:
         metricName.keyword: cpu-masters
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: Maximum_aggregated_memory_usage_masters
         metricName.keyword: max-memory-sum-masters
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
 
   - name: cluster-density-v2-120nodes
@@ -64,13 +62,11 @@ tests:
         metricName.keyword: cpu-masters
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: Maximum_aggregated_memory_usage_masters
         metricName.keyword: max-memory-sum-masters
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
 
   - name: cluster-density-v2-249nodes
@@ -100,13 +96,11 @@ tests:
         metricName.keyword: cpu-masters
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: Maximum_aggregated_memory_usage_masters
         metricName.keyword: max-memory-sum-masters
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
 
   - name: cdv2-kube-apiserver-etcd-249nodes
@@ -136,25 +130,21 @@ tests:
         metricName.keyword: cpu-kube-apiserver
         metric_of_interest: value
         agg:
-          value: kube_apiserver
           agg_type: avg
       - name: Max_Aggregated_RSS_Usage_kube-apiserver
         metricName.keyword: max-memory-sum-kube-apiserver
         metric_of_interest: value
         agg:
-          value: kube_apiserver
           agg_type: avg
       - name: CPU_Usage_etcd
         metricName.keyword: cpu-etcd
         metric_of_interest: value
         agg:
-          value: etcd
           agg_type: avg
       - name: Max_Aggregated_RSS_Usage_etcd
         metricName.keyword: max-memory-etcd
         metric_of_interest: value
         agg:
-          value: etcd
           agg_type: avg
 
   - name: cd-v2-controller-manager-249nodes
@@ -184,20 +174,17 @@ tests:
         metricName.keyword: cpu-kube-controller-manager
         metric_of_interest: value
         agg:
-          value: kube_controller_manager
           agg_type: avg
       - name: Max_Aggregated_RSS_Usage
         metricName.keyword: max-memory-sum-kube-controller-manager
         metric_of_interest: value
         agg:
-          value: kube_controller_manager
           agg_type: avg
       - name: Read_Only_API_request_P99_latency
         metricName.keyword: avg-ro-apicalls-latency
         labels.scope.keyword: resource
         metric_of_interest: value
         agg:
-          value: resource_scoped
           agg_type: avg
 
   - name: cd-v2-api-request-latency-249nodes
@@ -228,20 +215,17 @@ tests:
         labels.scope.keyword: namespace
         metric_of_interest: value
         agg:
-          value: namespace_scoped
           agg_type: avg
       - name: Read_Only_API_request_P99_latency_cluster
         metricName.keyword: avg-ro-apicalls-latency
         labels.scope.keyword: cluster
         metric_of_interest: value
         agg:
-          value: cluster_scoped
           agg_type: avg
       - name: Read_Only_API_request_P99_latency_avg
         metricName.keyword: avg-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
 
   - name: cd-v2-etcd-latency-249nodes
@@ -271,17 +255,14 @@ tests:
         metricName.keyword: 99thEtcdDiskWalFsync
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: 99th_Backend_I/O
         metricName.keyword: 99thEtcdDiskBackendCommit
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: 99th_Roundtrip
         metricName.keyword: 99thEtcdRoundTripTime
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg

--- a/examples/readout-control-plane-node-density.yaml
+++ b/examples/readout-control-plane-node-density.yaml
@@ -28,25 +28,21 @@ tests:
         metricName.keyword: cpu-kubelet
         metric_of_interest: value
         agg:
-          value: cpu-kubelet
           agg_type: avg
       - name: max-memory-kubelet
         metricName.keyword: max-memory-kubelet
         metric_of_interest: value
         agg:
-          value: max-memory-kubelet
           agg_type: avg
       - name: cpu-crio
         metricName.keyword: cpu-crio
         metric_of_interest: value
         agg:
-          value: cpu-crio
           agg_type: avg
       - name: max-memory-crio
         metricName.keyword: max-memory-crio
         metric_of_interest: value
         agg:
-          value: max-memory-crio
           agg_type: avg
 
   - name: node-density-24nodes
@@ -77,7 +73,6 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg
 
   - name: node-density-120nodes
@@ -108,7 +103,6 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg
 
   - name: node-density-249nodes
@@ -139,7 +133,6 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg
 
   - name: node-density-cni-24nodes
@@ -170,7 +163,6 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg
 
   - name: node-density-cni-120nodes
@@ -201,7 +193,6 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg
 
   - name: node-density-cni-249nodes
@@ -232,5 +223,4 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg

--- a/examples/readout-ingress.yaml
+++ b/examples/readout-ingress.yaml
@@ -25,54 +25,46 @@ tests:
         config.termination: passthrough
         metric_of_interest: total_avg_rps
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: passthrough_avg_lat
         config.termination: passthrough
         metric_of_interest: avg_lat_us
         agg:
-          value: avg_lat_us
           agg_type: avg
 
       - name: http_avg_rps
         config.termination: http
         metric_of_interest: total_avg_rps
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: http_avg_lat
         config.termination: http
         metric_of_interest: avg_lat_us
         agg:
-          value: avg_lat_us
           agg_type: avg
 
       - name: reencrypt_avg_rps
         config.termination: reencrypt
         metric_of_interest: total_avg_rps
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: reencrypt_avg_lat
         config.termination: reencrypt
         metric_of_interest: avg_lat_us
         agg:
-          value: avg_lat_us
           agg_type: avg
 
       - name: edge_avg_rps
         config.termination: edge
         metric_of_interest: total_avg_rps
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: edge_avg_lat
         config.termination: edge
         metric_of_interest: avg_lat_us
         agg:
-          value: avg_lat_us
           agg_type: avg

--- a/examples/readout-netperf-tcp.yaml
+++ b/examples/readout-netperf-tcp.yaml
@@ -33,7 +33,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: n2n-tput-64-2p
@@ -45,7 +44,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: n2n-tput-1024-1p
@@ -57,7 +55,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
       - name: n2n-tput-1024-2p
         parallelism: 2
@@ -68,7 +65,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: n2n-tput-4096-1p
@@ -80,7 +76,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: n2n-tput-4096-2p
@@ -92,7 +87,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: n2n-tput-8192-1p
@@ -104,7 +98,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: n2n-tput-8192-2p
@@ -116,7 +109,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: n2n-ltcy-1024-1p
@@ -128,7 +120,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
 
       - name: n2n-ltcy-1024-2p
@@ -140,7 +131,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
           # p2p
       - name: p2p-tput-64-1p
@@ -152,7 +142,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2p-tput-64-2p
@@ -164,7 +153,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2p-tput-1024-1p
@@ -176,7 +164,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
       - name: p2p-tput-1024-2p
         parallelism: 2
@@ -187,7 +174,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2p-tput-4096-1p
@@ -199,7 +185,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2p-tput-4096-2p
@@ -211,7 +196,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2p-tput-8192-1p
@@ -223,7 +207,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2p-tput-8192-2p
@@ -235,7 +218,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2p-ltcy-1024-1p
@@ -247,7 +229,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
 
       - name: p2p-ltcy-1024-2p
@@ -259,7 +240,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
           # p2s
       - name: p2s-tput-64-1p
@@ -272,7 +252,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2s-tput-1024-1p
@@ -285,7 +264,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2s-tput-4096-1p
@@ -298,7 +276,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2s-tput-8192-1p
@@ -311,7 +288,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: p2s-ltcy-1024-1p
@@ -324,5 +300,4 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg

--- a/examples/rhoso/rhoso-barbican.yaml
+++ b/examples/rhoso/rhoso-barbican.yaml
@@ -30,7 +30,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -43,7 +42,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -56,7 +54,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -69,7 +66,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -82,7 +78,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -95,7 +90,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -108,7 +102,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95

--- a/examples/rhoso/rhoso-cinder.yaml
+++ b/examples/rhoso/rhoso-cinder.yaml
@@ -30,7 +30,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -43,7 +42,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -56,7 +54,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -69,7 +66,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -82,7 +78,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -95,7 +90,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95

--- a/examples/rhoso/rhoso-glance.yaml
+++ b/examples/rhoso/rhoso-glance.yaml
@@ -30,7 +30,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95

--- a/examples/rhoso/rhoso-keystone.yaml
+++ b/examples/rhoso/rhoso-keystone.yaml
@@ -30,7 +30,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -43,7 +42,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -56,7 +54,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -69,7 +66,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -82,7 +78,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -95,7 +90,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -108,7 +102,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95

--- a/examples/rhoso/rhoso-neutron.yaml
+++ b/examples/rhoso/rhoso-neutron.yaml
@@ -30,7 +30,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -43,7 +42,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -56,7 +54,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -69,7 +66,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -82,7 +78,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -95,7 +90,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -108,7 +102,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -121,7 +114,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -134,7 +126,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -147,7 +138,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -160,7 +150,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -173,7 +162,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -186,7 +174,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -199,7 +186,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -212,7 +198,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -225,7 +210,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -238,7 +222,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -251,7 +234,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -264,7 +246,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -277,7 +258,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -290,7 +270,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -303,7 +282,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -316,7 +294,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95

--- a/examples/rhoso/rhoso-nova.yaml
+++ b/examples/rhoso/rhoso-nova.yaml
@@ -30,7 +30,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -43,7 +42,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -56,7 +54,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -69,7 +66,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -82,7 +78,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -95,7 +90,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -108,7 +102,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -121,7 +114,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -134,7 +126,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -147,7 +138,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -160,7 +150,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -173,7 +162,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -186,7 +174,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -199,7 +186,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -212,7 +198,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -225,7 +210,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95

--- a/examples/rhoso/rhoso-octavia.yaml
+++ b/examples/rhoso/rhoso-octavia.yaml
@@ -30,7 +30,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -43,7 +42,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95

--- a/examples/rhoso/rhoso-swift.yaml
+++ b/examples/rhoso/rhoso-swift.yaml
@@ -30,7 +30,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -43,7 +42,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -56,7 +54,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -69,7 +66,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -82,7 +78,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95
@@ -95,7 +90,6 @@ tests:
         doc_type: result
         metric_of_interest: raw
         agg:
-          value: duration
           agg_type: percentiles
           percents: [95]
           target_percentile: 95

--- a/examples/servicemesh-ingress.yaml
+++ b/examples/servicemesh-ingress.yaml
@@ -28,7 +28,6 @@ tests:
         not:
           config.requestRate: 5000
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: http_avg_cpu_usage_ingress_gateway_pods
@@ -37,7 +36,6 @@ tests:
         not:
           config.requestRate: 5000
         agg:
-          value: infra_metrics.avg_cpu_usage_ingress_gateway_pods
           agg_type: avg
 
       - name: http_avg_lat
@@ -45,7 +43,6 @@ tests:
         config.requestRate: 5000
         metric_of_interest: avg_lat_us
         agg:
-          value: avg_lat_us
           agg_type: avg
 
       - name: edge_avg_rps
@@ -54,7 +51,6 @@ tests:
         not:
           config.requestRate: 5000
         agg:
-          value: total_avg_rps
           agg_type: avg
 
       - name: edge_avg_cpu_usage_ingress_gateway_pods
@@ -63,7 +59,6 @@ tests:
         not:
           config.requestRate: 5000
         agg:
-          value: infra_metrics.avg_cpu_usage_ingress_gateway_pods
           agg_type: avg
 
       - name: edge_avg_lat
@@ -71,5 +66,4 @@ tests:
         config.requestRate: 5000
         metric_of_interest: avg_lat_us
         agg:
-          value: avg_lat_us
           agg_type: avg

--- a/examples/servicemesh-netperf-tcp.yaml
+++ b/examples/servicemesh-netperf-tcp.yaml
@@ -33,7 +33,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: throughput_1024_1p
@@ -46,7 +45,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: throughput_8192_1p
@@ -59,7 +57,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: throughput_64_2p
@@ -72,7 +69,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: throughput_1024_2p
@@ -85,7 +81,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: throughput_8192_2p
@@ -98,7 +93,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: throughput_64_4p
@@ -111,7 +105,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: throughput_1024_4p
@@ -124,7 +117,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       - name: throughput_8192_4p
@@ -137,7 +129,6 @@ tests:
         acrossAZ: false
         metric_of_interest: throughput
         agg:
-          value: throughput
           agg_type: avg
 
       # latency tests
@@ -151,7 +142,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
 
       - name: latency_1024_1p
@@ -164,7 +154,6 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg
 
       - name: latency_8192_1p
@@ -177,5 +166,4 @@ tests:
         acrossAZ: false
         metric_of_interest: latency
         agg:
-          value: latency
           agg_type: avg

--- a/examples/small-rosa-control-plane-node-density.yaml
+++ b/examples/small-rosa-control-plane-node-density.yaml
@@ -26,25 +26,21 @@ tests:
         metricName.keyword: cpu-kubelet
         metric_of_interest: value
         agg:
-          value: cpu-kubelet
           agg_type: avg
       - name: max-memory-kubelet
         metricName.keyword: max-memory-kubelet
         metric_of_interest: value
         agg:
-          value: max-memory-kubelet
           agg_type: avg
       - name: cpu-crio
         metricName.keyword: cpu-crio
         metric_of_interest: value
         agg:
-          value: cpu-crio
           agg_type: avg
       - name: max-memory-crio
         metricName.keyword: max-memory-crio
         metric_of_interest: value
         agg:
-          value: max-memory-crio
           agg_type: avg
 
   - name: node-density-24nodes
@@ -75,7 +71,6 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg
 
   - name: node-density-120nodes
@@ -106,7 +101,6 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg
 
   - name: node-density-cni-24nodes
@@ -137,7 +131,6 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg
 
   - name: node-density-cni-120nodes
@@ -168,5 +161,4 @@ tests:
         quantileName.keyword: Ready
         metric_of_interest: P99
         agg:
-          value: P99
           agg_type: avg

--- a/examples/small-scale-cluster-density-report.yaml
+++ b/examples/small-scale-cluster-density-report.yaml
@@ -33,106 +33,89 @@ tests:
         metricName.keyword: cpu-masters
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: Maximum_aggregated_memory_usage_masters
         metricName.keyword: max-memory-sum-masters
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: CPU_Usage_kube-apiserver
         metricName.keyword: cpu-kube-apiserver
         metric_of_interest: value
         agg:
-          value: kube_apiserver
           agg_type: avg
       - name: Max_Aggregated_RSS_Usage_kube-apiserver
         metricName.keyword: max-memory-sum-kube-apiserver
         metric_of_interest: value
         agg:
-          value: kube_apiserver
           agg_type: avg
       - name: CPU_Usage_etcd
         metricName.keyword: cpu-etcd
         metric_of_interest: value
         agg:
-          value: etcd
           agg_type: avg
       - name: Max_Aggregated_RSS_Usage_etcd
         metricName.keyword: max-memory-etcd
         metric_of_interest: value
         agg:
-          value: etcd
           agg_type: avg
       - name: Avg_Read_Only_API_request_P99_latency_namespace_scoped
         metricName.keyword: avg-ro-apicalls-latency
         labels.scope.keyword: namespace
         metric_of_interest: value
         agg:
-          value: namespace_scoped
           agg_type: avg
       - name: Max_Read_Only_API_request_P99_latency_namespace_scoped
         metricName.keyword: max-ro-apicalls-latency
         labels.scope.keyword: namespace
         metric_of_interest: value
         agg:
-          value: namespace_scoped
           agg_type: avg
       - name: Avg_Read_Only_API_request_P99_latency_cluster_scoped
         metricName.keyword: avg-ro-apicalls-latency
         labels.scope.keyword: cluster
         metric_of_interest: value
         agg:
-          value: cluster_scoped
           agg_type: avg
       - name: Max_Read_Only_API_request_P99_latency_cluster_scoped
         metricName.keyword: max-ro-apicalls-latency
         labels.scope.keyword: cluster
         metric_of_interest: value
         agg:
-          value: cluster_scoped
           agg_type: avg
       - name: Avg_Mutating_API_request_P99_latency
         metricName.keyword: avg-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: Max_Mutating_API_request_P99_latency
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: 99th_WAL_fsync
         metricName.keyword: 99thEtcdDiskWalFsync
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: 99th_Backend_I/O
         metricName.keyword: 99thEtcdDiskBackendCommit
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: 99th_Roundtrip
         metricName.keyword: 99thEtcdRoundTripTime
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: cpu_ovn_control_plane
         metricName.keyword: cpu-ovn-control-plane
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
       - name: cpu_ovnkube_node
         metricName.keyword: cpu-ovnkube-node
         metric_of_interest: value
         agg:
-          value: avg
           agg_type: avg
 

--- a/examples/small-scale-cluster-density.yaml
+++ b/examples/small-scale-cluster-density.yaml
@@ -29,7 +29,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
 
       - name: ovnCPU
@@ -37,7 +36,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
 
       - name: etcdCPU
@@ -45,14 +43,12 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
 
       - name: etcdDisk
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
 
       - name: ovsCPU-irate-all
@@ -60,7 +56,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -70,7 +65,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         direction: 1
         threshold: 10
@@ -80,7 +74,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         direction: 1
         threshold: 10
@@ -90,7 +83,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/small-scale-node-density-cni.yaml
+++ b/examples/small-scale-node-density-cni.yaml
@@ -35,7 +35,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -47,7 +46,6 @@ tests:
         labels.namespace.keyword: openshift-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -59,7 +57,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -71,7 +68,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -82,7 +78,6 @@ tests:
         metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
         metric_of_interest: value
         agg:
-          value: duration
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -95,7 +90,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -105,7 +99,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -117,7 +110,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -130,7 +122,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -143,7 +134,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -156,7 +146,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -169,7 +158,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -182,7 +170,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -194,7 +181,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -206,7 +192,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -218,7 +203,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -230,7 +214,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -243,7 +226,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -256,7 +238,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -269,7 +250,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -282,7 +262,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -295,7 +274,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/small-scale-node-density.yaml
+++ b/examples/small-scale-node-density.yaml
@@ -44,7 +44,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -56,7 +55,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -68,7 +66,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -81,7 +78,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/small-scale-udn-l2.yaml
+++ b/examples/small-scale-udn-l2.yaml
@@ -39,7 +39,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -52,7 +51,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -66,7 +64,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -80,7 +77,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -94,7 +90,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -108,7 +103,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -122,7 +116,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -135,7 +128,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -148,7 +140,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -161,7 +152,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -174,7 +164,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -188,7 +177,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -202,7 +190,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -216,7 +203,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -230,7 +216,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -244,7 +229,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/small-scale-udn-l3.yaml
+++ b/examples/small-scale-udn-l3.yaml
@@ -38,7 +38,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -51,7 +50,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -65,7 +63,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -79,7 +76,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -93,7 +89,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -107,7 +102,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -121,7 +115,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -134,7 +127,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -147,7 +139,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -159,7 +150,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -172,7 +162,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -186,7 +175,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -200,7 +188,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -214,7 +201,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -228,7 +214,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -242,7 +227,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/trt-external-payload-cluster-density-percentiles.yaml
+++ b/examples/trt-external-payload-cluster-density-percentiles.yaml
@@ -22,7 +22,6 @@ tests:
         metricName.keyword: podLatencyMeasurement
         metric_of_interest: containersReadyLatency
         agg:
-          value: cpu
           agg_type: percentiles
           percents: [10, 25, 50, 90, 95]
         not:
@@ -38,7 +37,6 @@ tests:
         labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: percentiles
           percents: [10, 25, 50, 90, 95]
         labels:

--- a/examples/trt-external-payload-cluster-density.yaml
+++ b/examples/trt-external-payload-cluster-density.yaml
@@ -37,7 +37,6 @@ tests:
         labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -50,7 +49,6 @@ tests:
         labels.container.keyword: kube-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -63,7 +61,6 @@ tests:
         labels.container.keyword: prometheus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -75,7 +72,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -88,7 +84,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -101,7 +96,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -114,7 +108,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -127,7 +120,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -140,7 +132,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -153,7 +144,6 @@ tests:
         labels.container.keyword: etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -166,7 +156,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -176,7 +165,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -188,7 +176,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -200,7 +187,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -212,7 +198,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/trt-external-payload-cpu.yaml
+++ b/examples/trt-external-payload-cpu.yaml
@@ -25,7 +25,6 @@ tests:
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -34,7 +33,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -43,7 +41,6 @@ tests:
         labels.namespace.keyword: openshift-cluster-csi-drivers
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -53,7 +50,6 @@ tests:
         labels.container.keyword: kube-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -62,7 +58,6 @@ tests:
         labels.namespace.keyword: openshift-machine-config-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -71,7 +66,6 @@ tests:
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -80,7 +74,6 @@ tests:
         labels.namespace.keyword: openshift-e2e-loki
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -89,7 +82,6 @@ tests:
         labels.namespace.keyword: openshift-dns
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -98,7 +90,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -107,7 +98,6 @@ tests:
         labels.namespace.keyword: openshift-machine-api
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -116,7 +106,6 @@ tests:
         labels.namespace.keyword: openshift-kube-controller-manager
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -125,7 +114,6 @@ tests:
         labels.namespace.keyword: openshift-insights
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -134,7 +122,6 @@ tests:
         labels.namespace.keyword: openshift-kube-scheduler
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -143,7 +130,6 @@ tests:
         labels.namespace.keyword: openshift-cluster-node-tuning-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -152,7 +138,6 @@ tests:
         labels.namespace.keyword: openshift-network-diagnostics
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -161,7 +146,6 @@ tests:
         labels.namespace.keyword: openshift-image-registry
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -170,7 +154,6 @@ tests:
         labels.namespace.keyword: openshift-operator-lifecycle-manager
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -179,7 +162,6 @@ tests:
         labels.namespace.keyword: openshift-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -188,7 +170,6 @@ tests:
         labels.namespace.keyword: openshift-network-node-identity
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -197,7 +178,6 @@ tests:
         labels.namespace.keyword: openshift-network-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -206,7 +186,6 @@ tests:
         labels.namespace.keyword: openshift-marketplace
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -215,7 +194,6 @@ tests:
         labels.namespace.keyword: kube-system
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -224,7 +202,6 @@ tests:
         labels.namespace.keyword: openshift-cluster-storage-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -233,7 +210,6 @@ tests:
         labels.namespace.keyword: openshift-console
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -242,7 +218,6 @@ tests:
         labels.namespace.keyword: openshift-cloud-credential-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -251,7 +226,6 @@ tests:
         labels.namespace.keyword: openshift-ingress-canary
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -260,7 +234,6 @@ tests:
         labels.namespace.keyword: openshift-cloud-controller-manager-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -269,7 +242,6 @@ tests:
         labels.namespace.keyword: openshift-authentication
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -278,7 +250,6 @@ tests:
         labels.namespace.keyword: openshift-route-controller-manager
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -287,7 +258,6 @@ tests:
         labels.namespace.keyword: openshift-cluster-samples-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -296,7 +266,6 @@ tests:
         labels.namespace.keyword: openshift-dns-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -305,7 +274,6 @@ tests:
         labels.namespace.keyword: openshift-ingress-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -314,7 +282,6 @@ tests:
         labels.namespace.keyword: openshift-cloud-controller-manager
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -323,7 +290,6 @@ tests:
         labels.namespace.keyword: openshift-cluster-machine-approver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -332,7 +298,6 @@ tests:
         labels.namespace.keyword: openshift-kube-storage-version-migrator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -341,7 +306,6 @@ tests:
         labels.namespace.keyword: openshift-authentication-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -350,7 +314,6 @@ tests:
         labels.namespace.keyword: openshift-oauth-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -359,7 +322,6 @@ tests:
         labels.namespace.keyword: openshift-controller-manager
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -368,7 +330,6 @@ tests:
         labels.namespace.keyword: openshift-ingress
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -377,7 +338,6 @@ tests:
         labels.namespace.keyword: openshift-kube-scheduler-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -386,7 +346,6 @@ tests:
         labels.namespace.keyword: openshift-operator-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -395,7 +354,6 @@ tests:
         labels.namespace.keyword: openshift-apiserver-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -404,7 +362,6 @@ tests:
         labels.namespace.keyword: openshift-cluster-olm-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -413,7 +370,6 @@ tests:
         labels.namespace.keyword: openshift-controller-manager-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -422,7 +378,6 @@ tests:
         labels.namespace.keyword: openshift-etcd-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -431,7 +386,6 @@ tests:
         labels.namespace.keyword: openshift-kube-apiserver-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -440,7 +394,6 @@ tests:
         labels.namespace.keyword: openshift-cloud-network-config-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -449,7 +402,6 @@ tests:
         labels.namespace.keyword: openshift-cluster-version
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -458,7 +410,6 @@ tests:
         labels.namespace.keyword: openshift-kube-controller-manager-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -467,7 +418,6 @@ tests:
         labels.namespace.keyword: openshift-service-ca-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -476,7 +426,6 @@ tests:
         labels.namespace.keyword: openshift-console-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -485,7 +434,6 @@ tests:
         labels.namespace.keyword: openshift-service-ca
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -494,7 +442,6 @@ tests:
         labels.namespace.keyword: openshift-catalogd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -503,7 +450,6 @@ tests:
         labels.namespace.keyword: openshift-config-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -512,7 +458,6 @@ tests:
         labels.namespace.keyword: openshift-kube-storage-version-migrator-operator
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -521,7 +466,6 @@ tests:
         labels.namespace.keyword: openshift-network-console
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -530,7 +474,6 @@ tests:
         labels.namespace.keyword: default
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/trt-external-payload-crd-scale.yaml
+++ b/examples/trt-external-payload-crd-scale.yaml
@@ -26,7 +26,6 @@ tests:
         labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -39,7 +38,6 @@ tests:
         labels.container.keyword: etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"

--- a/examples/trt-external-payload-node-density-cni.yaml
+++ b/examples/trt-external-payload-node-density-cni.yaml
@@ -48,7 +48,6 @@ tests:
         labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -61,7 +60,6 @@ tests:
         labels.container.keyword: kube-multus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: multus]"
@@ -74,7 +72,6 @@ tests:
         labels.container.keyword: prometheus
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: monitoring]"
@@ -87,7 +84,6 @@ tests:
         labels.container.keyword: etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -100,7 +96,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10
@@ -109,7 +104,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -121,7 +115,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -134,7 +127,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -147,7 +139,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -160,7 +151,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -173,7 +163,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -186,7 +175,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -198,7 +186,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -210,7 +197,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -222,7 +208,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -234,7 +219,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -247,7 +231,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -260,7 +243,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -273,7 +255,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -286,7 +267,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -299,7 +279,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/trt-external-payload-node-density-inherits.yaml
+++ b/examples/trt-external-payload-node-density-inherits.yaml
@@ -21,7 +21,6 @@ tests:
         labels.container.keyword: etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -34,7 +33,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 5

--- a/examples/trt-external-payload-node-density.yaml
+++ b/examples/trt-external-payload-node-density.yaml
@@ -46,7 +46,6 @@ tests:
         labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: kube-apiserver]"
@@ -58,7 +57,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -71,7 +69,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -84,7 +81,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -97,7 +93,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -110,7 +105,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -123,7 +117,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -136,7 +129,6 @@ tests:
         labels.container.keyword: etcd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: etcd]"
@@ -149,7 +141,6 @@ tests:
         labels:
           - "[Jira: Node]"
         agg:
-          value: cpu
           agg_type: avg
         direction: 1
         threshold: 10

--- a/examples/trt-external-payload-udn-l2.yaml
+++ b/examples/trt-external-payload-udn-l2.yaml
@@ -37,7 +37,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -50,7 +49,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -64,7 +62,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -78,7 +75,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -92,7 +88,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -106,7 +101,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -120,7 +114,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -133,7 +126,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -146,7 +138,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -159,7 +150,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -172,7 +162,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -186,7 +175,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -200,7 +188,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -214,7 +201,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -228,7 +214,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -242,7 +227,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/examples/trt-external-payload-udn-l3.yaml
+++ b/examples/trt-external-payload-udn-l3.yaml
@@ -37,7 +37,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -50,7 +49,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -64,7 +62,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -78,7 +75,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -92,7 +88,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -106,7 +101,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -120,7 +114,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: cpu
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -133,7 +126,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -146,7 +138,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: max
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -159,7 +150,6 @@ tests:
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -172,7 +162,6 @@ tests:
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -186,7 +175,6 @@ tests:
         labels.container.keyword: ovn-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -200,7 +188,6 @@ tests:
         labels.container.keyword: northd
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -214,7 +201,6 @@ tests:
         labels.container.keyword: nbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -228,7 +214,6 @@ tests:
         labels.container.keyword: sbdb
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"
@@ -242,7 +227,6 @@ tests:
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
         agg:
-          value: mem
           agg_type: avg
         labels:
           - "[Jira: Networking / ovn-kubernetes]"

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -340,7 +340,7 @@ class Matcher:
             .extra(size=0)
             .sort({timestamp_field: {"order": "desc"}})
         )
-        metric_of_interest = metric["metric_of_interest"]
+        metric_of_interest = metrics["metric_of_interest"]
         agg_type = metrics["agg"]["agg_type"]
         uuid_bucket = search.aggs.bucket("uuid", "terms", field=self.uuid_field+".keyword", size=len(uuids))
         uuid_bucket.metric("time", "avg", field=timestamp_field)

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -340,7 +340,7 @@ class Matcher:
             .extra(size=0)
             .sort({timestamp_field: {"order": "desc"}})
         )
-        agg_value = metrics["agg"]["value"]
+        metric_of_interest = metric["metric_of_interest"]
         agg_type = metrics["agg"]["agg_type"]
         uuid_bucket = search.aggs.bucket("uuid", "terms", field=self.uuid_field+".keyword", size=len(uuids))
         uuid_bucket.metric("time", "avg", field=timestamp_field)
@@ -349,26 +349,25 @@ class Matcher:
             # Get the percentile values from config (default to [50, 95, 99])
             percents = metrics["agg"].get("percents", [50, 95, 99])
             uuid_bucket.metric(
-                agg_value, "percentiles",
+                metric_of_interest, "percentiles",
                 field=metrics["metric_of_interest"],
                 percents=percents
             )
         elif agg_type == "count":
             # Count aggregation uses value_count in OpenSearch
-            uuid_bucket.metric(agg_value, "value_count", field=metrics["metric_of_interest"])
+            uuid_bucket.metric(metric_of_interest, "value_count", field=metrics["metric_of_interest"])
         else:
             # Standard aggregations (sum, avg, max, min)
-            uuid_bucket.metric(agg_value, agg_type, field=metrics["metric_of_interest"])
+            uuid_bucket.metric(metric_of_interest, agg_type, field=metrics["metric_of_interest"])
         result = search.execute()
         self.logger.info("Executing aggregated query for metric %s against index %s",
             metrics["name"], self.index)
         self.logger.debug("Executing query \r\n%s", search.to_dict())
-        data = self.parse_agg_results(result, agg_value, agg_type, timestamp_field, metrics)
+        data = self.parse_agg_results(result, agg_type, timestamp_field, metrics)
         return data
 
     def parse_agg_results(
         self, data: Dict[Any, Any],
-        agg_value: str,
         agg_type: str,
         timestamp_field: str = "timestamp",
         metrics: Dict[str, Any] = None
@@ -376,7 +375,6 @@ class Matcher:
         """parse out CPU data from kube-burner query
         Args:
             data (dict): Aggregated data from Elasticsearch DSL query
-            agg_value (str): Aggregation value field name
             agg_type (str): Aggregation type (e.g., 'avg', 'sum', 'percentiles', etc.)
             timestamp_field (str): Timestamp field name
             metrics (dict): Metrics configuration (needed for percentile target)
@@ -386,7 +384,7 @@ class Matcher:
         res = []
         if "aggregations" not in data:
             return res
-
+        metric_of_interest = metrics["metric_of_interest"]
         uuids = data.aggregations.uuid.buckets
 
         for uuid in uuids:
@@ -394,24 +392,24 @@ class Matcher:
                 self.uuid_field: uuid.key,
                 timestamp_field: uuid.time.value_as_string,
             }
-            value_key = agg_value + "_" + agg_type
+            value_key = metric_of_interest + "_" + agg_type
             if agg_type == "percentiles":
                 self.logger.info("AC agg_type == percentiles")
-                percentile_dict = uuid.get(agg_value).to_dict().get("values", {})
+                percentile_dict = uuid.get(metric_of_interest).to_dict().get("values", {})
                 if metrics and "agg" in metrics and "target_percentile" in metrics["agg"]:
                     target_percentile = float(metrics["agg"]["target_percentile"])
                     percentile_key = str(target_percentile)
                     self.logger.info("found target_percentile %s", target_percentile)
-                    value_key = agg_value + "_" + agg_type + "_" + percentile_key
+                    value_key = metric_of_interest + "_" + agg_type + "_" + percentile_key
                     data[value_key] = percentile_dict.get(percentile_key)
                 else:
                     self.logger.info("no target_percentile found, using all percentiles")
                     for key, val in percentile_dict.items():
                         self.logger.info("percentile_values value %s", key)
-                        data[agg_value + "_" + agg_type + "_" + str(key)] = val
+                        data[metric_of_interest + "_" + agg_type + "_" + str(key)] = val
             else:
                 # Standard single-value aggregations
-                data[value_key] = uuid.get(agg_value).value
+                data[value_key] = uuid.get(metric_of_interest).value
             res.append(data)
         return res
 

--- a/orion/tests/test_matcher.py
+++ b/orion/tests/test_matcher.py
@@ -460,20 +460,20 @@ def test_get_results_with_exists_fields_and_timestamp_field(request,
                             {
                                 "key": "uuid1",
                                 "time": {"value_as_string": "2024-02-09T12:00:00"},
-                                "cpu": {"value": 42}
+                                "value": {"value": 42}
                             },
                             {
                                 "key": "uuid2",
                                 "time": {"value_as_string": "2024-02-09T13:00:00"},
-                                "cpu": {"value": 56}
+                                "value": {"value": 56}
                             },
                         ]
                     },
                 }
             },
             [
-                {"uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "cpu_avg": 42},
-                {"uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "cpu_avg": 56},
+                {"uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "value_avg": 42},
+                {"uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "value_avg": 56},
             ],
         ),
         # uuid_matcher_instance with values
@@ -494,20 +494,20 @@ def test_get_results_with_exists_fields_and_timestamp_field(request,
                             {
                                 "key": "uuid1",
                                 "time": {"value_as_string": "2024-02-09T12:00:00"},
-                                "cpu": {"value": 42}
+                                "value": {"value": 42}
                             },
                             {
                                 "key": "uuid2",
                                 "time": {"value_as_string": "2024-02-09T13:00:00"},
-                                "cpu": {"value": 56}
+                                "value": {"value": 56}
                             },
                         ]
                     },
                 }
             },
             [
-                {"run_uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "cpu_avg": 42},
-                {"run_uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "cpu_avg": 56},
+                {"run_uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "valu_avg": 42},
+                {"run_uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "valu_avg": 56},
             ],
         ),
         # matcher_instance with no agg values (empty uuid buckets)

--- a/orion/tests/test_matcher.py
+++ b/orion/tests/test_matcher.py
@@ -506,8 +506,8 @@ def test_get_results_with_exists_fields_and_timestamp_field(request,
                 }
             },
             [
-                {"run_uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "valu_avg": 42},
-                {"run_uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "valu_avg": 56},
+                {"run_uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "value_avg": 42},
+                {"run_uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "value_avg": 56},
             ],
         ),
         # matcher_instance with no agg values (empty uuid buckets)

--- a/orion/tests/test_matcher_aggregations.py
+++ b/orion/tests/test_matcher_aggregations.py
@@ -49,20 +49,20 @@ def uuid_matcher_instance():
                             {
                                 "key": "uuid1",
                                 "time": {"value_as_string": "2024-02-09T12:00:00"},
-                                "cpu": {"value": 42},
+                                "value": {"value": 42},
                             },
                             {
                                 "key": "uuid2",
                                 "time": {"value_as_string": "2024-02-09T13:00:00"},
-                                "cpu": {"value": 56},
+                                "value": {"value": 56},
                             },
                         ]
                     },
                 }
             },
             [
-                {"uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "cpu_avg": 42},
-                {"uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "cpu_avg": 56},
+                {"uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "value_avg": 42},
+                {"uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "value_avg": 56},
             ],
         ),
         # uuid_matcher_instance with values
@@ -83,20 +83,20 @@ def uuid_matcher_instance():
                             {
                                 "key": "uuid1",
                                 "time": {"value_as_string": "2024-02-09T12:00:00"},
-                                "cpu": {"value": 42},
+                                "value": {"value": 42},
                             },
                             {
                                 "key": "uuid2",
                                 "time": {"value_as_string": "2024-02-09T13:00:00"},
-                                "cpu": {"value": 56},
+                                "value": {"value": 56},
                             },
                         ]
                     },
                 }
             },
             [
-                {"run_uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "cpu_avg": 42},
-                {"run_uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "cpu_avg": 56},
+                {"run_uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "value_avg": 42},
+                {"run_uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "value_avg": 56},
             ],
         ),
         # matcher_instance with no agg values (empty uuid buckets)

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -113,7 +113,7 @@ class Utils:
         self.logger.info("process_aggregation_metric")
         aggregated_metric_data = match.get_agg_metric_query(uuids, metric, timestamp_field)
         self.logger.info("aggregated_metric_data %s", aggregated_metric_data)
-        aggregation_value = metric["agg"]["value"]
+        aggregation_value = metric["metric_of_interest"]
         aggregation_type = metric["agg"]["agg_type"]
 
         if aggregation_type == "percentiles":


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

This field is confusing and not actually necessary, it is used to provide a name to the the returned ES bucket metric, however, we can just use metric_of_interest instead with the same result


## Related Tickets & Documents

- Related Issue #
- Closes #

