### PR TITLE
add rosa-hcp example configs

### DIFF
--- a/examples/small-rosa-hcp-cluster-density.yaml
+++ b/examples/small-rosa-hcp-cluster-density.yaml
@@ -1,0 +1,118 @@
+tests:
+  - name: rosa-hcp-small-scale-cluster-density-v2
+    metadata:
+      platform: AWS
+      clusterType: rosa-hcp
+      workerNodesType: m6i.xlarge
+      workerNodesCount: 24
+      benchmark.keyword: cluster-density-v2
+      ocpVersion: "{{ version }}"
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      pullNumber: {{ pull_number | default(0) }}
+      organization: {{ organization | default('') }}
+      repository: {{ repository | default('') }}
+
+
+    metrics:
+    - name: podReadyLatency
+      metricName.keyword: podLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PerfScale]"
+      direction: 1
+      threshold: 10
+
+    - name: containersStartedLatency
+      metricName.keyword: podLatencyQuantilesMeasurement
+      quantileName: ContainersStarted
+      labels:
+        - "[Jira: PodLatency]"
+      metric_of_interest: P99
+      direction: 1
+      threshold: 25
+
+    - name: etcdDisk
+      metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
+      metric_of_interest: value
+      agg:
+        value: duration
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: apiserverCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: apiserverMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: ovnCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*ovnkube-controlplane*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: kubelet
+      metricName.keyword: kubeletCPU
+      metric_of_interest: value
+      labels:
+        - "[Jira: Node]"
+      agg:
+        value: cpu
+        agg_type: avg
+      direction: 1
+      threshold: 10

--- a/examples/small-rosa-hcp-cluster-density.yaml
+++ b/examples/small-rosa-hcp-cluster-density.yaml
@@ -15,104 +15,104 @@ tests:
 
 
     metrics:
-    - name: podReadyLatency
-      metricName.keyword: podLatencyQuantilesMeasurement
-      quantileName: Ready
-      metric_of_interest: P99
-      not:
-        jobConfig.name: "garbage-collection"
-      labels:
-        - "[Jira: PerfScale]"
-      direction: 1
-      threshold: 10
+      - name: podReadyLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: Ready
+        metric_of_interest: P99
+        not:
+          jobConfig.name: "garbage-collection"
+        labels:
+          - "[Jira: PerfScale]"
+        direction: 1
+        threshold: 10
 
-    - name: containersStartedLatency
-      metricName.keyword: podLatencyQuantilesMeasurement
-      quantileName: ContainersStarted
-      labels:
-        - "[Jira: PodLatency]"
-      metric_of_interest: P99
-      direction: 1
-      threshold: 25
+      - name: containersStartedLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: ContainersStarted
+        labels:
+          - "[Jira: PodLatency]"
+        metric_of_interest: P99
+        direction: 1
+        threshold: 25
 
-    - name: etcdDisk
-      metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
-      metric_of_interest: value
-      agg:
-        value: duration
-        agg_type: avg
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdDisk
+        metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
+        metric_of_interest: value
+        agg:
+          value: duration
+          agg_type: avg
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: apiserverCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: apiserverMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: ovnCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*ovnkube-controlplane*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: Networking / ovn-kubernetes]"
-      direction: 1
-      threshold: 10
+      - name: ovnCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*ovnkube-controlplane*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: Networking / ovn-kubernetes]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: kubelet
-      metricName.keyword: kubeletCPU
-      metric_of_interest: value
-      labels:
-        - "[Jira: Node]"
-      agg:
-        value: cpu
-        agg_type: avg
-      direction: 1
-      threshold: 10
+      - name: kubelet
+        metricName.keyword: kubeletCPU
+        metric_of_interest: value
+        labels:
+          - "[Jira: Node]"
+        agg:
+          value: cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10

--- a/examples/small-rosa-hcp-cluster-density.yaml
+++ b/examples/small-rosa-hcp-cluster-density.yaml
@@ -46,7 +46,7 @@ tests:
 
       - name: apiserverCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: cpu
@@ -58,7 +58,7 @@ tests:
 
       - name: apiserverMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: memory
@@ -70,7 +70,7 @@ tests:
 
       - name: ovnCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*ovnkube-controlplane*"
+        labels.container.keyword: ovnkube-control-plane
         metric_of_interest: value
         agg:
           value: cpu
