### PR TITLE
added right-click to copy UUID on visualization

### DIFF
--- a/orion/tests/test_visualization.py
+++ b/orion/tests/test_visualization.py
@@ -70,9 +70,16 @@ def test_generate_test_html_writes_expected_file_and_injects_click_handler(
     html = (tmp_path / "output_payload_node-density_viz.html").read_text(encoding="utf-8")
     assert "Orion: node-density" in html
     assert ".plotly-graph-div { width: 100% !important; }" in html
-    assert "attachClickHandlers" in html
+    assert "attachHandlers" in html
     assert "repairProwUrl" in html
     assert "window.open(repairProwUrl(pt.customdata[0]), '_blank');" in html
+    assert "plotly_hover" in html
+    assert "plotly_unhover" in html
+    assert "contextmenu" in html
+    assert "clipboard" in html
+    assert "orion-toast" in html
+    assert "right-click to copy UUID" in html
+    assert "stopPropagation" in html
 
 
 def test_build_test_figure_renders_changepoints_and_skips_out_of_range(sample_dataframe):
@@ -105,6 +112,11 @@ def test_build_test_figure_renders_changepoints_and_skips_out_of_range(sample_da
     assert len(changepoint_traces) == 2
     assert {trace.x[0] for trace in changepoint_traces} == {1, 2}
 
+    for trace in changepoint_traces:
+        cd = trace.customdata[0]
+        assert len(cd) == 2, "customdata should contain [build_url, uuid]"
+        assert cd[1].startswith("uuid-"), "second element should be the UUID"
+
 
 def test_build_test_figure_renders_only_matching_ack_markers(sample_dataframe):
     viz_data = VizData(
@@ -130,3 +142,4 @@ def test_build_test_figure_renders_only_matching_ack_markers(sample_dataframe):
     assert len(ack_traces) == 1
     assert ack_traces[0].x[0] == 1
     assert ack_traces[0].customdata[0][0] == "https://example.com/build/2"
+    assert ack_traces[0].customdata[0][1] == "uuid-2"

--- a/orion/visualization.py
+++ b/orion/visualization.py
@@ -132,7 +132,8 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                 f"Date: {ts.strftime('%Y-%m-%d %H:%M UTC')}<br>"
                 f"Version: {v}<br>"
                 f"UUID: {u}<br>"
-                f"Build: {url[-60:]}"
+                f"Build: {url[-60:]}<br>"
+                f"<i>(right-click to copy UUID)</i>"
             )
 
         # Main time-series trace
@@ -144,7 +145,10 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                 name=metric_name,
                 hovertext=hover_texts,
                 hoverinfo="text",
-                customdata=[[build_urls.iloc[i]] for i in range(len(df))],
+                customdata=[
+                    [build_urls.iloc[i], str(uuids.iloc[i])]
+                    for i in range(len(df))
+                ],
                 marker={"size": 6, "color": line_color},
                 line={"width": 2, "color": line_color},
                 connectgaps=False,
@@ -203,10 +207,12 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                         f"{pct_change:+.1f}% change<br>"
                         f"Mean before: {cp.stats.mean_1:,.2f}<br>"
                         f"Mean after: {cp.stats.mean_2:,.2f}<br>"
-                        f"Build: {cp_build_url[-60:]}"
+                        f"UUID: {uuids.iloc[idx]}<br>"
+                        f"Build: {cp_build_url[-60:]}<br>"
+                        f"<i>(right-click to copy UUID)</i>"
                     ),
                     hoverinfo="text",
-                    customdata=[[cp_build_url]],
+                    customdata=[[cp_build_url, str(uuids.iloc[idx])]],
                 ),
                 row=row_idx,
                 col=1,
@@ -259,10 +265,11 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                     hovertext=(
                         f"<b>ACKed</b><br>"
                         f"Reason: {ack['reason']}<br>"
-                        f"UUID: {ack['uuid'][:8]}"
+                        f"UUID: {ack['uuid'][:8]}<br>"
+                        f"<i>(right-click to copy UUID)</i>"
                     ),
                     hoverinfo="text",
-                    customdata=[[ack_build_url]],
+                    customdata=[[ack_build_url, ack['uuid']]],
                 ),
                 row=row_idx,
                 col=1,
@@ -404,20 +411,29 @@ def generate_test_html(viz_data: VizData, output_file: str) -> str:
         default_width="100%",
     )
 
