### PR TITLE
Standardize metric naming

### DIFF
--- a/ack/all_ack.yaml
+++ b/ack/all_ack.yaml
@@ -15,12 +15,12 @@ ack:
     version: '4.22'
     test: cluster-density-v2
   - uuid: 5c3c9245-b9e1-4849-86c8-34c31d81898a
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: Missing data in ES, indexing failures
     version: '4.22'
     test: cluster-density-v2
   - uuid: fe336609-b83f-4dc4-a878-d68f5e25018a
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: Missing data in ES, indexing failures
     version: '4.22'
     test: cluster-density-v2
@@ -30,7 +30,7 @@ ack:
     version: '4.22'
     test: cluster-density-v2
   - uuid: e023e975-ad9f-404a-907f-b0756d3f7473
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: cdv2 updated metrics profile https://github.com/kube-burner/kube-burner-ocp/pull/380
     version: '4.22'
     test: cluster-density-v2
@@ -42,7 +42,7 @@ ack:
     test: crd-scale
   # node-density
   - uuid: 679b905a-318c-4b8c-a630-4b2dcc394d25
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: CPU bumps due to unintentional change in deletion strategy
     version: '4.22'
     test: node-density
@@ -57,7 +57,7 @@ ack:
     version: '4.22'
     test: node-density
   - uuid: 70b8deb3-1ed4-4ca0-9bcf-c0839645920f
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: node-density too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density
@@ -82,18 +82,18 @@ ack:
     version: '4.22'
     test: node-density
   - uuid: 62c5ae7f-d522-4919-b806-e4ed23a4f1e1
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.22'
     test: node-density
   # node-density-cni
   - uuid: ade4d0f9-84d8-4edf-926a-4aa88ca14f61
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: Random CPU spike
     version: '4.22'
     test: node-density-cni
   - uuid: fdbe9f2c-6408-4c8f-82aa-aecccd0029ea
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: Old CPU spike
     version: '4.22'
     test: node-density-cni
@@ -103,12 +103,12 @@ ack:
     version: '4.22'
     test: node-density-cni
   - uuid: 6ca8825c-3a47-4f0f-9cfe-b4a45986bd37
-    metric: ovsCPU-Workers_avg
+    metric: ovsWorkersCPU_avg
     reason: https://issues.redhat.com/browse/OCPBUGS-74474
     version: '4.22'
     test: node-density-cni
   - uuid: 6ca8825c-3a47-4f0f-9cfe-b4a45986bd37
-    metric: ovnMem-ovncontroller_avg
+    metric: ovnControllerMemory_avg
     reason: https://issues.redhat.com/browse/OCPBUGS-74474
     version: '4.22'
     test: node-density-cni
@@ -128,7 +128,7 @@ ack:
     version: '4.22'
     test: node-density-cni
   - uuid: 4d0019c4-040a-47c4-bf83-c0142522ff68
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: Random CPU Spike
     version: '4.22'
     test: node-density-cni
@@ -148,37 +148,37 @@ ack:
     version: '4.22'
     test: node-density-cni
   - uuid: 9a5e24b6-b79c-445f-bf65-ed4fb828bf13
-    metric: ovsCPU-Workers_avg
+    metric: ovsWorkersCPU_avg
     reason: node-density-cni job is too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density-cni
   - uuid: 9a5e24b6-b79c-445f-bf65-ed4fb828bf13
-    metric: ovnkCPU-overall_avg
+    metric: ovnkCPU_avg
     reason: node-density-cni job is too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density-cni
   - uuid: 9a5e24b6-b79c-445f-bf65-ed4fb828bf13
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: node-density-cni job is too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density-cni
   - uuid: 9a5e24b6-b79c-445f-bf65-ed4fb828bf13
-    metric: ovnCPU-northd_avg
+    metric: northdCPU_avg
     reason: node-density-cni job is too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density-cni
   - uuid: 9a5e24b6-b79c-445f-bf65-ed4fb828bf13
-    metric: ovnCPU-nbdb_avg
+    metric: nbdbCPU_avg
     reason: node-density-cni job is too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density-cni
   - uuid: 9a5e24b6-b79c-445f-bf65-ed4fb828bf13
-    metric: ovnCPU-sbdb_avg
+    metric: sbdbCPU_avg
     reason: node-density-cni job is too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density-cni
   - uuid: 9a5e24b6-b79c-445f-bf65-ed4fb828bf13
-    metric: ovnCPU-ovnk-controller_avg
+    metric: ovnkControllerCPU_avg
     reason: node-density-cni job is too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density-cni
@@ -188,12 +188,12 @@ ack:
     version: '4.22'
     test: node-density-cni
   - uuid: 9a5e24b6-b79c-445f-bf65-ed4fb828bf13
-    metric: monitoringCPU_avg
+    metric: monitoringPromCPU_avg
     reason: node-density-cni job is too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density-cni
   - uuid: 9a5e24b6-b79c-445f-bf65-ed4fb828bf13
-    metric: ovsCPU-irate-all_avg
+    metric: ovsCPUAll_avg
     reason: node-density-cni job is too short and sensitive, to be addressed by https://github.com/openshift/release/pull/75826
     version: '4.22'
     test: node-density-cni
@@ -203,7 +203,7 @@ ack:
     version: '4.22'
     test: node-density-cni
   - uuid: 88188cb9-22ae-4ffd-87ee-87bafc3752a3
-    metric: ovsCPU-Workers_avg
+    metric: ovsWorkersCPU_avg
     reason: ovsCPU is a counter, need to revisit this metric
     version: '4.22'
     test: node-density-cni
@@ -223,139 +223,139 @@ ack:
     version: '4.22'
     test: node-density-cni
   - uuid: dc7780d9-ee64-4219-a626-0363a32dfc17
-    metric: ovnCPU-nbdb_avg
+    metric: nbdbCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.22'
     test: node-density-cni
   - uuid: dc7780d9-ee64-4219-a626-0363a32dfc17
-    metric: ovnCPU-sbdb_avg
+    metric: sbdbCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.22'
     test: node-density-cni
   - uuid: dc7780d9-ee64-4219-a626-0363a32dfc17
