### PR TITLE
EgressIP coverage

### DIFF
--- a/examples/metal-perfscale-cpt-egressip.yaml
+++ b/examples/metal-perfscale-cpt-egressip.yaml
@@ -1,0 +1,79 @@
+tests:
+  - name: metal-perfscale-cpt-node-density
+    metadata:
+      platform: BareMetal
+      clusterType: self-managed
+      masterNodesType.keyword: ""
+      masterNodesCount: 3
+      workerNodesType.keyword: ""
+      workerNodesCount: 24
+      benchmark.keyword: egressip
+      wildcard:
+        ocpVersion: "{{ version }}*"
+      networkType: OVNKubernetes
+      jobType: "{{ jobtype | default('periodic') }}"
+      pullNumber: "{{ pull_number | default(0) }}"
+      organization: "{{ organization | default('') }}"
+      repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
+      not:
+        stream: okd
+
+    metrics:
+      - name: podReadyLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: Ready
+        metric_of_interest: P99
+        not:
+          jobConfig.name: "garbage-collection"
+        labels:
+          - "[Jira: PodLatency]"
+        threshold: 10
+
+      - name: containersStartedLatency
+        metricName.keyword: podLatencyQuantilesMeasurement
+        quantileName: ContainersStarted
+        labels:
+          - "[Jira: PodLatency]"
+        metric_of_interest: P99
+        direction: 1
+        threshold: 25
+
+      - name: ovsCPU-Workers
+        metricName.keyword: cgroupCPUSeconds-Workers
+        labels.id.keyword: /system.slice/ovs-vswitchd.service
+        metric_of_interest: value
+        agg:
+          value: cpu
+          agg_type: avg
+        labels:
+          - "[Jira: Networking / ovn-kubernetes]"
+        direction: 1
+        threshold: 10
+
+      - name: eipStartupLatencyTotal
+        metricName.keyword: eipStartupLatencyTotal
+        metric_of_interest: value
+        labels:
+          - "[Jira: Networking / ovn-kubernetes]"
+        direction: 1
+        threshold: 10
+
+      - name: eipRecoveryLatencyTotal
+        metricName.keyword: eipRecoveryLatencyTotal
+        metric_of_interest: value
+        labels:
+          - "[Jira: Networking / ovn-kubernetes]"
+        direction: 1
+        threshold: 10
+
+      - name: startupEipNodeIPReqCount
+        metricName.keyword: startupEipNodeIPReqCount
+        metric_of_interest: value
+        agg:
+          value: startupEipNodeIPReqCount
+          agg_type: avg
+        labels:
+          - "[Jira: Networking / ovn-kubernetes]"
+        direction: 1
+        threshold: 10

--- a/examples/metal-perfscale-cpt-egressip.yaml
+++ b/examples/metal-perfscale-cpt-egressip.yaml
@@ -59,14 +59,6 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: eipRecoveryLatencyTotal
-        metricName.keyword: eipRecoveryLatencyTotal
-        metric_of_interest: value
-        labels:
-          - "[Jira: Networking / ovn-kubernetes]"
-        direction: 1
-        threshold: 10
-
       - name: startupEipNodeIPReqCount
         metricName.keyword: startupEipNodeIPReqCount
         metric_of_interest: value
@@ -77,3 +69,12 @@ tests:
           - "[Jira: Networking / ovn-kubernetes]"
         direction: 1
         threshold: 10
+
+      - name: eipRecoveryLatencyTotal
+        metricName.keyword: eipRecoveryLatencyTotal
+        metric_of_interest: value
+        labels:
+          - "[Jira: Networking / ovn-kubernetes]"
+        direction: 1
+        threshold: 10
+


### PR DESCRIPTION
Egress IP coverage for the weekly testing.
```
$ VERSION=4.22 uv run orion --config examples/metal-perfscale-cpt-egressip.yaml --lookback 5d  --hunter-analyze --es-server=https://server.com --metadata-index=metadata --benchmark-index=benchmark
...
metal-perfscale-cpt-node-density
================================
time                 uuid                                  ocpVersion                            podReadyLatency_P99    containersStartedLatency_P99    ovsCPU-Workers_avg    eipStartupLatencyTotal_value    startupEipNodeIPReqCount_avg
-------------------  ------------------------------------  ----------------------------------  ---------------------  ------------------------------  --------------------  ------------------------------  ------------------------------
2026-05-02 19:16:08  189bd0b3-2aff-4aad-a070-2b4163bf832f  4.22.0-0.nightly-2026-05-02-045017                   2000                            1849               2254.34                               0                         452.108

time                 uuid                                  ocpVersion                            eipRecoveryLatencyTotal_value  buildUrl
-------------------  ------------------------------------  ----------------------------------  -------------------------------  ------------------------------------------------------------------------------------------------------------------------------------------------------------------
2026-05-02 19:16:08  189bd0b3-2aff-4aad-a070-2b4163bf832f  4.22.0-0.nightly-2026-05-02-045017                              nan  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.22-nightly-x86-weekly-eip/2050621496811851776
No regressions found
```

@venkataanil can you please review the eip related values to see if they make sense:
- `eipStartupLatencyTotal_value`: 0
- `startupEipNodeIPReqCount_avg`: 452.108
- `eipRecoveryLatencyTotal_value`: NaN