-    # Inject full-width style and click handler for build URLs
+    # Inject full-width style, click handler for build URLs,
+    # and right-click handler for copying UUIDs.
     injected = """
 <style>
   body { margin: 0; padding: 0; }
   .plotly-graph-div { width: 100% !important; }
+  .orion-toast {
+    position: fixed; bottom: 20px; right: 20px;
+    background: #39ff14; color: #1a1a2e;
+    padding: 10px 20px; border-radius: 6px;
+    font-size: 13px; font-family: monospace;
+    z-index: 9999; opacity: 1;
+    transition: opacity 0.3s ease;
+  }
 </style>
 <script>
-(function attachClickHandlers() {
+(function attachHandlers() {
   var divs = document.querySelectorAll('.plotly-graph-div');
   var allReady = divs.length > 0 && Array.prototype.every.call(divs, function(gd) {
     return typeof gd.on === 'function';
   });
   if (!allReady) {
-    setTimeout(attachClickHandlers, 200);
+    setTimeout(attachHandlers, 200);
     return;
   }
   function repairProwUrl(url) {
@@ -426,11 +442,59 @@ def generate_test_html(viz_data: VizData, output_file: str) -> str:
     return url.replace(/(openshift-eng-).*?(-ci-)/, '$1' + seg + '$2');
   }
   divs.forEach(function(gd) {
+    var lastHoveredUuid = null;
+
     gd.on('plotly_click', function(data) {
+      if (data.event && data.event.button !== 0) return;
       var pt = data.points[0];
       if (pt.customdata && pt.customdata[0]) {
         window.open(repairProwUrl(pt.customdata[0]), '_blank');
       }
+    });
+
+    gd.on('plotly_hover', function(data) {
+      var pt = data.points[0];
+      if (pt.customdata && pt.customdata[1]) {
+        lastHoveredUuid = pt.customdata[1];
+      }
+    });
+
+    gd.on('plotly_unhover', function() {
+      lastHoveredUuid = null;
+    });
+
+    gd.addEventListener('mousedown', function(e) {
+      if (e.button === 2 && lastHoveredUuid) {
+        e.stopPropagation();
+      }
+    });
+
+    gd.addEventListener('contextmenu', function(e) {
+      if (!lastHoveredUuid) return;
+      e.preventDefault();
+      var uuid = lastHoveredUuid;
+      var fallback = function() {
+        var ta = document.createElement('textarea');
+        ta.value = uuid;
+        ta.style.cssText = 'position:fixed;left:-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        ta.remove();
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(uuid).catch(fallback);
+      } else {
+        fallback();
+      }
+      var toast = document.createElement('div');
+      toast.className = 'orion-toast';
+      toast.textContent = 'UUID copied: ' + uuid;
+      document.body.appendChild(toast);
+      setTimeout(function() {
+        toast.style.opacity = '0';
+        setTimeout(function() { toast.remove(); }, 300);
+      }, 2000);
     });
   });
 })();


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds right-click-to-copy-UUID functionality to the Orion HTML visualization.

Currently, UUIDs are visible in hover tooltips but impossible to copy since the tooltip disappears when the cursor moves. This change tracks the hovered data point via `plotly_hover`/`plotly_unhover` events and intercepts right-click (`contextmenu`) to copy the UUID to clipboard with a toast notification.

Changes:
- Extended `customdata` on all Plotly traces (time-series, changepoint, ACK) to carry `[build_url, uuid]`
- Added hover tracking and `contextmenu` handler with clipboard copy + toast
- Added `document.execCommand('copy')` fallback for `file://` contexts
- Added UUID to changepoint hover text (was previously missing)
- Guarded `plotly_click` to only open build URLs on left-click

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- **System Under Test:** Orion HTML visualization output (self-contained HTML files generated by `generate_test_html` in `orion/visualization.py`)
- **Steps to test:**
  1. Generate a visualization HTML file using Orion
  2. Open the generated HTML file in a browser
  3. Hover over any data point (regular, changepoint diamond, or ACK marker) -- UUID should appear in the tooltip
  4. Right-click while hovering -- a green toast should appear saying "UUID copied: ..." and the UUID should be in your clipboard
  5. Left-click a data point -- the build URL should open in a new tab (existing behavior, unchanged)
  6. Right-click on empty chart area (not hovering a point) -- normal browser context menu should appear
- **Verification:** Unit tests pass (`pytest orion/tests/test_visualization.py`). Manual testing confirmed right-click copies UUID, left-click opens build URL, and the two do not interfere with each other.

## Reference 
- **PJ-Rehearse Job**: https://github.com/openshift/release/pull/78440

/cc @mohit-sheth 