-    metric: ovnCPU-northd_avg
+    metric: northdCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.22'
     test: node-density-cni
   - uuid: dc7780d9-ee64-4219-a626-0363a32dfc17
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.22'
     test: node-density-cni
   - uuid: dc7780d9-ee64-4219-a626-0363a32dfc17
-    metric: ovnkCPU-overall_avg
+    metric: ovnkCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.22'
     test: node-density-cni
   - uuid: dc7780d9-ee64-4219-a626-0363a32dfc17
-    metric: ovsCPU-irate-all_avg
+    metric: ovsCPUAll_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.22'
     test: node-density-cni
   # udn-density-pods
   - uuid: 62b5fe32-0b9f-4000-9cbe-ce8ee74cc7cd
-    metric: ovnCPU-nbdb_avg
+    metric: nbdbCPU_avg
     reason: cpu has returned, random spike
     version: '4.22'
     test: udn-density-pods
   - uuid: 5b665198-fd65-4832-8e92-1e03c405eb17 # l2-payload
-    metric: ovnMem-nbdb_avg
+    metric: nbdbMemory_avg
     reason: https://issues.redhat.com/browse/OCPBUGS-77720
     version: '4.22'
     test: udn-density-pods
   - uuid: ea58cf9b-a745-42a5-9507-3ea173273def # l3-24nodes
-    metric: ovnMem-nbdb_avg
+    metric: nbdbMemory_avg
     reason: https://issues.redhat.com/browse/OCPBUGS-77720
     version: '4.22'
     test: udn-density-pods
   - uuid: 1c95b3ee-bf24-4ca5-bd63-0f893d13ad63
-    metric: ovsCPU-Workers_avg
+    metric: ovsWorkersCPU_avg
     reason: https://issues.redhat.com/browse/PERFSCALE-4515
     version: '4.22'
     test: udn-density-pods
   - uuid: d32d0b5b-f2f6-47fa-8f9d-314ab31c7a02
-    metric: ovnMem-ovncontroller_avg
+    metric: ovnControllerMemory_avg
     reason: https://issues.redhat.com/browse/PERFSCALE-4515
     version: '4.22'
     test: udn-density-pods
   - uuid: f9b863c0-9780-4bf8-86d4-0ea66deafbb5
-    metric: ovnkCPU-overall_avg
+    metric: ovnkCPU_avg
     reason: added daemonset to udn-density job
     version: '4.22'
     test: udn-density-pods
   - uuid: 923bb455-04ec-4c1a-a6bc-1bf55f8dd728
-    metric: ovnCPU-northd_avg
+    metric: northdCPU_avg
     reason: added daemonset to udn-density job
     version: '4.22'
     test: udn-density-pods
   - uuid: b42cb882-87d1-4b50-867c-9f3ab60acbee
-    metric: ovnCPU-ovnk-controller_avg
+    metric: ovnkControllerCPU_avg
     reason: added daemonset to udn-density job
     version: '4.22'
     test: udn-density-pods
   - uuid: 282ae6af-6613-4771-a77f-d6f4abdc729b
-    metric: ovnkCPU-overall_avg
+    metric: ovnkCPU_avg
     reason: Metric is back to normal trend
     version: '4.22'
     test: udn-density-pods
   - uuid: 282ae6af-6613-4771-a77f-d6f4abdc729b
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: Metric is back to normal trend
     version: '4.22'
     test: udn-density-pods
   - uuid: 282ae6af-6613-4771-a77f-d6f4abdc729b
-    metric: ovnCPU-nbdb_avg
+    metric: nbdbCPU_avg
     reason: Metric is back to normal trend
     version: '4.22'
     test: udn-density-pods
   - uuid: 282ae6af-6613-4771-a77f-d6f4abdc729b
-    metric: ovnCPU-sbdb_avg
+    metric: sbdbCPU_avg
     reason: Metric is back to normal trend
     version: '4.22'
     test: udn-density-pods
   - uuid: 282ae6af-6613-4771-a77f-d6f4abdc729b
-    metric: ovnCPU-ovnk-controller_avg
+    metric: ovnkControllerCPU_avg
     reason: Metric is back to normal trend
     version: '4.22'
     test: udn-density-pods
   - uuid: bcee4a86-c0c9-4252-804c-462ba7c5a733
-    metric: ovnCPU-northd_avg
+    metric: northdCPU_avg
     reason: Metric is back to normal trend
     version: '4.22'
     test: udn-density-pods
   # 120-node udn-density-l2
   - uuid: 77b0d861-ce3d-468c-b5c4-a557478ce452
-    metric: ovsMemory-all_avg
+    metric: ovsMemory_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: 77b0d861-ce3d-468c-b5c4-a557478ce452
-    metric: ovnMem-northd_avg
+    metric: northdMemory_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: 77b0d861-ce3d-468c-b5c4-a557478ce452
-    metric: ovnMem-sbdb_avg
+    metric: sbdbMemory_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: dc8cb79d-0aa3-4246-973c-9add43f36d58
-    metric: ovsMemory-all_avg
+    metric: ovsMemory_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: dc8cb79d-0aa3-4246-973c-9add43f36d58
-    metric: ovnMem-ovncontroller_avg
+    metric: ovnControllerMemory_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: dc8cb79d-0aa3-4246-973c-9add43f36d58
-    metric: ovnMem-northd_avg
+    metric: northdMemory_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: dc8cb79d-0aa3-4246-973c-9add43f36d58
-    metric: ovnMem-sbdb_avg
+    metric: sbdbMemory_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
@@ -365,37 +365,37 @@ ack:
     version: '4.22'
     test: udn-density-pods
   - uuid: 10f24a16-c788-43b7-b87e-ff74e50698aa