@@ -82,7 +82,7 @@ tests:
 
       - name: etcdCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: cpu
@@ -94,7 +94,7 @@ tests:
 
       - name: etcdMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: memory

--- a/examples/small-rosa-hcp-cluster-density.yaml
+++ b/examples/small-rosa-hcp-cluster-density.yaml
@@ -8,12 +8,10 @@ tests:
       benchmark.keyword: cluster-density-v2
       ocpVersion: "{{ version }}"
       networkType: OVNKubernetes
-      jobType: {{ jobtype | default('periodic') }}
-      pullNumber: {{ pull_number | default(0) }}
-      organization: {{ organization | default('') }}
-      repository: {{ repository | default('') }}
-
-
+      jobType: "{{ jobtype | default('periodic') }}"
+      pullNumber: "{{ pull_number | default(0) }}"
+      organization: "{{ organization | default('') }}"
+      repository: "{{ repository | default('') }}"
     metrics:
       - name: podReadyLatency
         metricName.keyword: podLatencyQuantilesMeasurement

--- a/examples/small-rosa-hcp-crd-scale.yaml
+++ b/examples/small-rosa-hcp-crd-scale.yaml
@@ -14,50 +14,50 @@ tests:
       repository: {{ repository | default('') }}
 
     metrics:
-    - name: apiserverCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: apiserverMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10

--- a/examples/small-rosa-hcp-crd-scale.yaml
+++ b/examples/small-rosa-hcp-crd-scale.yaml
@@ -8,11 +8,10 @@ tests:
       benchmark.keyword: crd-scale
       ocpVersion: "{{ version }}"
       networkType: OVNKubernetes
-      jobType: {{ jobtype | default('periodic') }}
-      pullNumber: {{ pull_number | default(0) }}
-      organization: {{ organization | default('') }}
-      repository: {{ repository | default('') }}
-
+      jobType: "{{ jobtype | default('periodic') }}"
+      pullNumber: "{{ pull_number | default(0) }}"
+      organization: "{{ organization | default('') }}"
+      repository: "{{ repository | default('') }}"
     metrics:
       - name: apiserverCPU
         metricName.keyword: podCPU-Controlplane

--- a/examples/small-rosa-hcp-crd-scale.yaml
+++ b/examples/small-rosa-hcp-crd-scale.yaml
@@ -1,0 +1,63 @@
+tests:
+  - name: rosa-hcp-small-scale-crd-scale
+    metadata:
+      platform: AWS
+      clusterType: rosa-hcp
+      workerNodesType: m6i.xlarge
+      workerNodesCount: 24
+      benchmark.keyword: crd-scale
+      ocpVersion: "{{ version }}"
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      pullNumber: {{ pull_number | default(0) }}
+      organization: {{ organization | default('') }}
+      repository: {{ repository | default('') }}
+
+    metrics:
+    - name: apiserverCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: apiserverMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10

--- a/examples/small-rosa-hcp-crd-scale.yaml
+++ b/examples/small-rosa-hcp-crd-scale.yaml
@@ -15,7 +15,7 @@ tests:
     metrics:
       - name: apiserverCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: cpu
@@ -27,7 +27,7 @@ tests:
 
       - name: apiserverMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: memory
@@ -39,7 +39,7 @@ tests:
 
       - name: etcdCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: cpu
@@ -51,7 +51,7 @@ tests:
 
       - name: etcdMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: memory

--- a/examples/small-rosa-hcp-node-density-cni.yaml
+++ b/examples/small-rosa-hcp-node-density-cni.yaml
@@ -8,12 +8,10 @@ tests:
       benchmark.keyword: node-density-cni
       ocpVersion: "{{ version }}"
       networkType: OVNKubernetes
-      jobType: {{ jobtype | default('periodic') }}
-      pullNumber: {{ pull_number | default(0) }}
-      organization: {{ organization | default('') }}
-      repository: {{ repository | default('') }}
-
-
+      jobType: "{{ jobtype | default('periodic') }}"
+      pullNumber: "{{ pull_number | default(0) }}"
+      organization: "{{ organization | default('') }}"
+      repository: "{{ repository | default('') }}"
     metrics:
       - name: podReadyLatency
         metricName.keyword: podLatencyQuantilesMeasurement

