### PR TITLE
Adding fips to toogle on/off

### DIFF
--- a/examples/config/ols-load-generator-config.yaml
+++ b/examples/config/ols-load-generator-config.yaml
@@ -16,5 +16,6 @@ metadata:
   ocpVersion: "{{ version }}"
   networkType: OVNKubernetes
   mcpEnabled: false
+  fips: "{{ fips | default('false') }}"
   not:
     stream: okd

--- a/examples/label-small-scale-cluster-density.yaml
+++ b/examples/label-small-scale-cluster-density.yaml
@@ -8,11 +8,11 @@ tests:
       workerNodesCount: 24
       benchmark.keyword: cluster-density-v2
       ocpVersion: "{{ version }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
         # networkType: OVNKubernetes
         # encrypted: true
-        # fips: false
         # ipsec: false
 
     metrics:

--- a/examples/large-scale-cluster-density.yaml
+++ b/examples/large-scale-cluster-density.yaml
@@ -13,6 +13,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/large-scale-node-density-cni.yaml
+++ b/examples/large-scale-node-density-cni.yaml
@@ -13,6 +13,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/large-scale-node-density.yaml
+++ b/examples/large-scale-node-density.yaml
@@ -13,6 +13,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/large-scale-udn-l2.yaml
+++ b/examples/large-scale-udn-l2.yaml
@@ -15,10 +15,10 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
     # encrypted: true
-    # fips: false
     # ipsec: false
 
     metrics:

--- a/examples/large-scale-udn-l3.yaml
+++ b/examples/large-scale-udn-l3.yaml
@@ -15,10 +15,10 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
     # encrypted: true
-    # fips: false
     # ipsec: false
 
     metrics:

--- a/examples/med-scale-cluster-density.yaml
+++ b/examples/med-scale-cluster-density.yaml
@@ -13,6 +13,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/med-scale-node-density-cni.yaml
+++ b/examples/med-scale-node-density-cni.yaml
@@ -13,6 +13,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/med-scale-node-density.yaml
+++ b/examples/med-scale-node-density.yaml
@@ -13,6 +13,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/med-scale-udn-l2.yaml
+++ b/examples/med-scale-udn-l2.yaml
@@ -14,10 +14,10 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
     # encrypted: true
-    # fips: false
     # ipsec: false
 
     metrics:

--- a/examples/med-scale-udn-l3.yaml
+++ b/examples/med-scale-udn-l3.yaml
@@ -14,10 +14,10 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
     # encrypted: true
-    # fips: false
     # ipsec: false
 
     metrics:

--- a/examples/metal-perfscale-cpt-data-path.yaml
+++ b/examples/metal-perfscale-cpt-data-path.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
         serviceMeshMode:

--- a/examples/metal-perfscale-cpt-ingress.yaml
+++ b/examples/metal-perfscale-cpt-ingress.yaml
@@ -13,12 +13,12 @@ tests:
       infraNodesType.keyword: ""
       networkType: OVNKubernetes
       encrypted: false
-      fips: false
       ipsec: false
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
         serviceMeshMode:

--- a/examples/metal-perfscale-cpt-node-density-heavy.yaml
+++ b/examples/metal-perfscale-cpt-node-density-heavy.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/metal-perfscale-cpt-node-density.yaml
+++ b/examples/metal-perfscale-cpt-node-density.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/metal-perfscale-cpt-rds-core.yaml
+++ b/examples/metal-perfscale-cpt-rds-core.yaml
@@ -11,6 +11,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
     metrics:

--- a/examples/metal-perfscale-cpt-virt-datapath.yaml
+++ b/examples/metal-perfscale-cpt-virt-datapath.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
         serviceMeshMode:

--- a/examples/metal-perfscale-cpt-virt-density-nomount.yaml
+++ b/examples/metal-perfscale-cpt-virt-density-nomount.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/metal-perfscale-cpt-virt-udn-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-udn-density.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/netobserv-diff-meta-index.yaml
+++ b/examples/netobserv-diff-meta-index.yaml
@@ -12,6 +12,7 @@ tests:
       ocpVersion: "{{ version }}"
       ocpMajorVersion: "{{ version }}"
       sdnType: OVNKubernetes
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/netpol-24nodes.yaml
+++ b/examples/netpol-24nodes.yaml
@@ -16,6 +16,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
 
     metrics:
 