-    metric: ovnkCPU-overall_avg
+    metric: ovnkCPU_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: 10f24a16-c788-43b7-b87e-ff74e50698aa
-    metric: ovnCPU-nbdb_avg
+    metric: nbdbCPU_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: 10f24a16-c788-43b7-b87e-ff74e50698aa
-    metric: ovnCPU-sbdb_avg
+    metric: sbdbCPU_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: 10f24a16-c788-43b7-b87e-ff74e50698aa
-    metric: ovnCPU-ovnk-controller_avg
+    metric: ovnkControllerCPU_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: 10f24a16-c788-43b7-b87e-ff74e50698aa
-    metric: ovnMem-ovnk-controller_avg
+    metric: ovnkControllerMemory_avg
     reason: https://redhat.atlassian.net/browse/PERFSCALE-4572
     version: '4.22'
     test: udn-density-pods
   - uuid: 206b4ac7-1180-4c23-b67e-f23612dec40d
-    metric: ovsCPU-irate-all_avg
+    metric: ovsCPUAll_avg
     reason: https://redhat.atlassian.net/browse/OCPBUGS-69936
     version: '4.22'
     test: udn-density-pods
   - uuid: 0151d9a9-dfad-4e52-a5a9-677a9c414ebb
-    metric: ovsCPU-irate-all_avg
+    metric: ovsCPUAll_avg
     reason: https://redhat.atlassian.net/browse/OCPBUGS-69936
     version: '4.22'
     test: cluster-density-v2
@@ -408,12 +408,12 @@ ack:
   # === Version 5.0 ===
 
   - uuid: a9274d3c-c092-4aa9-adc8-aebfd6ebf9c3
-    metric: ovsCPU-irate-all_avg
+    metric: ovsCPUAll_avg
     reason: https://redhat.atlassian.net/browse/OCPBUGS-69936
     version: '5.0'
     test: cluster-density-v2
   - uuid: 1c95b84c-5bc7-487c-8067-edb48925d7ef
-    metric: ovsCPU-irate-all_avg
+    metric: ovsCPUAll_avg
     reason: https://redhat.atlassian.net/browse/OCPBUGS-69936
     version: '5.0'
     test: udn-density-pods
@@ -423,7 +423,7 @@ ack:
     version: '5.0'
     test: udn-density-pods
   - uuid: 091c3235-7236-4391-a4bb-99255d6cc464
-    metric: ovnCPU-ovnk-controller_avg
+    metric: ovnkControllerCPU_avg
     reason: later run shows cpu usage dropping.
     version: '5.0'
     test: udn-density-pods
@@ -437,7 +437,7 @@ ack:
     version: '4.21'
     test: cluster-density-v2
   - uuid: 12414e33-883e-4ef1-91b3-cac7b0cce3c5
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: Missing data in ES, indexing failures
     version: '4.21'
     test: cluster-density-v2
@@ -459,7 +459,7 @@ ack:
     version: '4.21'
     test: node-density
   - uuid: ca5bf944-1229-4b12-8296-c975be0f0fb4
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: CPU bumps due to unintentional change in deletion strategy
     version: '4.21'
     test: node-density
@@ -494,13 +494,13 @@ ack:
     version: '4.21'
     test: node-density
   - uuid: fe042b59-c5fe-4c44-8c2b-1b6e18e25b92
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.21'
     test: node-density
   # node-density-cni
   - uuid: 5bdef865-13ce-40fb-94be-4117ecdf8f4d
-    metric: ovnCPU-ovnk-controller_avg
+    metric: ovnkControllerCPU_avg
     reason: It has come back down in later runs
     version: '4.21'
     test: node-density-cni
@@ -515,22 +515,22 @@ ack:
     version: '4.21'
     test: node-density-cni
   - uuid: 10c07387-55e9-4721-a5c8-8ab006297be1
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: ovnk-controller cpu spike (random)
     version: '4.21'
     test: node-density-cni
   - uuid: 10c07387-55e9-4721-a5c8-8ab006297be1
-    metric: ovnkCPU-overall_avg
+    metric: ovnkCPU_avg
     reason: old CPU spike
     version: '4.21'
     test: node-density-cni
   - uuid: 10c07387-55e9-4721-a5c8-8ab006297be1
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: old CPU spike
     version: '4.21'
     test: node-density-cni
   - uuid: 10c07387-55e9-4721-a5c8-8ab006297be1
-    metric: ovnCPU-ovnk-controller_avg
+    metric: ovnkControllerCPU_avg
     reason: old CPU spike
     version: '4.21'
     test: node-density-cni
@@ -540,12 +540,12 @@ ack:
     version: '4.21'
     test: node-density-cni
   - uuid: 3a6b3569-356a-4895-9877-4b722ca0844f
-    metric: ovsCPU-Workers_avg
+    metric: ovsWorkersCPU_avg
     reason: https://issues.redhat.com/browse/OCPBUGS-74474
     version: '4.21'
     test: node-density-cni
   - uuid: 3a6b3569-356a-4895-9877-4b722ca0844f
-    metric: ovnMem-ovncontroller_avg
+    metric: ovnControllerMemory_avg
     reason: https://issues.redhat.com/browse/OCPBUGS-74474
     version: '4.21'
     test: node-density-cni
@@ -560,7 +560,7 @@ ack:
     version: '4.21'
     test: node-density-cni
   - uuid: 2d000ed6-badd-48e2-b9ee-1031faeeebaa
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: it comes back down after a few runs
     version: '4.21'
     test: node-density-cni
@@ -570,7 +570,7 @@ ack:
     version: '4.21'
     test: node-density-cni
   - uuid: 558dcca2-f5cd-4661-8517-ebf7eb5f9fe7
-    metric: ovsCPU-Workers_avg
+    metric: ovsWorkersCPU_avg
     reason: ovsCPU is a counter, need to revisit this metric
     version: '4.21'
     test: node-density-cni
@@ -590,32 +590,32 @@ ack:
     version: '4.21'
     test: node-density-cni
   - uuid: 48d2d5d2-7adf-41d8-a960-8afa4bdc1f7e
-    metric: ovnCPU-nbdb_avg
+    metric: nbdbCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.21'
     test: node-density-cni
   - uuid: 48d2d5d2-7adf-41d8-a960-8afa4bdc1f7e
