### PR TITLE
Cast timestamp after proven to be seconds

### DIFF
--- a/orion/tests/test_utils.py
+++ b/orion/tests/test_utils.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for orion/utils.py
+"""
+
+# pylint: disable = redefined-outer-name
+# pylint: disable = missing-function-docstring
+# pylint: disable = import-error
+# pylint: disable = missing-class-docstring
+
+import logging
+
+import pandas as pd
+import pytest
+
+from orion.logger import SingletonLogger
+from orion.utils import (
+    Utils,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _init_logger():
+    """Ensure the singleton logger exists for every test."""
+    SingletonLogger(debug=logging.DEBUG, name="Orion")
+
+
+@pytest.fixture
+def utils():
+    return Utils()
+
+
+@pytest.fixture
+def utils_custom_fields():
+    return Utils(uuid_field="run_uuid", version_field="cluster_version")
+
+
+# ---------------------------------------------------------------------------
+# standardize_timestamp
+# ---------------------------------------------------------------------------
+
+class TestStandardizeTimestamp:
+    def test_none_returns_none(self, utils):
+        assert utils.standardize_timestamp(None) is None
+
+    def test_integer_epoch_seconds(self, utils):
+        # 2024-01-01 00:00:00 UTC
+        result = utils.standardize_timestamp(1704067200)
+        assert result == "2024-01-01T00:00:00"
+
+    def test_numeric_string_epoch_seconds(self, utils):
+        result = utils.standardize_timestamp("1704067200")
+        assert result == "2024-01-01T00:00:00"
+
+    def test_iso_string(self, utils):
+        result = utils.standardize_timestamp("2024-06-15T12:30:45Z")
+        assert result == "2024-06-15T12:30:45"
+
+    def test_iso_string_with_offset(self, utils):
+        result = utils.standardize_timestamp("2024-06-15T12:30:45+00:00")
+        assert result == "2024-06-15T12:30:45"
+
+    def test_float_epoch_not_treated_as_seconds(self, utils):
+        # BEHAVIOR GUARD: floats take the else branch in standardize_timestamp,
+        # where pd.to_datetime interprets them as nanoseconds, NOT seconds.
+        # A float like 1.7e9 (valid epoch seconds for 2024) gets interpreted
+        # as ~1.7 seconds after 1970-01-01.
+        #
+        # If this test fails it means the float handling changed — callers
+        # that rely on passing int/str for epoch-seconds may now silently
+        # get wrong results from floats, or vice-versa. Either way, audit
+        # all call sites before accepting the new behavior.
+        ts = 1704067200.123  # 2024-01-01 as epoch seconds
+        result = utils.standardize_timestamp(ts)
+        assert result.startswith("1970-01-01"), (
+            f"Float timestamp handling changed! Got {result} — expected 1970 "
+            f"(float treated as nanoseconds). If this is intentional, update "
+            f"this test and audit callers of standardize_timestamp."
+        )
+
+    def test_pandas_timestamp(self, utils):
+        ts = pd.Timestamp("2024-03-15 08:00:00", tz="UTC")
+        result = utils.standardize_timestamp(ts)
+        assert result == "2024-03-15T08:00:00"

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -144,7 +144,7 @@ class Utils:
         # Handle int timestamps and numeric strings in seconds
         if isinstance(timestamp, int) or \
             (isinstance(timestamp, str) and timestamp.isnumeric()):
-            dt = pd.to_datetime(timestamp, unit='s', utc=True)
+            dt = pd.to_datetime(int(timestamp), unit='s', utc=True)
         # Default to pd for float (millisec precision), ISO/RFC etc.
         else:
             dt = pd.to_datetime(timestamp, utc=True)


### PR DESCRIPTION
satisfies pandas to_datetime() FutureWarning on unit

## Type of change

- [x] Bug fix

## Description

This code currently throws a warning when executed. Since we check whether `timestamp` is numeric, we can simply cast it to an int to satisfy the warning.

```
FutureWarning: The behavior of 'to_datetime' with 'unit' when parsing strings is deprecated. In a future version, strings will be parsed as datetime strings, matching the behavior without a '
unit'. To retain the old behavior, explicitly cast ints or floats to numeric type before calling to_datetime.                                                                                                                                                                
    dt = pd.to_datetime(timestamp, unit='s', utc=True)                                                                                                                                                                                                                       
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Unit tests added can be executed via 'pytest'