### PR TITLE
Display kube-burner-ocp version

### DIFF
--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -227,6 +227,45 @@ class Matcher:
         runs = [hit.to_dict()["_source"] for hit in all_hits]
         return runs
 
+    def get_kb_version(self, uuids: List[str],
+                       timestamp_field: str = "timestamp") -> Dict[str, str]:
+        """Get kube-burner-ocp version for each UUID from jobSummary docs.
+
+        Args:
+            uuids (list): list of uuids
+            timestamp_field (str): timestamp field in data
+
+        Returns:
+            dict: mapping of uuid to kube-burner-ocp version string
+        """
+        query = Q(
+            "bool",
+            filter=[
+                Q("terms", **{self.uuid_field + ".keyword": uuids}),
+                Q("match", metricName="jobSummary"),
+                ~Q("match", **{"jobConfig.name": "garbage-collection"}),
+            ],
+        )
+        search = (
+            Search(using=self.es, index=self.index)
+            .query(query)
+            .source([self.uuid_field, "version"])
+            .extra(size=self.search_size)
+            .sort({timestamp_field: {"order": "desc"}})
+        )
+        try:
+            all_hits = self.query_index(search, return_all=True)
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        kb_versions = {}
+        for hit in all_hits:
+            src = hit.to_dict()["_source"]
+            uid = src.get(self.uuid_field)
+            if uid and uid not in kb_versions:
+                ver = src.get("version", "N/A")
+                kb_versions[uid] = ver.split("@")[0] if "@" in ver else ver
+        return kb_versions
+
     def filter_runs(self, pdata: Dict[Any, Any], data: Dict[Any, Any]) -> List[str]:
         """filter out runs with different jobIterations
         Args:

--- a/orion/tests/test_visualization.py
+++ b/orion/tests/test_visualization.py
@@ -34,6 +34,7 @@ def sample_dataframe():
                 "https://example.com/build/2",
                 "https://example.com/build/3",
             ],
+            "kbVersion": ["1.2.0", "1.2.0", "1.3.0"],
             "latency": [10.0, 20.0, 30.0],
             "cpu": [30.0, 20.0, 10.0],
         }
@@ -73,7 +74,7 @@ def test_generate_test_html_writes_expected_file_and_injects_click_handler(
     assert "attachClickHandlers" in html
     assert "repairProwUrl" in html
     assert "window.open(repairProwUrl(pt.customdata[0]), '_blank');" in html
-
+    assert "kube-burner-ocp" in html
 
 def test_build_test_figure_renders_changepoints_and_skips_out_of_range(sample_dataframe):
     viz_data = VizData(

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -388,6 +388,8 @@ class Utils:
             return None, None
         match.index = options.get("benchmark_index") or test.get("benchmark_index")
 
+        kb_versions = match.get_kb_version(uuids, timestamp_field)
+
         uuids = self.filter_uuids_on_index(
             metadata,
             options["benchmark_index"],
@@ -428,6 +430,10 @@ class Utils:
                 lambda uuid: versions[uuid]
             )
             merged_df.loc[:, "prs"] = merged_df[self.uuid_field].apply(lambda uuid: prs[uuid])
+
+        merged_df.loc[:, "kbVersion"] = merged_df[self.uuid_field].apply(
+            lambda uuid: kb_versions.get(uuid, "N/A")
+        )
 
         # Add display field data if requested
         display_data = {run[self.uuid_field]: {field: run.get(field) for field in options["display"]} for run in runs}

--- a/orion/visualization.py
+++ b/orion/visualization.py
@@ -92,6 +92,7 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
     versions = df.get(viz_data.version_field, pd.Series(["N/A"] * len(df)))
     uuids = df.get(viz_data.uuid_field, pd.Series(["N/A"] * len(df)))
     build_urls = df.get("buildUrl", pd.Series([""] * len(df)))
+    kb_versions = df.get("kbVersion", pd.Series(["N/A"] * len(df)))
 
     # Evenly spaced x-axis
     x_indices = list(range(len(df)))
@@ -123,14 +124,15 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
 
         # Rich hover with all relevant metadata
         hover_texts = []
-        for i, (ts, v, u, val) in enumerate(
-            zip(timestamps, versions, uuids, values)
+        for i, (ts, v, u, val, kb) in enumerate(
+            zip(timestamps, versions, uuids, values, kb_versions)
         ):
             url = build_urls.iloc[i] if i < len(build_urls) else ""
             hover_texts.append(
                 f"<b>{metric_name}: {val}</b><br>"
                 f"Date: {ts.strftime('%Y-%m-%d %H:%M UTC')}<br>"
                 f"Version: {v}<br>"
+                f"kube-burner-ocp: {kb}<br>"
                 f"UUID: {u}<br>"
                 f"Build: {url[-60:]}"
             )
@@ -203,6 +205,7 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                         f"{pct_change:+.1f}% change<br>"
                         f"Mean before: {cp.stats.mean_1:,.2f}<br>"
                         f"Mean after: {cp.stats.mean_2:,.2f}<br>"
+                        f"kube-burner-ocp: {kb_versions.iloc[idx]}<br>"
                         f"Build: {cp_build_url[-60:]}"
                     ),
                     hoverinfo="text",
@@ -259,6 +262,7 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                     hovertext=(
                         f"<b>ACKed</b><br>"
                         f"Reason: {ack['reason']}<br>"
+                        f"kube-burner-ocp: {kb_versions.iloc[ack_idx]}<br>"
                         f"UUID: {ack['uuid'][:8]}"
                     ),
                     hoverinfo="text",


### PR DESCRIPTION
## Summary

Add the **kube-burner-ocp version** to all hover tooltips in the interactive HTML visualizations, so users can see which version of kube-burner-ocp was used for each run without leaving the chart.

The version is fetched from `jobSummary` documents in the benchmark Elasticsearch index (where kube-burner-ocp already writes it as the `version` field), mapped per UUID, and displayed in the hover alongside existing fields like OCP version, UUID, and build URL.

## Changes

### `orion/matcher.py`
- Added `get_kb_version()` method to the `Matcher` class
- Queries `jobSummary` docs from the benchmark index using `_source` filtering (only fetches `uuid` and `version` fields) for minimal overhead
- Returns a `{uuid: version}` dict, stripping the `@commitHash` suffix for clean display
- Deduplicates on UUID and excludes `garbage-collection` jobs

### `orion/utils.py`
- Calls `match.get_kb_version()` in `process_test()` after the index switches to the benchmark index
- Merges the result as a `kbVersion` column into `merged_df`, following the same pattern used for `buildUrl` and `ocpVersion`

### `orion/visualization.py`
- Extracts `kbVersion` from the dataframe with a graceful fallback to `"N/A"`
- Added `kube-burner-ocp: <version>` line to all three hover templates:
  - Data-point hover (main time-series markers)
  - Changepoint hover (diamond markers)
  - ACK marker hover (acknowledged changepoints)

### `orion/tests/test_visualization.py`
- Added `kbVersion` column to the `sample_dataframe` fixture
- Added assertion that the generated HTML contains `kube-burner-ocp` in hover text

## Design decisions

- **No external repo changes required** — the `version` field already exists in ES from kube-burner-ocp
- **Lightweight** — `_source` filtering keeps the ES query small (2 fields per doc)
- **Graceful fallback** — non-kube-burner workloads (ingress-perf, netperf) show `N/A`
- **Historical data works** — the `version` field has been in `JobSummary` since early kube-burner versions

## Reference 
- **PJ-Rehearse Job**: https://github.com/openshift/release/pull/78442


/cc @mohit-sheth 