-    metric: ovnCPU-sbdb_avg
+    metric: sbdbCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.21'
     test: node-density-cni
   - uuid: 48d2d5d2-7adf-41d8-a960-8afa4bdc1f7e
-    metric: ovnCPU-northd_avg
+    metric: northdCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.21'
     test: node-density-cni
   - uuid: 48d2d5d2-7adf-41d8-a960-8afa4bdc1f7e
-    metric: ovnCPU-ovncontroller_avg
+    metric: ovnControllerCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.21'
     test: node-density-cni
   - uuid: 48d2d5d2-7adf-41d8-a960-8afa4bdc1f7e
-    metric: ovnkCPU-overall_avg
+    metric: ovnkCPU_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.21'
     test: node-density-cni
   - uuid: 48d2d5d2-7adf-41d8-a960-8afa4bdc1f7e
-    metric: ovsCPU-irate-all_avg
+    metric: ovsCPUAll_avg
     reason: Disabled gc-metrics in the test. https://github.com/openshift/release/pull/76871
     version: '4.21'
     test: node-density-cni
@@ -631,12 +631,12 @@ ack:
     version: '4.21'
     test: udn-density-pods
   - uuid: 80e3e90d-d974-49fa-8e39-3e44afcbb408
-    metric: ovnMem-ovncontroller_avg
+    metric: ovnControllerMemory_avg
     reason: same nightly
     version: '4.21'
     test: udn-density-pods
   - uuid: 80e3e90d-d974-49fa-8e39-3e44afcbb408
-    metric: ovnMem-northd_avg
+    metric: northdMemory_avg
     reason: same nightly
     version: '4.21'
     test: udn-density-pods
@@ -651,62 +651,62 @@ ack:
     version: '4.21'
     test: udn-density-pods
   - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
-    metric: ovnMem-ovncontroller_avg
+    metric: ovnControllerMemory_avg
     reason: shift from w/o pause to with pause in config
     version: '4.21'
     test: udn-density-pods
   - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
-    metric: ovnMem-northd_avg
+    metric: northdMemory_avg
     reason: shift from w/o pause to with pause in config
     version: '4.21'
     test: udn-density-pods
   - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
-    metric: ovnMem-nbdb_avg
+    metric: nbdbMemory_avg
     reason: shift from w/o pause to with pause in config
     version: '4.21'
     test: udn-density-pods
   - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
-    metric: ovnMem-sbdb_avg
+    metric: sbdbMemory_avg
     reason: shift from w/o pause to with pause in config
     version: '4.21'
     test: udn-density-pods
   - uuid: 60d9fb49-648e-4e26-ab4d-e8704f749e80
-    metric: ovnkMem-overall_avg
+    metric: ovnkMemory_avg
     reason: shift from w/o pause to with pause in config
     version: '4.21'
     test: udn-density-pods
   - uuid: 96e6fa58-4ea2-46e2-ab65-567ca91911f2
-    metric: ovsCPU-Workers_avg
+    metric: ovsWorkersCPU_avg
     reason: https://issues.redhat.com/browse/PERFSCALE-4515
     version: '4.21'
     test: udn-density-pods
   - uuid: f682a732-4f62-4f9b-bc8a-d8d5064fba69
-    metric: ovnMem-ovncontroller_avg
+    metric: ovnControllerMemory_avg
     reason: https://issues.redhat.com/browse/PERFSCALE-4515
     version: '4.21'
     test: udn-density-pods
   - uuid: e8a2b5f7-211b-4465-8371-5581067d8bc2
-    metric: ovsCPU-irate-all_avg
+    metric: ovsCPUAll_avg
     reason: added daemonset to udn-density job
     version: '4.21'
     test: udn-density-pods
   - uuid: aad88a60-67b4-4844-871c-0aa1bcb418cf
-    metric: ovnCPU-northd_avg
+    metric: northdCPU_avg
     reason: added daemonset to udn-density job
     version: '4.21'
     test: udn-density-pods
   - uuid: e8a2b5f7-211b-4465-8371-5581067d8bc2
-    metric: ovnCPU-northd_avg
+    metric: northdCPU_avg
     reason: added daemonset to udn-density job
     version: '4.21'
     test: udn-density-pods
   - uuid: e8a2b5f7-211b-4465-8371-5581067d8bc2
-    metric: ovnCPU-ovnk-controller_avg
+    metric: ovnkControllerCPU_avg
     reason: added daemonset to udn-density job
     version: '4.21'
     test: udn-density-pods
   - uuid: 8cf0a474-78da-41b7-b672-455c11cb7227
-    metric: ovnMem-nbdb_avg
+    metric: nbdbMemory_avg
     reason: added daemonset to udn-density job
     version: '4.21'
     test: udn-density-pods
@@ -722,12 +722,12 @@ ack:
     version: '4.21'
     test: virt-udn-density
   - uuid: 0e85edc5-b1e7-4d7f-b116-8a60a0b591dc
-    metric: monitoringCPU_avg
+    metric: monitoringPromCPU_avg
     reason: Earlier a Preload bug diluted resource averages
     version: '4.21'
     test: virt-udn-density
   - uuid: 0e85edc5-b1e7-4d7f-b116-8a60a0b591dc
-    metric: ovnCPU_avg
+    metric: ovnkCPU_avg
     reason: Earlier a Preload bug diluted resource averages
     version: '4.21'
     test: virt-udn-density

--- a/examples/label-small-scale-cluster-density.yaml
+++ b/examples/label-small-scale-cluster-density.yaml
@@ -34,7 +34,7 @@ tests:
         labels:
           - "[Jira: kube-apiserver]"
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/large-scale-cluster-density.yaml
+++ b/examples/large-scale-cluster-density.yaml
@@ -52,7 +52,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -64,7 +64,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -99,7 +99,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -111,7 +111,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -123,7 +123,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -135,7 +135,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value