--- a/examples/small-rosa-hcp-node-density-cni.yaml
+++ b/examples/small-rosa-hcp-node-density-cni.yaml
@@ -15,104 +15,104 @@ tests:
 
 
     metrics:
-    - name: podReadyLatency
-      metricName.keyword: podLatencyQuantilesMeasurement
-      quantileName: Ready
-      metric_of_interest: P99
-      not:
-        jobConfig.name: "garbage-collection"
-      labels:
-        - "[Jira: PerfScale]"
-      direction: 1
-      threshold: 10
+      - name: podReadyLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: Ready
+        metric_of_interest: P99
+        not:
+          jobConfig.name: "garbage-collection"
+        labels:
+          - "[Jira: PerfScale]"
+        direction: 1
+        threshold: 10
 
-    - name: containersStartedLatency
-      metricName.keyword: podLatencyQuantilesMeasurement
-      quantileName: ContainersStarted
-      labels:
-        - "[Jira: PodLatency]"
-      metric_of_interest: P99
-      direction: 1
-      threshold: 25
+      - name: containersStartedLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: ContainersStarted
+        labels:
+          - "[Jira: PodLatency]"
+        metric_of_interest: P99
+        direction: 1
+        threshold: 25
 
-    - name: etcdDisk
-      metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
-      metric_of_interest: value
-      agg:
-        value: duration
-        agg_type: avg
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdDisk
+        metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
+        metric_of_interest: value
+        agg:
+          value: duration
+          agg_type: avg
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: apiserverCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: apiserverMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: ovnCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*ovnkube-controlplane*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: Networking / ovn-kubernetes]"
-      direction: 1
-      threshold: 10
+      - name: ovnCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*ovnkube-controlplane*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: Networking / ovn-kubernetes]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: kubelet
-      metricName.keyword: kubeletCPU
-      metric_of_interest: value
-      labels:
-        - "[Jira: Node]"
-      agg:
-        value: cpu
-        agg_type: avg
-      direction: 1
-      threshold: 10
+      - name: kubelet
+        metricName.keyword: kubeletCPU
+        metric_of_interest: value
+        labels:
+          - "[Jira: Node]"
+        agg:
+          value: cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10

--- a/examples/small-rosa-hcp-node-density-cni.yaml
+++ b/examples/small-rosa-hcp-node-density-cni.yaml
@@ -46,7 +46,7 @@ tests:
 
       - name: apiserverCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: cpu
@@ -58,7 +58,7 @@ tests:
 
       - name: apiserverMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: memory
@@ -70,7 +70,7 @@ tests:
 
       - name: ovnCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*ovnkube-controlplane*"
+        labels.container.keyword: ovnkube-control-plane
         metric_of_interest: value
         agg:
           value: cpu
@@ -82,7 +82,7 @@ tests:
 
       - name: etcdCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: cpu
@@ -94,7 +94,7 @@ tests:
 
       - name: etcdMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: memory

--- a/examples/small-rosa-hcp-node-density-cni.yaml
+++ b/examples/small-rosa-hcp-node-density-cni.yaml
@@ -1,0 +1,118 @@
+tests:
+  - name: rosa-hcp-small-scale-node-density-cni
+    metadata:
+      platform: AWS
+      clusterType: rosa-hcp
+      workerNodesType: m6i.xlarge
+      workerNodesCount: 24
+      benchmark.keyword: node-density-cni
+      ocpVersion: "{{ version }}"
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      pullNumber: {{ pull_number | default(0) }}
+      organization: {{ organization | default('') }}
+      repository: {{ repository | default('') }}
+
+
+    metrics:
+    - name: podReadyLatency
+      metricName.keyword: podLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PerfScale]"
+      direction: 1
+      threshold: 10
+
+    - name: containersStartedLatency
+      metricName.keyword: podLatencyQuantilesMeasurement
+      quantileName: ContainersStarted
+      labels:
+        - "[Jira: PodLatency]"
+      metric_of_interest: P99
+      direction: 1
+      threshold: 25
+
+    - name: etcdDisk
+      metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
+      metric_of_interest: value
+      agg:
+        value: duration
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: apiserverCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: apiserverMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: ovnCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*ovnkube-controlplane*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: kubelet
+      metricName.keyword: kubeletCPU
+      metric_of_interest: value
+      labels:
+        - "[Jira: Node]"
+      agg:
+        value: cpu
+        agg_type: avg
+      direction: 1
+      threshold: 10

