### PR TITLE
Add yamllint to test requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ pytest-cov==4.1.0
 pytest-random-order==1.1.0
 pylint==3.3.2
 google-yamlfmt==0.21.0
+yamllint==1.38.0


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

yamllint was missing as a dependency, so it would not be found in new installs.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
1. Create new venv
2. `pip install -r requirements-test.txt`
3. `make lint`