### PR TITLE
Add project metadata to pyproject.toml for uv compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,27 @@
+[project]
+name = "orion"
+dynamic = ["version"]
+requires-python = ">=3.11,<3.15"
+dependencies = [
+    "click==8.1.7",
+    "setuptools_scm>=6.2",
+    "apache-otava @ git+https://github.com/apache/otava.git@3b3d59a787ea03749e972c3509241114b861c99e",
+    "elastic-transport==8.11.0",
+    "opensearch-dsl==2.1.0",
+    "opensearch-py==3.0.0",
+    "Jinja2==3.1.3",
+    "PyYAML==6.0.1",
+    "pyshorteners==1.0.1",
+    "numpy==2.2.0",
+    "scikit-learn==1.5.0",
+    "pandas==2.3.3",
+    "tabulate==0.9.0",
+    "plotly>=5.18.0",
+]
+
+[project.scripts]
+orion = "main:main"
+
 [build-system]
 requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adding project metadata to `pyproject.toml` so commands like `uv run` just work out of the box:
```
VERSION=4.22 uv run orion --config metal-perfscale-cpt-virt-density.yaml --lookback 60d  --hunter-analyze --es-server=https://server.com --metadata-index=index-* --benchmark-index=index-*
      Built orion @ file:///var/home/jose/dev/orion
      Built pyshorteners==1.0.1
Uninstalled 1 package in 0.38ms
Installed 4 packages in 106ms
2026-04-27 09:55:44,459 - Orion      - INFO - file: main.py - line: 199 - 🏹 Starting Orion (0.0.16.dev422+ge63365555.d20260427) in command-line mode
...
```