--- a/examples/small-rosa-hcp-node-density.yaml
+++ b/examples/small-rosa-hcp-node-density.yaml
@@ -8,12 +8,10 @@ tests:
       benchmark.keyword: node-density
       ocpVersion: "{{ version }}"
       networkType: OVNKubernetes
-      jobType: {{ jobtype | default('periodic') }}
-      pullNumber: {{ pull_number | default(0) }}
-      organization: {{ organization | default('') }}
-      repository: {{ repository | default('') }}
-
-
+      jobType: "{{ jobtype | default('periodic') }}"
+      pullNumber: "{{ pull_number | default(0) }}"
+      organization: "{{ organization | default('') }}"
+      repository: "{{ repository | default('') }}"
     metrics:
       - name: podReadyLatency
         metricName.keyword: podLatencyQuantilesMeasurement

--- a/examples/small-rosa-hcp-node-density.yaml
+++ b/examples/small-rosa-hcp-node-density.yaml
@@ -1,0 +1,118 @@
+tests:
+  - name: rosa-hcp-small-scale-node-density
+    metadata:
+      platform: AWS
+      clusterType: rosa-hcp
+      workerNodesType: m6i.xlarge
+      workerNodesCount: 24
+      benchmark.keyword: node-density
+      ocpVersion: "{{ version }}"
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      pullNumber: {{ pull_number | default(0) }}
+      organization: {{ organization | default('') }}
+      repository: {{ repository | default('') }}
+
+
+    metrics:
+    - name: podReadyLatency
+      metricName.keyword: podLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PerfScale]"
+      direction: 1
+      threshold: 10
+
+    - name: containersStartedLatency
+      metricName.keyword: podLatencyQuantilesMeasurement
+      quantileName: ContainersStarted
+      labels:
+        - "[Jira: PodLatency]"
+      metric_of_interest: P99
+      direction: 1
+      threshold: 25
+
+    - name: etcdDisk
+      metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
+      metric_of_interest: value
+      agg:
+        value: duration
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: apiserverCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: apiserverMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: ovnCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*ovnkube-controlplane*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: kubelet
+      metricName.keyword: kubeletCPU
+      metric_of_interest: value
+      labels:
+        - "[Jira: Node]"
+      agg:
+        value: cpu
+        agg_type: avg
+      direction: 1
+      threshold: 10

--- a/examples/small-rosa-hcp-node-density.yaml
+++ b/examples/small-rosa-hcp-node-density.yaml
@@ -15,104 +15,104 @@ tests:
 
 
     metrics:
-    - name: podReadyLatency
-      metricName.keyword: podLatencyQuantilesMeasurement
-      quantileName: Ready
-      metric_of_interest: P99
-      not:
-        jobConfig.name: "garbage-collection"
-      labels:
-        - "[Jira: PerfScale]"
-      direction: 1
-      threshold: 10
+      - name: podReadyLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: Ready
+        metric_of_interest: P99
+        not:
+          jobConfig.name: "garbage-collection"
+        labels:
+          - "[Jira: PerfScale]"
+        direction: 1
+        threshold: 10
 
-    - name: containersStartedLatency
-      metricName.keyword: podLatencyQuantilesMeasurement
-      quantileName: ContainersStarted
-      labels:
-        - "[Jira: PodLatency]"
-      metric_of_interest: P99
-      direction: 1
-      threshold: 25
+      - name: containersStartedLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: ContainersStarted
+        labels:
+          - "[Jira: PodLatency]"
+        metric_of_interest: P99
+        direction: 1
+        threshold: 25
 
-    - name: etcdDisk
-      metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
-      metric_of_interest: value
-      agg:
-        value: duration
-        agg_type: avg
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdDisk
+        metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
+        metric_of_interest: value
+        agg:
+          value: duration
+          agg_type: avg
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: apiserverCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: apiserverMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: ovnCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*ovnkube-controlplane*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: Networking / ovn-kubernetes]"
-      direction: 1
-      threshold: 10
+      - name: ovnCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*ovnkube-controlplane*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: Networking / ovn-kubernetes]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: kubelet
-      metricName.keyword: kubeletCPU
-      metric_of_interest: value
-      labels:
-        - "[Jira: Node]"
-      agg:
-        value: cpu
-        agg_type: avg
-      direction: 1
-      threshold: 10
+      - name: kubelet
+        metricName.keyword: kubeletCPU
+        metric_of_interest: value
+        labels:
+          - "[Jira: Node]"
+        agg:
+          value: cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10