--- a/examples/large-scale-node-density-cni.yaml
+++ b/examples/large-scale-node-density-cni.yaml
@@ -63,7 +63,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -98,7 +98,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -110,7 +110,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -122,7 +122,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -135,7 +135,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -148,7 +148,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -161,7 +161,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -174,7 +174,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
@@ -187,7 +187,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -199,7 +199,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -211,7 +211,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -223,7 +223,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -235,7 +235,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -248,7 +248,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -261,7 +261,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -274,7 +274,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -287,7 +287,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller

--- a/examples/large-scale-node-density.yaml
+++ b/examples/large-scale-node-density.yaml
@@ -49,7 +49,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/large-scale-udn-l2.yaml
+++ b/examples/large-scale-udn-l2.yaml
@@ -33,7 +33,7 @@ tests:
           - "[Jira: PerfScale]"
         direction: 1
         threshold: 10
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -46,7 +46,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -59,7 +59,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -73,7 +73,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -87,7 +87,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -101,7 +101,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -115,7 +115,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -129,7 +129,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -142,7 +142,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -155,7 +155,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -168,7 +168,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -181,7 +181,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -195,7 +195,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -209,7 +209,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -223,7 +223,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -237,7 +237,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/large-scale-udn-l3.yaml
+++ b/examples/large-scale-udn-l3.yaml
@@ -33,7 +33,7 @@ tests:
           - "[Jira: PerfScale]"
         direction: 1
         threshold: 10
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -46,7 +46,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -59,7 +59,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -73,7 +73,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -87,7 +87,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -101,7 +101,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -115,7 +115,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -129,7 +129,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -142,7 +142,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -155,7 +155,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -168,7 +168,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -181,7 +181,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -195,7 +195,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -209,7 +209,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -223,7 +223,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -237,7 +237,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/med-scale-cluster-density.yaml
+++ b/examples/med-scale-cluster-density.yaml
@@ -52,7 +52,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -64,7 +64,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -99,7 +99,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -111,7 +111,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -123,7 +123,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -135,7 +135,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value

--- a/examples/med-scale-node-density-cni.yaml
+++ b/examples/med-scale-node-density-cni.yaml
@@ -63,7 +63,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -98,7 +98,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -110,7 +110,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -122,7 +122,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -135,7 +135,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -148,7 +148,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -161,7 +161,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -174,7 +174,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
@@ -187,7 +187,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -199,7 +199,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -211,7 +211,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -223,7 +223,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -235,7 +235,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -248,7 +248,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -261,7 +261,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -274,7 +274,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -287,7 +287,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller

--- a/examples/med-scale-node-density.yaml
+++ b/examples/med-scale-node-density.yaml
@@ -49,7 +49,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/med-scale-udn-l2.yaml
+++ b/examples/med-scale-udn-l2.yaml
@@ -32,7 +32,7 @@ tests:
           - "[Jira: PerfScale]"
         direction: 1
         threshold: 10
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -45,7 +45,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -58,7 +58,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -72,7 +72,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -86,7 +86,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -100,7 +100,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -114,7 +114,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -128,7 +128,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -141,7 +141,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -154,7 +154,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -167,7 +167,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -180,7 +180,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -194,7 +194,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -208,7 +208,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -222,7 +222,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -236,7 +236,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/med-scale-udn-l3.yaml
+++ b/examples/med-scale-udn-l3.yaml
@@ -32,7 +32,7 @@ tests:
           - "[Jira: PerfScale]"
         direction: 1
         threshold: 10
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -45,7 +45,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -58,7 +58,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -72,7 +72,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -86,7 +86,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -100,7 +100,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -114,7 +114,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -128,7 +128,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -141,7 +141,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -154,7 +154,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -167,7 +167,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -180,7 +180,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -194,7 +194,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -208,7 +208,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -222,7 +222,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -236,7 +236,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/metal-perfscale-cpt-node-density-heavy.yaml
+++ b/examples/metal-perfscale-cpt-node-density-heavy.yaml
@@ -50,7 +50,7 @@ tests:
           - "[Jira: multus]"
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -61,7 +61,7 @@ tests:
           - "[Jira: monitoring]"
         threshold: 10
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/metal-perfscale-cpt-node-density.yaml
+++ b/examples/metal-perfscale-cpt-node-density.yaml
@@ -59,7 +59,7 @@ tests:
           - "[Jira: multus]"
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -70,7 +70,7 @@ tests:
           - "[Jira: monitoring]"
         threshold: 10
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/metal-perfscale-cpt-rds-core.yaml
+++ b/examples/metal-perfscale-cpt-rds-core.yaml
@@ -423,7 +423,7 @@ tests:
           - "[Jira: Networking / Average memory-ovnkube-node]"
         direction: 1
         threshold: 10
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: cpu-ovnkube-node
         labels.container.keyword: northd
         metric_of_interest: value
@@ -434,7 +434,7 @@ tests:
           - "[Jira: Networking / ovn-kubernetes]"
         direction: 1
         threshold: 10
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: cpu-ovnkube-node
         labels.container.keyword: nbdb
         metric_of_interest: value
@@ -445,7 +445,7 @@ tests:
           - "[Jira: Networking / ovn-kubernetes]"
         direction: 1
         threshold: 10
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: cpu-ovnkube-node
         labels.container.keyword: sbdb
         metric_of_interest: value
@@ -456,7 +456,7 @@ tests:
           - "[Jira: Networking / ovn-kubernetes]"
         direction: 1
         threshold: 10
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: memory-ovnkube-node
         labels.container.keyword: northd
         metric_of_interest: value
@@ -467,7 +467,7 @@ tests:
           - "[Jira: Networking / ovn-kubernetes]"
         direction: 1
         threshold: 10
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: memory-ovnkube-node
         labels.container.keyword: nbdb
         metric_of_interest: value
@@ -478,7 +478,7 @@ tests:
           - "[Jira: Networking / ovn-kubernetes]"
         direction: 1
         threshold: 10
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: memory-ovnkube-node
         labels.container.keyword: sbdb
         metric_of_interest: value

