### PR TITLE
Adds field for pytest to bypass TestResults

### DIFF
--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -28,6 +28,7 @@ class AnalyzeResult(NamedTuple):
 
 class TestResults(NamedTuple):
     """Return type for run() results tuples."""
+    __test__ = False
     output: Optional[Dict[str, Any]]
     regression_flag: bool
     regression_data: list


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

The class `TestResults` in run_test is not a test class, but pytest thinks it is and throws a warning about it.

This field tells pytest to ignore the confusing name.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests. (not required)