--- a/examples/node_scenarios.yaml
+++ b/examples/node_scenarios.yaml
@@ -31,6 +31,7 @@ tests:
       fips_enabled: "{{ fips_enabled }}"
       ipsec_enabled: "{{ ipsec_enabled }}"
       tag.keyword: "{{ run_tag }}"
+      fips: "{{ fips | default('false') }}"
     metrics:
       # Recovery & Health metrics
       - name: affected_nodes_recovery

--- a/examples/okd-control-plane-cluster-density.yaml
+++ b/examples/okd-control-plane-cluster-density.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       stream: okd
 
     metrics:

--- a/examples/okd-control-plane-crd-scale.yaml
+++ b/examples/okd-control-plane-crd-scale.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       stream: okd
 
     metrics:

--- a/examples/okd-control-plane-node-density-cni.yaml
+++ b/examples/okd-control-plane-node-density-cni.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       stream: okd
 
     metrics:

--- a/examples/okd-control-plane-node-density.yaml
+++ b/examples/okd-control-plane-node-density.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       stream: okd
 
     metrics:

--- a/examples/okd-data-plane-data-path.yaml
+++ b/examples/okd-data-plane-data-path.yaml
@@ -10,6 +10,7 @@ tests:
       workerNodesCount: 9
       benchmark.keyword: k8s-netperf
       networkType: OVNKubernetes
+      fips: "{{ fips | default('false') }}"
       stream: okd
       not:
         serviceMeshMode:

--- a/examples/olmv1.yaml
+++ b/examples/olmv1.yaml
@@ -9,6 +9,7 @@ tests:
       workerNodesCount: 3
       benchmark.keyword: olm
       ocpVersion: "{{ version }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
     metrics:

--- a/examples/payload-scale.yaml
+++ b/examples/payload-scale.yaml
@@ -10,6 +10,7 @@ tests:
       benchmark.keyword: cluster-density-v2
       ocpVersion: "{{ version }}"
       networkType: OVNKubernetes
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/quay-load-test-stable-stage.yaml
+++ b/examples/quay-load-test-stable-stage.yaml
@@ -12,6 +12,7 @@ tests:
       ocpVersion: "{{ ocp_version }}"
       quayVersion: "{{ quay_version }}"
       networkType: OVNKubernetes
+      fips: "{{ fips | default('false') }}"
 
     metrics:
       - name: image_pulls_success_count

--- a/examples/quay-load-test-stable.yaml
+++ b/examples/quay-load-test-stable.yaml
@@ -12,6 +12,7 @@ tests:
       ocpVersion: "{{ ocp_version }}"
       quayVersion: "{{ quay_version }}"
       networkType: OVNKubernetes
+      fips: "{{ fips | default('false') }}"
 
     metrics:
       - name: create_users_latency

--- a/examples/readout-control-plane-cdv2.yaml
+++ b/examples/readout-control-plane-cdv2.yaml
@@ -15,10 +15,10 @@ tests:
       networkType: OVNKubernetes
       ipsec: false
       encrypted: true
-      fips: false
       publish: External
       computeArch: amd64
       controlPlaneArch: amd64
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/readout-control-plane-node-density.yaml
+++ b/examples/readout-control-plane-node-density.yaml
@@ -15,10 +15,10 @@ tests:
       networkType: OVNKubernetes
       ipsec: false
       encrypted: true
-      fips: false
       publish: External
       computeArch: amd64
       controlPlaneArch: amd64
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/readout-ingress.yaml
+++ b/examples/readout-ingress.yaml
@@ -11,7 +11,7 @@ tests:
       workerNodesType: m5.2xlarge
       networkType: OVNKubernetes
       encrypted: false
-      fips: false
+      fips: "{{ fips | default('false') }}"
       ipsec: false
       not:
         stream: okd

--- a/examples/readout-netperf-tcp.yaml
+++ b/examples/readout-netperf-tcp.yaml
@@ -14,7 +14,7 @@ tests:
       totalNodesCount: 15
       networkType: OVNKubernetes
       encrypted: true
-      fips: false
+      fips: "{{ fips | default('false') }}"
       ipsec: false
       not:
         stream: okd

--- a/examples/servicemesh-ingress.yaml
+++ b/examples/servicemesh-ingress.yaml
@@ -13,7 +13,7 @@ tests:
       infraNodesType: c6i.4xlarge
       networkType: OVNKubernetes
       encrypted: false
-      fips: false
+      fips: "{{ fips | default('false') }}"
       ipsec: false
       serviceMeshMode: "{{ service_mesh_mode }}"
       not:

--- a/examples/servicemesh-netperf-tcp.yaml
+++ b/examples/servicemesh-netperf-tcp.yaml
@@ -13,7 +13,7 @@ tests:
       infraNodesType: c6i.4xlarge
       networkType: OVNKubernetes
       encrypted: false
-      fips: false
+      fips: "{{ fips | default('false') }}"
       ipsec: false
       serviceMeshMode: "{{ service_mesh_mode }}"
       not:

--- a/examples/small-rosa-control-plane-node-density.yaml
+++ b/examples/small-rosa-control-plane-node-density.yaml
@@ -15,7 +15,7 @@ tests:
       networkType: OVNKubernetes
       ipsec: false
       encrypted: true
-      fips: false
+      fips: "{{ fips | default('false') }}"
       publish: External
       computeArch: amd64
       controlPlaneArch: amd64

--- a/examples/small-scale-cluster-density-report.yaml
+++ b/examples/small-scale-cluster-density-report.yaml
@@ -14,7 +14,7 @@ tests:
       networkType: OVNKubernetes
       ipsec: false
       encrypted: true
-      fips: false
+      fips: "{{ fips | default('false') }}"
       publish: External
       computeArch: amd64
       controlPlaneArch: amd64

--- a/examples/small-scale-cluster-density.yaml
+++ b/examples/small-scale-cluster-density.yaml
@@ -9,10 +9,10 @@ tests:
       benchmark.keyword: cluster-density-v2
       ocpVersion: "{{ version }}"
       networkType: OVNKubernetes
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
     # encrypted: true
-    # fips: false
     # ipsec: false
 
     metrics:

--- a/examples/small-scale-node-density-cni.yaml
+++ b/examples/small-scale-node-density-cni.yaml
@@ -13,6 +13,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/small-scale-node-density.yaml
+++ b/examples/small-scale-node-density.yaml
@@ -13,6 +13,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/small-scale-udn-l2.yaml
+++ b/examples/small-scale-udn-l2.yaml
@@ -14,10 +14,10 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
     # encrypted: true
-    # fips: false
     # ipsec: false
 
     metrics:

--- a/examples/small-scale-udn-l3.yaml
+++ b/examples/small-scale-udn-l3.yaml
@@ -14,10 +14,10 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
     # encrypted: true
-    # fips: false
     # ipsec: false
 
     metrics:

--- a/examples/trt-external-payload-cluster-density.yaml
+++ b/examples/trt-external-payload-cluster-density.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/trt-external-payload-cpu.yaml
+++ b/examples/trt-external-payload-cpu.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/trt-external-payload-crd-scale.yaml
+++ b/examples/trt-external-payload-crd-scale.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/trt-external-payload-node-density-cni.yaml
+++ b/examples/trt-external-payload-node-density-cni.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/trt-external-payload-node-density-inherits.yaml
+++ b/examples/trt-external-payload-node-density-inherits.yaml
@@ -9,6 +9,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/trt-external-payload-node-density.yaml
+++ b/examples/trt-external-payload-node-density.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/trt-external-payload-udn-l2.yaml
+++ b/examples/trt-external-payload-udn-l2.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 

--- a/examples/trt-external-payload-udn-l3.yaml
+++ b/examples/trt-external-payload-udn-l3.yaml
@@ -14,6 +14,7 @@ tests:
       pullNumber: "{{ pull_number | default(0) }}"
       organization: "{{ organization | default('') }}"
       repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
       not:
         stream: okd
 


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Adding option to toogle fips on/off which will be required for this PR: https://github.com/openshift/release/pull/77628

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Tested and verified in local by setting the variable `export fips=true`
```
(venv) vchalla@vchalla-mac orion % orion --node-count true --config examples/trt-external-payload-cluster-density.yaml --hunter-analyze --es-server server --metadata-index index --benchmark-index index --lookback 30d --debug

[{'_index': 'perf_scale_ci-000054', '_id': 'rehearse-77628-pe...}]
2026-04-22 13:40:25,561 - Orion      - INFO - file: matcher.py - line: 74 - Executing query against index: perf_scale_ci-000054
2026-04-22 13:40:25,561 - Orion      - DEBUG - file: matcher.py - line: 75 - Executing query
{'query': {'bool': {'must': [{'terms': {'uuid.keyword': ['004e9b47-4349-4460-b0b3-381e2f676f08']}}, {'bool': {}}, {'bool': {'must': [{'exists': {'field': 'ocpVersion'}}]}}]}}, 'sort': [{'timestamp': {'order': 'desc'}}], 'size': 10000}
```