--- a/examples/metal-perfscale-cpt-virt-density-nomount.yaml
+++ b/examples/metal-perfscale-cpt-virt-density-nomount.yaml
@@ -53,7 +53,7 @@ tests:
         threshold: 10
         direction: 1
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -65,7 +65,7 @@ tests:
         threshold: 10
         direction: 1
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -53,7 +53,7 @@ tests:
         threshold: 10
         direction: 1
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -65,7 +65,7 @@ tests:
         threshold: 10
         direction: 1
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/metal-perfscale-cpt-virt-udn-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-udn-density.yaml
@@ -53,7 +53,7 @@ tests:
         threshold: 10
         direction: 1
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -65,7 +65,7 @@ tests:
         threshold: 10
         direction: 1
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -21,7 +21,7 @@
   direction: 1
   threshold: 10
 
-- name: ovnCPU
+- name: ovnkCPU
   metricName: containerCPU
   labels.namespace.keyword: openshift-ovn-kubernetes
   metric_of_interest: value

--- a/examples/netobserv-diff-meta-index.yaml
+++ b/examples/netobserv-diff-meta-index.yaml
@@ -16,7 +16,7 @@ tests:
         stream: okd
 
     metrics:
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/netpol-24nodes.yaml
+++ b/examples/netpol-24nodes.yaml
@@ -55,7 +55,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU-Masters
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -68,7 +68,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU-Masters
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -81,7 +81,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU-Masters
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -94,7 +94,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU-Masters
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -133,7 +133,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory-Masters
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -146,7 +146,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory-Masters
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -159,7 +159,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory-Masters
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -172,7 +172,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory-Masters
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller

--- a/examples/okd-control-plane-cluster-density.yaml
+++ b/examples/okd-control-plane-cluster-density.yaml
@@ -50,7 +50,7 @@ tests:
           - "[Jira: multus]"
         direction: 1
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -61,7 +61,7 @@ tests:
           - "[Jira: monitoring]"
         direction: 1
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/okd-control-plane-node-density-cni.yaml
+++ b/examples/okd-control-plane-node-density-cni.yaml
@@ -27,7 +27,7 @@ tests:
           - "[Jira: PerfScale]"
         direction: 1
         threshold: 10
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -39,7 +39,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -52,7 +52,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -65,7 +65,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -78,7 +78,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -91,7 +91,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
@@ -116,7 +116,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -128,7 +128,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -141,7 +141,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -154,7 +154,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -167,7 +167,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -180,7 +180,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
@@ -217,7 +217,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value

--- a/examples/payload-scale.yaml
+++ b/examples/payload-scale.yaml
@@ -29,7 +29,7 @@ tests:
           value: cpu
           agg_type: avg
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -79,7 +79,7 @@ tests:
           value: cpu
           agg_type: avg
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/small-scale-cluster-density.yaml
+++ b/examples/small-scale-cluster-density.yaml
@@ -31,7 +31,7 @@ tests:
           value: cpu
           agg_type: avg
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -54,7 +54,7 @@ tests:
           value: duration
           agg_type: avg
 
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -64,7 +64,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -74,7 +74,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -84,7 +84,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value

--- a/examples/small-scale-node-density-cni.yaml
+++ b/examples/small-scale-node-density-cni.yaml
@@ -52,7 +52,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -98,7 +98,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -110,7 +110,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -122,7 +122,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -135,7 +135,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -148,7 +148,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -161,7 +161,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -174,7 +174,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
@@ -187,7 +187,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -199,7 +199,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -211,7 +211,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -223,7 +223,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -235,7 +235,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -248,7 +248,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -261,7 +261,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -274,7 +274,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -287,7 +287,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller

--- a/examples/small-scale-node-density.yaml
+++ b/examples/small-scale-node-density.yaml
@@ -49,7 +49,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value

--- a/examples/small-scale-udn-l2.yaml
+++ b/examples/small-scale-udn-l2.yaml
@@ -32,7 +32,7 @@ tests:
           - "[Jira: PerfScale]"
         direction: 1
         threshold: 10
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -45,7 +45,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -58,7 +58,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -72,7 +72,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -86,7 +86,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -100,7 +100,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -114,7 +114,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -128,7 +128,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -141,7 +141,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -154,7 +154,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -167,7 +167,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -180,7 +180,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -194,7 +194,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -208,7 +208,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -222,7 +222,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -236,7 +236,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/small-scale-udn-l3.yaml
+++ b/examples/small-scale-udn-l3.yaml
@@ -32,7 +32,7 @@ tests:
           - "[Jira: PerfScale]"
         direction: 1
         threshold: 10
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -44,7 +44,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -57,7 +57,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -71,7 +71,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -85,7 +85,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -99,7 +99,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -113,7 +113,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -127,7 +127,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -140,7 +140,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -153,7 +153,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -165,7 +165,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -178,7 +178,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -192,7 +192,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -206,7 +206,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -220,7 +220,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -234,7 +234,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/trt-external-payload-cluster-density.yaml
+++ b/examples/trt-external-payload-cluster-density.yaml
@@ -55,7 +55,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         labels.container.keyword: prometheus
@@ -68,7 +68,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -80,7 +80,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -93,7 +93,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
@@ -106,7 +106,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -119,7 +119,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -132,7 +132,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -169,7 +169,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -181,7 +181,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -193,7 +193,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -205,7 +205,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value

--- a/examples/trt-external-payload-cpu.yaml
+++ b/examples/trt-external-payload-cpu.yaml
@@ -18,7 +18,7 @@ tests:
         stream: okd
 
     metrics:
-      - name: openshift-monitoring-ns-CPU
+      - name: openshiftMonitoringNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         metric_of_interest: value
@@ -27,7 +27,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-ovn-kubernetes-ns-CPU
+      - name: openshiftOvnKubernetesNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -36,7 +36,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cluster-csi-drivers-ns-CPU
+      - name: openshiftClusterCsiDriversNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cluster-csi-drivers
         metric_of_interest: value
@@ -45,7 +45,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-multus-ns-CPU
+      - name: openshiftMultusNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-multus
         labels.container.keyword: kube-multus
@@ -55,7 +55,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-machine-config-operator-ns-CPU
+      - name: openshiftMachineConfigOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-machine-config-operator
         metric_of_interest: value