--- a/examples/small-rosa-hcp-node-density.yaml
+++ b/examples/small-rosa-hcp-node-density.yaml
@@ -46,7 +46,7 @@ tests:
 
       - name: apiserverCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: cpu
@@ -58,7 +58,7 @@ tests:
 
       - name: apiserverMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: memory
@@ -70,7 +70,7 @@ tests:
 
       - name: ovnCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*ovnkube-controlplane*"
+        labels.container.keyword: ovnkube-control-plane
         metric_of_interest: value
         agg:
           value: cpu
@@ -82,7 +82,7 @@ tests:
 
       - name: etcdCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: cpu
@@ -94,7 +94,7 @@ tests:
 
       - name: etcdMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: memory

--- a/examples/small-rosa-hcp-udn-l2.yaml
+++ b/examples/small-rosa-hcp-udn-l2.yaml
@@ -1,0 +1,118 @@
+tests:
+  - name: rosa-hcp-small-scale-udn-density-l2-pods
+    metadata:
+      platform: AWS
+      clusterType: rosa-hcp
+      workerNodesType: m6i.xlarge
+      workerNodesCount: 24
+      benchmark.keyword: udn-density-pods
+      ocpVersion: "{{ version }}"
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      pullNumber: {{ pull_number | default(0) }}
+      organization: {{ organization | default('') }}
+      repository: {{ repository | default('') }}
+
+
+    metrics:
+    - name: podReadyLatency
+      metricName.keyword: podLatencyQuantilesMeasurement
+      quantileName: Ready
+      metric_of_interest: P99
+      not:
+        jobConfig.name: "garbage-collection"
+      labels:
+        - "[Jira: PerfScale]"
+      direction: 1
+      threshold: 10
+
+    - name: containersStartedLatency
+      metricName.keyword: podLatencyQuantilesMeasurement
+      quantileName: ContainersStarted
+      labels:
+        - "[Jira: PodLatency]"
+      metric_of_interest: P99
+      direction: 1
+      threshold: 25
+
+    - name: etcdDisk
+      metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
+      metric_of_interest: value
+      agg:
+        value: duration
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: apiserverCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: apiserverMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*kube-apiserver*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: kube-apiserver]"
+      direction: 1
+      threshold: 10
+
+    - name: ovnCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*ovnkube-controlplane*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: Networking / ovn-kubernetes]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdCPU
+      metricName.keyword: podCPU-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: cpu
+        agg_type: avg
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: etcdMemory
+      metricName.keyword: podMemory-Controlplane
+      labels.pod.keyword: "*etcd*"
+      metric_of_interest: value
+      agg:
+        value: memory
+        agg_type: max
+      labels:
+        - "[Jira: etcd]"
+      direction: 1
+      threshold: 10
+
+    - name: kubelet
+      metricName.keyword: kubeletCPU
+      metric_of_interest: value
+      labels:
+        - "[Jira: Node]"
+      agg:
+        value: cpu
+        agg_type: avg
+      direction: 1
+      threshold: 10

--- a/examples/small-rosa-hcp-udn-l2.yaml
+++ b/examples/small-rosa-hcp-udn-l2.yaml
@@ -15,104 +15,104 @@ tests:
 
 
     metrics:
-    - name: podReadyLatency
-      metricName.keyword: podLatencyQuantilesMeasurement
-      quantileName: Ready
-      metric_of_interest: P99
-      not:
-        jobConfig.name: "garbage-collection"
-      labels:
-        - "[Jira: PerfScale]"
-      direction: 1
-      threshold: 10
+      - name: podReadyLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: Ready
+        metric_of_interest: P99
+        not:
+          jobConfig.name: "garbage-collection"
+        labels:
+          - "[Jira: PerfScale]"
+        direction: 1
+        threshold: 10
 
