### PR TITLE
Attach HTML visualization files to JIRA issues on auto-create

### DIFF
--- a/main.py
+++ b/main.py
@@ -161,7 +161,7 @@ def format_jira_description(regression: dict, metric_name: str, pct_change: floa
     return desc
 
 
-def auto_create_jira_issues(regression_data: list, provider: AckProvider, logger) -> int:
+def auto_create_jira_issues(regression_data: list, provider: AckProvider, logger) -> tuple[int, dict[str, list[str]]]:  # pylint: disable=too-many-locals
     """
     Automatically create JIRA issues for detected regressions.
 
@@ -171,10 +171,12 @@ def auto_create_jira_issues(regression_data: list, provider: AckProvider, logger
         logger: Logger instance
 
     Returns:
-        Number of JIRA issues successfully created
+        Tuple of (created_count, issue_keys_by_test) where issue_keys_by_test
+        maps test_name to a list of created JIRA issue keys.
     """
+    issue_keys_by_test: dict[str, list[str]] = {}
     if not regression_data:
-        return 0
+        return 0, issue_keys_by_test
 
     created_count = 0
     skipped_count = 0
@@ -203,7 +205,7 @@ def auto_create_jira_issues(regression_data: list, provider: AckProvider, logger
                 bad_ver = regression.get("bad_ver")
                 prev_ver = regression.get("prev_ver")
 
-                success = provider.create_ack(
+                issue_key = provider.create_ack(
                     uuid=uuid,
                     metric=metric_name,
                     reason=format_jira_description(regression, metric_name, pct_change),
@@ -214,9 +216,12 @@ def auto_create_jira_issues(regression_data: list, provider: AckProvider, logger
                     prev_version=str(prev_ver)[:4].rstrip('.') if prev_ver else None
                 )
 
-                if success:
+                if issue_key:
                     created_count += 1
-                    logger.info("✓ Created JIRA issue for %s / %s", uuid[:8], metric_name)
+                    logger.info("✓ Created JIRA issue %s for %s / %s", issue_key, uuid[:8], metric_name)
+                    test_name = regression.get("test_name")
+                    if test_name:
+                        issue_keys_by_test.setdefault(test_name, []).append(issue_key)
                 else:
                     skipped_count += 1
                     logger.debug("Skipped (likely already exists): %s / %s", uuid[:8], metric_name)
@@ -230,7 +235,21 @@ def auto_create_jira_issues(regression_data: list, provider: AckProvider, logger
     if skipped_count > 0:
         logger.debug("Skipped %d issue(s) (already exist or failed)", skipped_count)
 
-    return created_count
+    return created_count, issue_keys_by_test
+
+
+def _attach_viz_to_jira(
+    jira_provider, issue_keys_by_test: dict[str, list[str]],
+    output_base_path: str, run_type: str, logger
+) -> None:
+    """Attach generated HTML visualization files to their corresponding JIRA issues."""
+    for test_name, keys in issue_keys_by_test.items():
+        viz_file = build_viz_output_file(output_base_path, test_name, run_type)
+        if not os.path.isfile(viz_file):
+            logger.debug("Viz file not found for %s, skipping attachment", test_name)
+            continue
+        for issue_key in keys:
+            jira_provider.attach_file(issue_key, viz_file)
 
 
 class Dictionary(click.ParamType):
@@ -506,11 +525,6 @@ def main(**kwargs):
     # Load config first (needed for auto-detection)
     kwargs["config"] = load_config(kwargs["config"], kwargs["input_vars"])
 
-    # Validate --jira-auto-create requires --jira-ack
-    if kwargs.get("jira_auto_create") and not kwargs.get("jira_ack"):
-        logger.error("--jira-auto-create requires --jira-ack to be enabled")
-        sys.exit(1)
-
     # Handle ACK loading using provider system
     providers, version, test_type = get_ack_providers(kwargs, kwargs["config"], logger)
 
@@ -521,6 +535,10 @@ def main(**kwargs):
             if isinstance(provider, JiraAckProvider):
                 jira_provider = provider
                 break
+
+    # If --jira-auto-create without --jira-ack, create a Jira provider for issue creation only
+    if kwargs.get("jira_auto_create") and not jira_provider:
+        jira_provider = _create_jira_provider(kwargs, kwargs["config"], logger)
 
     if providers:
         # Collect ACKs from all providers
@@ -577,10 +595,12 @@ def main(**kwargs):
         is_pull = True
 
     # Auto-create JIRA issues for regressions if enabled
+    issue_keys_by_test = {}
+    issue_keys_by_test_pull = {}
     if kwargs.get("jira_auto_create") and jira_provider:
         if results.regression_flag and results.regression_data:
             logger.info("Auto-creating JIRA issues for detected regressions...")
-            created = auto_create_jira_issues(results.regression_data, jira_provider, logger)
+            created, issue_keys_by_test = auto_create_jira_issues(results.regression_data, jira_provider, logger)
             if created == 0 and results.regression_data:
                 logger.warning(
                     "No JIRA issues were created. This may be due to permissions. "
@@ -588,7 +608,7 @@ def main(**kwargs):
                 )
         if is_pull and results_pull.regression_flag and results_pull.regression_data:
             logger.info("Auto-creating JIRA issues for pull request regressions...")
-            created = auto_create_jira_issues(results_pull.regression_data, jira_provider, logger)
+            created, issue_keys_by_test_pull = auto_create_jira_issues(results_pull.regression_data, jira_provider, logger)
             if created == 0 and results_pull.regression_data:
                 logger.warning(
                     "No JIRA issues were created. This may be due to permissions. "
@@ -619,6 +639,17 @@ def main(**kwargs):
                     generate_test_html(viz_data, output_file)
         except Exception as e:  # pylint: disable=broad-except
             logger.warning("Visualization generation failed: %s", e)
+
+    # Attach HTML visualizations to JIRA issues
+    if kwargs.get("viz") and kwargs.get("jira_auto_create") and jira_provider:
+        try:
+            output_base_path = str(Path(kwargs['save_output_path']).with_suffix(''))
+            _attach_viz_to_jira(jira_provider, issue_keys_by_test, output_base_path,
+                                "periodic" if is_pull else "", logger)
+            _attach_viz_to_jira(jira_provider, issue_keys_by_test_pull, output_base_path,
+                                "pull", logger)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning("JIRA attachment failed: %s", e)
 
     if has_regression:
         sys.exit(2) ## regression detected

--- a/orion/ack_providers/base.py
+++ b/orion/ack_providers/base.py
@@ -48,7 +48,7 @@ class AckProvider(ABC):
         version: Optional[str] = None,
         test: Optional[str] = None,
         **kwargs
-    ) -> bool:
+    ) -> Optional[str]:
         """
         Create a new acknowledgment for a regression.
 
@@ -61,7 +61,7 @@ class AckProvider(ABC):
             **kwargs: Provider-specific additional arguments
 
         Returns:
-            True if acknowledgment was created successfully, False otherwise
+            Provider-specific identifier on success (e.g. JIRA issue key), None on failure
         """
 
     def merge_acks(self, ack_lists: List[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:

--- a/orion/ack_providers/file_provider.py
+++ b/orion/ack_providers/file_provider.py
@@ -73,7 +73,7 @@ class FileAckProvider(AckProvider):
         version: Optional[str] = None,
         test: Optional[str] = None,
         **kwargs
-    ) -> bool:
+    ) -> Optional[str]:
         """
         Append a new acknowledgment to the YAML file.
 
@@ -86,7 +86,7 @@ class FileAckProvider(AckProvider):
             **kwargs: Additional fields to include
 
         Returns:
-            True if successful, False otherwise
+            UUID on success, None on failure
         """
         try:
             # Load existing acks
@@ -116,7 +116,7 @@ class FileAckProvider(AckProvider):
                         "ACK entry already exists for uuid=%s, metric=%s",
                         uuid, metric
                     )
-                    return False
+                    return None
 
             # Append and save
             existing_acks.setdefault("ack", []).append(new_entry)
@@ -128,8 +128,8 @@ class FileAckProvider(AckProvider):
                 "Created ACK entry: uuid=%s, metric=%s, file=%s",
                 uuid[:8], metric, self.ack_file
             )
-            return True
+            return uuid
 
         except Exception as e:  # pylint: disable=broad-exception-caught
             self.logger.error("Failed to create ACK entry: %s", e)
-            return False
+            return None

--- a/orion/ack_providers/jira_provider.py
+++ b/orion/ack_providers/jira_provider.py
@@ -4,6 +4,7 @@ orion.ack_providers.jira_provider
 JIRA-based ACK provider for tracking regressions in JIRA.
 """
 
+import os
 import time
 from typing import List, Dict, Any, Optional, NamedTuple
 import re
@@ -398,7 +399,7 @@ class JiraAckProvider(AckProvider):
         version: Optional[str] = None,
         test: Optional[str] = None,
         **kwargs
-    ) -> bool:
+    ) -> Optional[str]:
         """
         Create a new JIRA issue for a regression acknowledgment.
 
@@ -411,7 +412,7 @@ class JiraAckProvider(AckProvider):
             **kwargs: Additional fields (e.g., build_url, pct_change)
 
         Returns:
-            True if issue created successfully, False otherwise
+            JIRA issue key (e.g. 'PERFSCALE-123') on success, None on failure
         """
         # Check if issue already exists
         existing = self._find_existing_issue(uuid, metric)
@@ -420,7 +421,7 @@ class JiraAckProvider(AckProvider):
                 "JIRA issue already exists for uuid=%s, metric=%s: %s",
                 uuid[:8], metric, existing.key
             )
-            return False
+            return None
 
         # Build issue fields
         labels = []
@@ -505,10 +506,10 @@ class JiraAckProvider(AckProvider):
                 verify = self._find_existing_issue(uuid, metric)
                 if verify:
                     self.logger.info("Verified JIRA issue creation: %s", verify.key)
-                    return True
+                    return new_issue.key
 
                 self.logger.warning("JIRA issue created but verification failed")
-                return True  # Issue was created even if verification failed
+                return new_issue.key
 
             except JIRAError as e:
                 # Check for permission errors specifically
@@ -524,7 +525,7 @@ class JiraAckProvider(AckProvider):
                         self.project
                     )
                     # Don't retry permission errors
-                    return False
+                    return None
                 if e.status_code == 400 and "component" in e.text.lower():
                     self.logger.error(
                         "JIRA component error (HTTP %d): %s",
@@ -539,7 +540,7 @@ class JiraAckProvider(AckProvider):
                         self.project
                     )
                     # Don't retry component errors
-                    return False
+                    return None
                 self.logger.warning(
                     "JIRA creation attempt %d/%d failed: %s",
                     attempt + 1, self.config.retry_attempts, e
@@ -552,7 +553,20 @@ class JiraAckProvider(AckProvider):
                 break
 
         self.logger.error("Failed to create JIRA issue after %d attempts", self.config.retry_attempts)
-        return False
+        return None
+
+    def attach_file(self, issue_key: str, file_path: str) -> bool:
+        """Attach a file to an existing JIRA issue."""
+        try:
+            self.jira.add_attachment(issue=issue_key, attachment=file_path)
+            self.logger.info(
+                "Attached %s to JIRA issue %s",
+                os.path.basename(file_path), issue_key
+            )
+            return True
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            self.logger.warning("Failed to attach file to %s: %s", issue_key, e)
+            return False
 
     def _find_existing_issue(self, uuid: str, metric: str):
         """

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -114,7 +114,7 @@ class Utils:
         """
         self.logger.info("process_aggregation_metric")
         aggregated_metric_data = match.get_agg_metric_query(uuids, metric, timestamp_field)
-        self.logger.info("aggregated_metric_data %s", aggregated_metric_data)
+        self.logger.debug("aggregated_metric_data %s", aggregated_metric_data)
         aggregation_value = metric["metric_of_interest"]
         aggregation_type = metric["agg"]["agg_type"]
 


### PR DESCRIPTION
When --jira-auto-create and --viz are both enabled, the generated HTML visualization file is now attached to the corresponding JIRA issue. This lets reviewers download the interactive chart directly from the ticket. https://redhat.atlassian.net/browse/PERFSCALE-4731 

- `create_ack()` returns issue key (Optional[str]) instead of bool
- ` --jira-auto-create` works independently of` --jira-ack` (helps with testing already ack'd uuids)
- Extract` _attach_viz_to_jira()` helper for clean separation
- Demote noisy `aggregated_metric_data` log to DEBUG

