### PR TITLE
chore: add copy of stackrox config

### DIFF
--- a/examples/stackrox-cluster-density.yaml
+++ b/examples/stackrox-cluster-density.yaml
@@ -1,7 +1,7 @@
 tests :
   - name : 24-node-scale-cdv2
-    index: {{ es_metadata_index }}
-    benchmarkIndex: {{ es_benchmark_index }}
+    index: "{{ es_metadata_index }}"
+    benchmarkIndex: "{{ es_benchmark_index }}"
     metadata:
       platform: AWS
       clusterType: self-managed
@@ -10,9 +10,9 @@ tests :
       workerNodesType: m6a.xlarge
       workerNodesCount: 24
       benchmark.keyword: cluster-density-v2
-      ocpVersion: {{ version }}
+      ocpVersion: "{{ version }}"
       networkType: OVNKubernetes
-      jobType: {{ jobtype | default('periodic') }}
+      jobType: "{{ jobtype | default('periodic') }}"
       not:
         stream: okd
 

--- a/examples/stackrox-cluster-density.yaml
+++ b/examples/stackrox-cluster-density.yaml
@@ -1,0 +1,133 @@
+tests :
+  - name : 24-node-scale-cdv2
+    index: {{ es_metadata_index }}
+    benchmarkIndex: {{ es_benchmark_index }}
+    metadata:
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6a.xlarge
+      masterNodesCount: 3
+      workerNodesType: m6a.xlarge
+      workerNodesCount: 24
+      benchmark.keyword: cluster-density-v2
+      ocpVersion: {{ version }}
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      not:
+        stream: okd
+
+    metrics :
+    - name: collector-cpu
+      metricName: stackrox_container_cpu
+      labels.container: collector
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: collector-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: collector
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg
+
+    - name: admission-cpu
+      metricName: stackrox_container_cpu
+      labels.container: admission-control
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: admission-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: admission-control
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg
+
+    - name: central-cpu
+      metricName: stackrox_container_cpu
+      labels.container: central
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: central-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: central
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg
+
+    - name: central-db-cpu
+      metricName: stackrox_container_cpu
+      labels.container: central-db
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: central-db-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: central-db
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg
+
+    - name: sensor-cpu
+      metricName: stackrox_container_cpu
+      labels.container: sensor
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: sensor-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: sensor
+      direction: 1
+      threshold: 5
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg

--- a/examples/stackrox-cluster-density.yaml
+++ b/examples/stackrox-cluster-density.yaml
@@ -1,5 +1,5 @@
-tests :
-  - name : 24-node-scale-cdv2
+tests:
+  - name: 24-node-scale-cdv2
     index: "{{ es_metadata_index }}"
     benchmarkIndex: "{{ es_benchmark_index }}"
     metadata:
@@ -16,118 +16,118 @@ tests :
       not:
         stream: okd
 
-    metrics :
-    - name: collector-cpu
-      metricName: stackrox_container_cpu
-      labels.container: collector
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: cpu
-        agg_type: avg
-    - name: collector-mem
-      metricName: stackrox_container_memory_working_set_bytes
-      labels.container: collector
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: mem
-        agg_type: avg
+    metrics:
+      - name: collector-cpu
+        metricName: stackrox_container_cpu
+        labels.container: collector
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: cpu
+          agg_type: avg
+      - name: collector-mem
+        metricName: stackrox_container_memory_working_set_bytes
+        labels.container: collector
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: mem
+          agg_type: avg
 
-    - name: admission-cpu
-      metricName: stackrox_container_cpu
-      labels.container: admission-control
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: cpu
-        agg_type: avg
-    - name: admission-mem
-      metricName: stackrox_container_memory_working_set_bytes
-      labels.container: admission-control
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: mem
-        agg_type: avg
+      - name: admission-cpu
+        metricName: stackrox_container_cpu
+        labels.container: admission-control
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: cpu
+          agg_type: avg
+      - name: admission-mem
+        metricName: stackrox_container_memory_working_set_bytes
+        labels.container: admission-control
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: mem
+          agg_type: avg
 
-    - name: central-cpu
-      metricName: stackrox_container_cpu
-      labels.container: central
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: cpu
-        agg_type: avg
-    - name: central-mem
-      metricName: stackrox_container_memory_working_set_bytes
-      labels.container: central
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: mem
-        agg_type: avg
+      - name: central-cpu
+        metricName: stackrox_container_cpu
+        labels.container: central
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: cpu
+          agg_type: avg
+      - name: central-mem
+        metricName: stackrox_container_memory_working_set_bytes
+        labels.container: central
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: mem
+          agg_type: avg
 
-    - name: central-db-cpu
-      metricName: stackrox_container_cpu
-      labels.container: central-db
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: cpu
-        agg_type: avg
-    - name: central-db-mem
-      metricName: stackrox_container_memory_working_set_bytes
-      labels.container: central-db
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: mem
-        agg_type: avg
+      - name: central-db-cpu
+        metricName: stackrox_container_cpu
+        labels.container: central-db
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: cpu
+          agg_type: avg
+      - name: central-db-mem
+        metricName: stackrox_container_memory_working_set_bytes
+        labels.container: central-db
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: mem
+          agg_type: avg
 
-    - name: sensor-cpu
-      metricName: stackrox_container_cpu
-      labels.container: sensor
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: cpu
-        agg_type: avg
-    - name: sensor-mem
-      metricName: stackrox_container_memory_working_set_bytes
-      labels.container: sensor
-      direction: 1
-      threshold: 5
-      metric_of_interest: value
-      not:
-        jobConfig.name: "garbage-collection"
-      agg:
-        value: mem
-        agg_type: avg
+      - name: sensor-cpu
+        metricName: stackrox_container_cpu
+        labels.container: sensor
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: cpu
+          agg_type: avg
+      - name: sensor-mem
+        metricName: stackrox_container_memory_working_set_bytes
+        labels.container: sensor
+        direction: 1
+        threshold: 5
+        metric_of_interest: value
+        not:
+          jobConfig.name: "garbage-collection"
+        agg:
+          value: mem
+          agg_type: avg


### PR DESCRIPTION
Add stackrox orion config to allow use from orion-mcp (reads configs from orion/examples/* in https://github.com/cloud-bulldozer/orion-mcp/blob/1845802124d079ec7ed73425362df346cc9d4cb8/orion_mcp.py#L49)

Copied from https://raw.githubusercontent.com/stackrox/stackrox/refs/heads/master/tests/performance/scale/config/orion-acs-cluster-density-v2.yml

## Related Tickets & Documents

- Related Issue #https://redhat.atlassian.net/browse/ROX-33793
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
none (config is in-use with orion in prow jobs, but not tested in orion-mcp yet)