-    - name: containersStartedLatency
-      metricName.keyword: podLatencyQuantilesMeasurement
-      quantileName: ContainersStarted
-      labels:
-        - "[Jira: PodLatency]"
-      metric_of_interest: P99
-      direction: 1
-      threshold: 25
+      - name: containersStartedLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: ContainersStarted
+        labels:
+          - "[Jira: PodLatency]"
+        metric_of_interest: P99
+        direction: 1
+        threshold: 25
 
-    - name: etcdDisk
-      metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
-      metric_of_interest: value
-      agg:
-        value: duration
-        agg_type: avg
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdDisk
+        metricName.keyword: 99thEtcdDiskBackendCommitDurationSeconds
+        metric_of_interest: value
+        agg:
+          value: duration
+          agg_type: avg
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: apiserverCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: apiserverMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*kube-apiserver*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: kube-apiserver]"
-      direction: 1
-      threshold: 10
+      - name: apiserverMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*kube-apiserver*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
 
-    - name: ovnCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*ovnkube-controlplane*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: Networking / ovn-kubernetes]"
-      direction: 1
-      threshold: 10
+      - name: ovnCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*ovnkube-controlplane*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: Networking / ovn-kubernetes]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdCPU
-      metricName.keyword: podCPU-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: cpu
-        agg_type: avg
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdCPU
+        metricName.keyword: podCPU-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: etcdMemory
-      metricName.keyword: podMemory-Controlplane
-      labels.pod.keyword: "*etcd*"
-      metric_of_interest: value
-      agg:
-        value: memory
-        agg_type: max
-      labels:
-        - "[Jira: etcd]"
-      direction: 1
-      threshold: 10
+      - name: etcdMemory
+        metricName.keyword: podMemory-Controlplane
+        labels.pod.keyword: "*etcd*"
+        metric_of_interest: value
+        agg:
+          value: memory
+          agg_type: max
+        labels:
+          - "[Jira: etcd]"
+        direction: 1
+        threshold: 10
 
-    - name: kubelet
-      metricName.keyword: kubeletCPU
-      metric_of_interest: value
-      labels:
-        - "[Jira: Node]"
-      agg:
-        value: cpu
-        agg_type: avg
-      direction: 1
-      threshold: 10
+      - name: kubelet
+        metricName.keyword: kubeletCPU
+        metric_of_interest: value
+        labels:
+          - "[Jira: Node]"
+        agg:
+          value: cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10

--- a/examples/small-rosa-hcp-udn-l2.yaml
+++ b/examples/small-rosa-hcp-udn-l2.yaml
@@ -8,12 +8,10 @@ tests:
       benchmark.keyword: udn-density-pods
       ocpVersion: "{{ version }}"
       networkType: OVNKubernetes
-      jobType: {{ jobtype | default('periodic') }}
-      pullNumber: {{ pull_number | default(0) }}
-      organization: {{ organization | default('') }}
-      repository: {{ repository | default('') }}
-
-
+      jobType: "{{ jobtype | default('periodic') }}"
+      pullNumber: "{{ pull_number | default(0) }}"
+      organization: "{{ organization | default('') }}"
+      repository: "{{ repository | default('') }}"
     metrics:
       - name: podReadyLatency
         metricName.keyword: podLatencyQuantilesMeasurement

--- a/examples/small-rosa-hcp-udn-l2.yaml
+++ b/examples/small-rosa-hcp-udn-l2.yaml
@@ -46,7 +46,7 @@ tests:
 
       - name: apiserverCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: cpu
@@ -58,7 +58,7 @@ tests:
 
       - name: apiserverMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*kube-apiserver*"
+        labels.container.keyword: kube-apiserver
         metric_of_interest: value
         agg:
           value: memory
@@ -70,7 +70,7 @@ tests:
 
       - name: ovnCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*ovnkube-controlplane*"
+        labels.container.keyword: ovnkube-control-plane
         metric_of_interest: value
         agg:
           value: cpu
@@ -82,7 +82,7 @@ tests:
 
       - name: etcdCPU
         metricName.keyword: podCPU-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: cpu
@@ -94,7 +94,7 @@ tests:
 
       - name: etcdMemory
         metricName.keyword: podMemory-Controlplane
-        labels.pod.keyword: "*etcd*"
+        labels.container.keyword: etcd
         metric_of_interest: value
         agg:
           value: memory

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -46,6 +46,25 @@ class Matcher:
         self.version_field = version_field
         self.uuid_field = uuid_field
 