@@ -64,7 +64,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-etcd-ns-CPU
+      - name: openshiftEtcdNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-etcd
         metric_of_interest: value
@@ -73,7 +73,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-e2e-loki-ns-CPU
+      - name: openshiftE2eLokiNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-e2e-loki
         metric_of_interest: value
@@ -82,7 +82,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-dns-ns-CPU
+      - name: openshiftDnsNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-dns
         metric_of_interest: value
@@ -91,7 +91,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-kube-apiserver-ns-CPU
+      - name: openshiftKubeApiserverNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-kube-apiserver
         metric_of_interest: value
@@ -100,7 +100,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-machine-api-ns-CPU
+      - name: openshiftMachineApiNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-machine-api
         metric_of_interest: value
@@ -109,7 +109,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-kube-controller-manager-ns-CPU
+      - name: openshiftKubeControllerManagerNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-kube-controller-manager
         metric_of_interest: value
@@ -118,7 +118,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-insights-ns-CPU
+      - name: openshiftInsightsNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-insights
         metric_of_interest: value
@@ -127,7 +127,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-kube-scheduler-ns-CPU
+      - name: openshiftKubeSchedulerNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-kube-scheduler
         metric_of_interest: value
@@ -136,7 +136,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cluster-node-tuning-operator-ns-CPU
+      - name: openshiftClusterNodeTuningOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cluster-node-tuning-operator
         metric_of_interest: value
@@ -145,7 +145,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-network-diagnostics-ns-CPU
+      - name: openshiftNetworkDiagnosticsNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-network-diagnostics
         metric_of_interest: value
@@ -154,7 +154,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-image-registry-ns-CPU
+      - name: openshiftImageRegistryNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-image-registry
         metric_of_interest: value
@@ -163,7 +163,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-operator-lifecycle-manager-ns-CPU
+      - name: openshiftOperatorLifecycleManagerNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-operator-lifecycle-manager
         metric_of_interest: value
@@ -172,7 +172,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-apiserver-ns-CPU
+      - name: openshiftApiserverNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-apiserver
         metric_of_interest: value
@@ -181,7 +181,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-network-node-identity-ns-CPU
+      - name: openshiftNetworkNodeIdentityNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-network-node-identity
         metric_of_interest: value
@@ -190,7 +190,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-network-operator-ns-CPU
+      - name: openshiftNetworkOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-network-operator
         metric_of_interest: value
@@ -199,7 +199,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-marketplace-ns-CPU
+      - name: openshiftMarketplaceNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-marketplace
         metric_of_interest: value
@@ -208,7 +208,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: kube-system-ns-CPU
+      - name: kubeSystemNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: kube-system
         metric_of_interest: value
@@ -217,7 +217,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cluster-storage-operator-ns-CPU
+      - name: openshiftClusterStorageOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cluster-storage-operator
         metric_of_interest: value
@@ -226,7 +226,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-console-ns-CPU
+      - name: openshiftConsoleNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-console
         metric_of_interest: value
@@ -235,7 +235,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cloud-credential-operator-ns-CPU
+      - name: openshiftCloudCredentialOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cloud-credential-operator
         metric_of_interest: value
@@ -244,7 +244,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-ingress-canary-ns-CPU
+      - name: openshiftIngressCanaryNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ingress-canary
         metric_of_interest: value
@@ -253,7 +253,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cloud-controller-manager-operator-ns-CPU
+      - name: openshiftCloudControllerManagerOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cloud-controller-manager-operator
         metric_of_interest: value
@@ -262,7 +262,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-authentication-ns-CPU
+      - name: openshiftAuthenticationNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-authentication
         metric_of_interest: value
@@ -271,7 +271,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-route-controller-manager-ns-CPU
+      - name: openshiftRouteControllerManagerNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-route-controller-manager
         metric_of_interest: value
@@ -280,7 +280,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cluster-samples-operator-ns-CPU
+      - name: openshiftClusterSamplesOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cluster-samples-operator
         metric_of_interest: value
@@ -289,7 +289,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-dns-operator-ns-CPU
+      - name: openshiftDnsOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-dns-operator
         metric_of_interest: value
@@ -298,7 +298,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-ingress-operator-ns-CPU
+      - name: openshiftIngressOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ingress-operator
         metric_of_interest: value
@@ -307,7 +307,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cloud-controller-manager-ns-CPU
+      - name: openshiftCloudControllerManagerNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cloud-controller-manager
         metric_of_interest: value
@@ -316,7 +316,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cluster-machine-approver-ns-CPU
+      - name: openshiftClusterMachineApproverNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cluster-machine-approver
         metric_of_interest: value
@@ -325,7 +325,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-kube-storage-version-migrator-ns-CPU
+      - name: openshiftKubeStorageVersionMigratorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-kube-storage-version-migrator
         metric_of_interest: value
@@ -334,7 +334,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-authentication-operator-ns-CPU
+      - name: openshiftAuthenticationOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-authentication-operator
         metric_of_interest: value
@@ -343,7 +343,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-oauth-apiserver-ns-CPU
+      - name: openshiftOauthApiserverNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-oauth-apiserver
         metric_of_interest: value
@@ -352,7 +352,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-controller-manager-ns-CPU
+      - name: openshiftControllerManagerNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-controller-manager
         metric_of_interest: value
@@ -361,7 +361,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-ingress-ns-CPU
+      - name: openshiftIngressNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ingress
         metric_of_interest: value
@@ -370,7 +370,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-kube-scheduler-operator-ns-CPU
+      - name: openshiftKubeSchedulerOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-kube-scheduler-operator
         metric_of_interest: value
@@ -379,7 +379,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-operator-controller-ns-CPU
+      - name: openshiftOperatorControllerNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-operator-controller
         metric_of_interest: value
@@ -388,7 +388,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-apiserver-operator-ns-CPU
+      - name: openshiftApiserverOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-apiserver-operator
         metric_of_interest: value
@@ -397,7 +397,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cluster-olm-operator-ns-CPU
+      - name: openshiftClusterOlmOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cluster-olm-operator
         metric_of_interest: value
