### PR TITLE
ack 4.22 ovnCPU-northd_avg regression

### DIFF
--- a/ack/all_ack.yaml
+++ b/ack/all_ack.yaml
@@ -318,6 +318,11 @@ ack:
     reason: Metric is back to normal trend
     version: '4.22'
     test: udn-density-pods
+  - uuid: bcee4a86-c0c9-4252-804c-462ba7c5a733
+    metric: ovnCPU-northd_avg
+    reason: Metric is back to normal trend
+    version: '4.22'
+    test: udn-density-pods
   # 120-node udn-density-l2
   - uuid: 77b0d861-ce3d-468c-b5c4-a557478ce452
     metric: ovsMemory-all_avg


### PR DESCRIPTION
Similar to https://github.com/cloud-bulldozer/orion/pull/343

Regression observed in https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.22-nightly-x86-udn-density-l3-24nodes/2042060247715024896/artifacts/udn-density-l3-24nodes/openshift-qe-orion-udn-density/build-log.txt