+    @staticmethod
+    def _build_field_query(field: str, value: str) -> Q:
+        """Build a match or wildcard query depending on whether the value contains wildcards.
+
+        If the value contains '*', an Elasticsearch wildcard query is used.
+        Otherwise, a standard match query is used.
+
+        Args:
+            field: The field name to query against.
+            value: The value to match, may include '*' for wildcard matching.
+
+        Returns:
+            Q: An opensearch-dsl query object.
+        """
+        str_value = str(value)
+        if '*' in str_value:
+            return Q("wildcard", **{field: {"value": str_value}})
+        return Q("match", **{field: str_value})
+
     def get_metadata_by_uuid(self, uuid: str) -> dict:
         """Returns back metadata when uuid is given
 
@@ -269,11 +288,11 @@ class Matcher:
             uuids.remove(uuid)
         metric_queries = []
         not_queries = [
-            ~Q("match", **{not_item_key: not_item_value})
+            ~self._build_field_query(not_item_key, not_item_value)
             for not_item_key, not_item_value in metrics.get("not", {}).items()
         ]
         metric_queries = [
-            Q("match", **{metric_key: metric_value})
+            self._build_field_query(metric_key, metric_value)
             for metric_key, metric_value in metrics.items()
             if metric_key not in ["name", "metric_of_interest", "not"]
         ]
@@ -318,11 +337,11 @@ class Matcher:
         """
         metric_queries = []
         not_queries = [
-            ~Q("match", **{not_item_key: not_item_value})
+            ~self._build_field_query(not_item_key, not_item_value)
             for not_item_key, not_item_value in metrics.get("not", {}).items()
         ]
         metric_queries = [
-            Q("match", **{metric_key: metric_value})
+            self._build_field_query(metric_key, metric_value)
             for metric_key, metric_value in metrics.items()
             if metric_key not in ["name", "metric_of_interest", "not", "agg"]
         ]

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -46,25 +46,6 @@ class Matcher:
         self.version_field = version_field
         self.uuid_field = uuid_field
 
-    @staticmethod
-    def _build_field_query(field: str, value: str) -> Q:
-        """Build a match or wildcard query depending on whether the value contains wildcards.
-
-        If the value contains '*', an Elasticsearch wildcard query is used.
-        Otherwise, a standard match query is used.
-
-        Args:
-            field: The field name to query against.
-            value: The value to match, may include '*' for wildcard matching.
-
-        Returns:
-            Q: An opensearch-dsl query object.
-        """
-        str_value = str(value)
-        if '*' in str_value:
-            return Q("wildcard", **{field: {"value": str_value}})
-        return Q("match", **{field: str_value})
-
     def get_metadata_by_uuid(self, uuid: str) -> dict:
         """Returns back metadata when uuid is given
 
@@ -288,11 +269,11 @@ class Matcher:
             uuids.remove(uuid)
         metric_queries = []
         not_queries = [
-            ~self._build_field_query(not_item_key, not_item_value)
+            ~Q("match", **{not_item_key: not_item_value})
             for not_item_key, not_item_value in metrics.get("not", {}).items()
         ]
         metric_queries = [
-            self._build_field_query(metric_key, metric_value)
+            Q("match", **{metric_key: metric_value})
             for metric_key, metric_value in metrics.items()
             if metric_key not in ["name", "metric_of_interest", "not"]
         ]
@@ -337,11 +318,11 @@ class Matcher:
         """
         metric_queries = []
         not_queries = [
-            ~self._build_field_query(not_item_key, not_item_value)
+            ~Q("match", **{not_item_key: not_item_value})
             for not_item_key, not_item_value in metrics.get("not", {}).items()
         ]
         metric_queries = [
-            self._build_field_query(metric_key, metric_value)
+            Q("match", **{metric_key: metric_value})
             for metric_key, metric_value in metrics.items()
             if metric_key not in ["name", "metric_of_interest", "not", "agg"]
         ]


### PR DESCRIPTION
Add small-rosa-hcp example configs for cluster-density, node-density, node-density-cni, crd-scale, and udn-l2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple example test configurations for Rosa HCP small-scale scenarios (cluster density, CRD scale, node density with/without CNI, and UDN L2 pods) with extensive performance metrics, thresholds, and templated job/version parameters.

* **Refactor**
  * Simplified internal query-building logic to improve maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->