@@ -406,7 +406,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-controller-manager-operator-ns-CPU
+      - name: openshiftControllerManagerOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-controller-manager-operator
         metric_of_interest: value
@@ -415,7 +415,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-etcd-operator-ns-CPU
+      - name: openshiftEtcdOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-etcd-operator
         metric_of_interest: value
@@ -424,7 +424,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-kube-apiserver-operator-ns-CPU
+      - name: openshiftKubeApiserverOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-kube-apiserver-operator
         metric_of_interest: value
@@ -433,7 +433,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cloud-network-config-controller-ns-CPU
+      - name: openshiftCloudNetworkConfigControllerNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cloud-network-config-controller
         metric_of_interest: value
@@ -442,7 +442,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-cluster-version-ns-CPU
+      - name: openshiftClusterVersionNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-cluster-version
         metric_of_interest: value
@@ -451,7 +451,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-kube-controller-manager-operator-ns-CPU
+      - name: openshiftKubeControllerManagerOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-kube-controller-manager-operator
         metric_of_interest: value
@@ -460,7 +460,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-service-ca-operator-ns-CPU
+      - name: openshiftServiceCaOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-service-ca-operator
         metric_of_interest: value
@@ -469,7 +469,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-console-operator-ns-CPU
+      - name: openshiftConsoleOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-console-operator
         metric_of_interest: value
@@ -478,7 +478,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-service-ca-ns-CPU
+      - name: openshiftServiceCaNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-service-ca
         metric_of_interest: value
@@ -487,7 +487,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-catalogd-ns-CPU
+      - name: openshiftCatalogdNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-catalogd
         metric_of_interest: value
@@ -496,7 +496,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-config-operator-ns-CPU
+      - name: openshiftConfigOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-config-operator
         metric_of_interest: value
@@ -505,7 +505,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-kube-storage-version-migrator-operator-ns-CPU
+      - name: openshiftKubeStorageVersionMigratorOperatorNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-kube-storage-version-migrator-operator
         metric_of_interest: value
@@ -514,7 +514,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: openshift-network-console-ns-CPU
+      - name: openshiftNetworkConsoleNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-network-console
         metric_of_interest: value
@@ -523,7 +523,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: default-ns-CPU
+      - name: defaultNsCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: default
         metric_of_interest: value

--- a/examples/trt-external-payload-node-density-cni.yaml
+++ b/examples/trt-external-payload-node-density-cni.yaml
@@ -66,7 +66,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: monitoringCPU
+      - name: monitoringPromCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-monitoring
         labels.container.keyword: prometheus
@@ -102,7 +102,7 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -114,7 +114,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -126,7 +126,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -139,7 +139,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -152,7 +152,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -165,7 +165,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -178,7 +178,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
@@ -191,7 +191,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -203,7 +203,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -215,7 +215,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
@@ -227,7 +227,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -239,7 +239,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -252,7 +252,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -265,7 +265,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -278,7 +278,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
@@ -291,7 +291,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller

--- a/examples/trt-external-payload-node-density.yaml
+++ b/examples/trt-external-payload-node-density.yaml
@@ -51,7 +51,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
@@ -63,7 +63,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
@@ -76,7 +76,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
@@ -89,7 +89,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
@@ -102,7 +102,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
@@ -115,7 +115,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb

--- a/examples/trt-external-payload-udn-l2.yaml
+++ b/examples/trt-external-payload-udn-l2.yaml
@@ -29,7 +29,7 @@ tests:
           - "[Jira: PerfScale]"
         direction: 1
         threshold: 10
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -42,7 +42,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -55,7 +55,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -69,7 +69,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -83,7 +83,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -97,7 +97,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -111,7 +111,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -125,7 +125,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -138,7 +138,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -151,7 +151,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         jobName.keyword: udn-density-l2-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -164,7 +164,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -177,7 +177,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -191,7 +191,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -205,7 +205,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -219,7 +219,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -233,7 +233,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l2-pods
         labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/trt-external-payload-udn-l3.yaml
+++ b/examples/trt-external-payload-udn-l3.yaml
@@ -29,7 +29,7 @@ tests:
           - "[Jira: PerfScale]"
         direction: 1
         threshold: 10
-      - name: ovsCPU-irate-all
+      - name: ovsCPUAll
         metricName.keyword: cgroupCPU
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -42,7 +42,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkCPU-overall
+      - name: ovnkCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -55,7 +55,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovncontroller
+      - name: ovnControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -69,7 +69,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-northd
+      - name: northdCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -83,7 +83,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-nbdb
+      - name: nbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -97,7 +97,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-sbdb
+      - name: sbdbCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -111,7 +111,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnCPU-ovnk-controller
+      - name: ovnkControllerCPU
         metricName.keyword: containerCPU
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -125,7 +125,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Workers
+      - name: ovsWorkersMemory
         metricName.keyword: cgroupMemoryRSS-Workers
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -138,7 +138,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-Masters
+      - name: ovsMastersMemory
         metricName.keyword: cgroupMemoryRSS-Masters
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -151,7 +151,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovsMemory-all
+      - name: ovsMemory
         metricName.keyword: cgroupMemoryRSS
         jobName.keyword: udn-density-l3-pods
         labels.id.keyword: /system.slice/ovs-vswitchd.service
@@ -164,7 +164,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnkMem-overall
+      - name: ovnkMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -177,7 +177,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovncontroller
+      - name: ovnControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -191,7 +191,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-northd
+      - name: northdMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -205,7 +205,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-nbdb
+      - name: nbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -219,7 +219,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-sbdb
+      - name: sbdbMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes
@@ -233,7 +233,7 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: ovnMem-ovnk-controller
+      - name: ovnkControllerMemory
         metricName.keyword: containerMemory
         jobName.keyword: udn-density-l3-pods
         labels.namespace.keyword: openshift-ovn-kubernetes


### PR DESCRIPTION
Rename hyphenated OVN/OVS metric names to camelCase across all example configs and ack file for consistency and readability.