### PR TITLE
Restore popped timestamp field after every test iteration

### DIFF
--- a/orion/utils.py
+++ b/orion/utils.py
@@ -55,6 +55,7 @@ class Utils:
         """
         dataframe_list = []
         metrics_config = {}
+        global_timestamp_field = timestamp_field
 
         for metric in metrics:
             metric_name = metric["name"]
@@ -63,7 +64,7 @@ class Utils:
             labels = metric.pop("labels", None)
             direction = int(metric.pop("direction", 0))
             threshold = abs(int(metric.pop("threshold", test_threshold)))
-            timestamp_field = metric.pop("timestamp", timestamp_field)
+            timestamp_field = metric.pop("timestamp", global_timestamp_field)
             correlation = metric.pop("correlation", "")
             context = metric.pop("context", 5)
             self.logger.info("Collecting %s", metric_name)
@@ -80,6 +81,7 @@ class Utils:
                 metric["labels"] = labels
                 metric["direction"] = direction
                 metric["threshold"] = threshold
+                metric["timestamp"] = timestamp_field
                 metric["correlation"] = correlation
                 metric["context"] = context
                 for metric_dataframe_name in metric_dataframe_names:


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Having .pop in while reading metrics from test configuration has been causing inconsistencies to the multi-chained tests. So making sure that all temporary pops are being restored.

## Related Tickets & Documents
- Closes # https://redhat-internal.slack.com/archives/C0780C0J6HJ/p1777480495542529

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested and verified in local. 
```
orion --node-count false --config examples/netobserv-orion.yaml --lookback 30d --hunter-analyze --output-format text --github-repos kube-burner/kube-burner,kube-burner/kube-burner-ocp,cloud-bulldozer/e2e-benchmarking,openshift/release --viz --es-server 'ES_SERVER' --benchmark-index 'prod-netobserv-datapoints*' --metadata-index 'perf_scale_ci*' --debug
```
Runs as expected.