### PR TITLE
Orion version

### DIFF
--- a/main.py
+++ b/main.py
@@ -180,7 +180,8 @@ def main(**kwargs):
     report_value = kwargs.pop("report", None)
     if report_value:
         level = logging.DEBUG if kwargs["debug"] else logging.INFO
-        SingletonLogger(debug=level, name="Orion")
+        logger = SingletonLogger(debug=level, name="Orion")
+        logger.info("Orion version: %s", __version__)
         files = [f.strip() for f in report_value.split(",") if f.strip()]
         data = load_json_files(files)
         has_regression = generate_report(data)
@@ -195,7 +196,7 @@ def main(**kwargs):
     if kwargs['output_format'] == cnsts.JSON :
         level = logging.ERROR
     logger = SingletonLogger(debug=level, name="Orion")
-    logger.info("🏹 Starting Orion in command-line mode")
+    logger.info("🏹 Starting Orion (%s) in command-line mode", __version__)
 
     # Load config first (needed for auto-detection)
     kwargs["config"] = load_config(kwargs["config"], kwargs["input_vars"])


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Print the orion version along with the execution logs.

```
(orion) rsevilla@toolbx ~/labs/orion (main) $ orion --node-count true --config examples/trt-external-payload-udn-l2.yaml --lookback 15d --hunter-analyze  --no-default-ack  --display ""
2026-04-20 13:10:41,274 - Orion      - INFO - file: main.py - line: 199 - 🏹 Starting Orion (0.1.4.dev327+g020f22d29.d20260420) in command-line mode
blablabla
```