### PR TITLE
Adds metadata type metric

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,6 +321,46 @@ Works complementary to `correlation` by analyzing runs before and after the curr
 context: 5  # Analyze 5 runs before and after (default)
 ```
 
+## Metadata Metrics
+
+Metrics can be marked with `type: metadata` to fetch data from OpenSearch without including it in regression analysis. Metadata metrics are carried alongside the test results as attributes — they appear in text, JSON, and JUnit output but are not analyzed for changepoints.
+
+This is useful for attaching contextual information to each test run, such as the Kubernetes version, cluster configuration, or any other field that helps identify what changed between runs without being a performance metric itself.
+
+### Usage
+
+Add `type: metadata` to any metric definition. The metric is fetched and merged into the results dataframe like any other metric, but it is treated as an attribute (like UUID or version) rather than an analyzed metric.
+
+```yaml
+metrics:
+  - name: kubeBurnerVersion
+    metricName.keyword: jobSummary
+    metric_of_interest: k8sVersion
+    not:
+      jobConfig.name: "garbage-collection"
+    type: metadata
+
+  - name: podReadyLatency
+    metricName.keyword: podLatencyQuantilesMeasurement
+    quantileName: Ready
+    metric_of_interest: P99
+    not:
+      jobConfig.name: "garbage-collection"
+    labels:
+      - "[Jira: PerfScale]"
+    direction: 1
+    threshold: 10
+```
+
+In this example, `kubeBurnerVersion` fetches the `k8sVersion` field from `jobSummary` documents. It appears in every output row next to UUID and version, but Orion does not run changepoint detection or regression analysis on it. The `podReadyLatency` metric is analyzed normally.
+
+### Behavior
+
+- Metadata metrics use the same query fields (`metricName`, `metric_of_interest`, `not`, etc.) as regular metrics
+- They are excluded from `metrics_config`, so algorithms skip them during analysis
+- They are included as **attributes** in the output series, appearing in report tables alongside UUID and version columns
+- The `direction`, `threshold`, `labels`, and `correlation` fields are ignored for metadata metrics (they can be omitted)
+
 ## Aggregation Metrics
 
 Orion supports aggregating metric values across multiple data points per test run. This is useful for computing statistics like average CPU usage, total memory consumed, or latency percentiles.

--- a/orion/algorithms/algorithm.py
+++ b/orion/algorithms/algorithm.py
@@ -43,10 +43,12 @@ class Algorithm(ABC): # pylint: disable = too-many-arguments, too-many-instance-
             for column, value in self.metrics_config.items()
         }
         data = {column: self.dataframe[column] for column in self.metrics_config}
+        attribute_fields = [self.test["uuid_field"], self.test["version_field"]]
+        attribute_fields += self.test.get("metadata_columns", [])
         attributes = {
             column: self.dataframe[column]
             for column in self.dataframe.columns
-            if column in [self.test["uuid_field"], self.test["version_field"]]
+            if column in attribute_fields
         }
         series = Series(
             test_name=self.test["name"],

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -282,7 +282,7 @@ class Matcher:
         metric_queries = [
             Q("match", **{metric_key: metric_value})
             for metric_key, metric_value in metrics.items()
-            if metric_key not in ["name", "metric_of_interest", "not"]
+            if metric_key not in ["name", "metric_of_interest", "not", "type"]
         ]
         exists_queries = []
         if exists_fields:
@@ -331,7 +331,7 @@ class Matcher:
         metric_queries = [
             Q("match", **{metric_key: metric_value})
             for metric_key, metric_value in metrics.items()
-            if metric_key not in ["name", "metric_of_interest", "not", "agg"]
+            if metric_key not in ["name", "metric_of_interest", "not", "agg", "type"]
         ]
         metric_query = Q("bool", must=metric_queries + not_queries)
         query = Q(

--- a/orion/pipeline/formatters/junit_formatter.py
+++ b/orion/pipeline/formatters/junit_formatter.py
@@ -19,12 +19,14 @@ class JUnitFormatter(BaseFormatter):
         json_formatter = JsonFormatter()
         json_result = json_formatter.format(data)
         data_json = json.loads(json_result[data.test_name])
+        metadata_cols = data.test.get("metadata_columns", [])
+        all_display = (data.display_fields or []) + metadata_cols
         data_junit = json_to_junit(
             test_name=data.test_name,
             data_json=data_json,
             metrics_config=data.metrics_config,
             uuid_field=data.uuid_field,
-            display_fields=data.display_fields,
+            display_fields=all_display,
         )
         return {data.test_name: data_junit}
 

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -40,17 +40,18 @@ class Utils:
     # pylint: disable=too-many-locals
     def get_metric_data(
         self, uuids: List[str], metrics: Dict[str, Any], match: Matcher, test_threshold: int, timestamp_field: str="timestamp"
-    ) -> List[pd.DataFrame]:
+    ) -> Tuple[List[pd.DataFrame], Dict[str, Any], List[str]]:
         """Gets details metrics based on metric yaml list
 
         Args:
-            ids (list): list of all uuids
+            uuids (list): list of all uuids
             metrics (dict): metrics to gather data on
             match (Matcher): current matcher instance
-            logger (logger): log data to one output
+            test_threshold (int): default threshold for metrics
+            timestamp_field (str): field name for timestamps
 
         Returns:
-            dataframe_list: dataframe of the all metrics
+            tuple: (dataframe_list, metrics_config, metadata_columns)
         """
         dataframe_list = []
         metrics_config = {}
@@ -67,7 +68,7 @@ class Utils:
             timestamp_field = metric.pop("timestamp", global_timestamp_field)
             correlation = metric.pop("correlation", "")
             context = metric.pop("context", 5)
-            metric_type = metric.pop("type", None)
+            metric_type = metric.get("type")
             self.logger.info("Collecting %s", metric_name)
             try:
                 if "agg" in metric:

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -54,6 +54,7 @@ class Utils:
         """
         dataframe_list = []
         metrics_config = {}
+        metadata_columns = []
         global_timestamp_field = timestamp_field
 
         for metric in metrics:
@@ -66,6 +67,7 @@ class Utils:
             timestamp_field = metric.pop("timestamp", global_timestamp_field)
             correlation = metric.pop("correlation", "")
             context = metric.pop("context", 5)
+            metric_type = metric.pop("type", None)
             self.logger.info("Collecting %s", metric_name)
             try:
                 if "agg" in metric:
@@ -83,8 +85,11 @@ class Utils:
                 metric["timestamp"] = timestamp_field
                 metric["correlation"] = correlation
                 metric["context"] = context
-                for metric_dataframe_name in metric_dataframe_names:
-                    metrics_config[metric_dataframe_name] = metric
+                if metric_type != "metadata":
+                    for metric_dataframe_name in metric_dataframe_names:
+                        metrics_config[metric_dataframe_name] = metric
+                else:
+                    metadata_columns.extend(metric_dataframe_names)
                 dataframe_list.append(metric_df)
                 self.logger.debug(metric_df)
             except Exception as e:
@@ -93,7 +98,7 @@ class Utils:
                     metric_name,
                     e,
                 )
-        return dataframe_list, metrics_config
+        return dataframe_list, metrics_config, metadata_columns
 
 
     def process_aggregation_metric(
@@ -399,9 +404,10 @@ class Utils:
         )
         # get metrics data and dataframe
         metrics = test["metrics"]
-        dataframe_list, metrics_config = self.get_metric_data(
+        dataframe_list, metrics_config, metadata_columns = self.get_metric_data(
             uuids, metrics, match, test_threshold, timestamp_field
         )
+        test["metadata_columns"] = metadata_columns
         if not dataframe_list:
             return None, metrics_config
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds metadata type metric.

Bypases analysis and presents the metrics as an attribute of the result

### Results
With the metric

```
      - name: kubeBurnerVersion
        metricName.keyword: jobSummary
        metric_of_interest: k8sVersion
        not:
          jobConfig.name: "garbage-collection"
        type: metadata
```

#### Text
```
payload-node-density
====================
time                 uuid                                  kubeBurnerVersion_k8sVersion    ocpVersion                           podReadyLatency_P99    containersStartedLatency_P99    apiserverCPU_avg    ovnCPU_avg    ovnCPU-ovncontroller_avg
-------------------  ------------------------------------  ------------------------------  ---------------------------------  ---------------------  ------------------------------  ------------------  ------------  --------------------------
2026-04-28 22:01:19  d50a9500-5000-4865-9db3-5e0645533176  v1.35.3                         5.0.0-0.nightly-2026-04-28-195058                   3000                            2452             40.5224       2.32662                     3.0434
2026-04-29 06:56:53  b80d678e-3bfa-4020-8b84-c13d07ca8078  v1.35.3                         5.0.0-0.nightly-2026-04-29-043930                   2000                            2262             39.8249       2.38109                     2.6622
2026-04-29 15:39:19  9187feda-7897-46de-8f40-fd2bf4cb4c4a  v1.35.3                         5.0.0-0.nightly-2026-04-29-125648                   3000                            2351             44.6435       2.40655                     2.82389
2026-04-30 03:32:26  2c5380b7-3fa8-48bf-98b1-f81a42a20b47  v1.35.3                         5.0.0-0.nightly-2026-04-30-010124                   3000                            2291             37.3084       2.34033                     2.58907
2026-04-30 11:01:43  99199e7e-2f19-436c-93e8-657c69bd9b3e  v1.35.3                         5.0.0-0.nightly-2026-04-30-083209                   3000                            2730             39.2978       2.35986                     2.76098
2026-04-30 17:59:39  df8ea54f-8e34-4584-a841-8373ae18941a  v1.35.3                         5.0.0-0.nightly-2026-04-30-154809                   3000                            2428             41.771        2.37506                     2.76524
2026-05-01 03:38:46  a97526c2-130f-422f-87d3-54d904c54b49  v1.35.3                         5.0.0-0.nightly-2026-05-01-010944                   3000                            2337             35.7709       2.29893                     2.66581
2026-05-01 12:32:33  40014c9c-36b6-4d42-88d3-99f90e5fdbf0  v1.35.3                         5.0.0-0.nightly-2026-05-01-102026                   3000                            2307             42.2475       2.43672                     2.89748
```

#### Json
```
{
  "periodic": [
    {
      "uuid": "d50a9500-5000-4865-9db3-5e0645533176",
      "kubeBurnerVersion_k8sVersion": "v1.35.3",
      "timestamp": 1777413679,
      "ocpVersion": "5.0.0-0.nightly-2026-04-28-195058",
      "prs": [
        "https://github.com/openshift/cluster-bootstrap/pull/127",
        "https://github.com/openshift/oc-mirror/pull/1391",
        "https://github.com/openshift/machine-api-operator/pull/1491",
        "https://github.com/openshift/console/pull/15655",
        "https://github.com/openshift/cluster-kube-storage-version-migrator-operator/pull/158",
        "https://github.com/openshift/cluster-kube-storage-version-migrator-operator/pull/159",
        "https://github.com/openshift/cluster-etcd-operator/pull/1597",
        "https://github.com/openshift/console/pull/16228",
```

#### Junit
```
		<testcase name="[Jira: Networking / ovn-kubernetes] ovnCPU-sbdb_avg regression detection" timestamp="1778692864">
			<failure>
+----+--------------------------------------+----------------------+-------------------+------------------+---------------------+--------------------------------+
|    | uuid                                 | timestamp            |   ovnCPU-sbdb_avg | is_changepoint   |   percentage_change | kubeBurnerVersion_k8sVersion   |
|----+--------------------------------------+----------------------+-------------------+------------------+---------------------+--------------------------------|
|  0 | d50a9500-5000-4865-9db3-5e0645533176 | 2026-04-28T22:01:19Z |          0.534473 | False            |              0      | v1.35.3                        |
|  1 | b80d678e-3bfa-4020-8b84-c13d07ca8078 | 2026-04-29T06:56:53Z |          0.513225 | False            |              0      | v1.35.3                        |
|  2 | 9187feda-7897-46de-8f40-fd2bf4cb4c4a | 2026-04-29T15:39:19Z |          0.523625 | False            |              0      | v1.35.3                        |
|  3 | 2c5380b7-3fa8-48bf-98b1-f81a42a20b47 | 2026-04-30T03:32:26Z |          0.532988 | False            |              0      | v1.35.3                        |
|  4 | 99199e7e-2f19-436c-93e8-657c69bd9b3e | 2026-04-30T11:01:43Z |          0.505948 | False            |              0      | v1.35.3                        |
|  5 | df8ea54f-8e34-4584-a841-8373ae18941a | 2026-04-30T17:59:39Z |          0.519995 | False            |              0      | v1.35.3                        |
|  6 | a97526c2-130f-422f-87d3-54d904c54b49 | 2026-05-01T03:38:46Z |          0.479828 | False            |              0      | v1.35.3                        |
|  7 | 40014c9c-36b6-4d42-88d3-99f90e5fdbf0 | 2026-05-01T12:32:33Z |          0.547969 | False            |              0      | v1.35.3                        |
|  8 | f1acf62c-ca2f-448e-a13e-79663cccdccb | 2026-05-02T06:50:24Z |          0.513369 | False            |              0      | v1.35.3                        |
|  9 | 4e6378ae-9b71-4964-a479-380c4fb18b71 | 2026-05-02T13:00:32Z |          0.489603 | False            |              0      | v1.35.3                        |
| 10 | 9ee257ec-1ed2-46af-bdec-7f98a8bd3328 | 2026-05-02T19:04:26Z |          0.551721 | False            |              0      | v1.35.3                        |
| 11 | f938f8fe-0283-4a86-a3c8-99a0e953c8d4 | 2026-05-03T01:08:29Z |          0.51333  | False            |              0      | v1.35.3                        |
| 12 | 490a61fe-0b75-4a90-bcef-294cdbe331d1 | 2026-05-03T07:44:34Z |          0.532054 | False            |              0      | v1.35.3                        |
| 13 | 748b1030-346f-4778-85a7-f6e9a78dc6ba | 2026-05-03T15:03:50Z |          0.51515  | False            |              0      | v1.35.3                        |
| 14 | 24e769db-894b-41fd-9077-439ddd254f92 | 2026-05-03T21:51:20Z |          0.505338 | False            |              0      | v1.35.3                        |
| 15 | d4678d78-e60f-4056-b10f-416aa272ce50 | 2026-05-04T11:12:30Z |          0.524996 | False            |              0      | v1.35.3                        |
| 16 | aa0d4542-4917-4add-b825-219e00e90d20 | 2026-05-04T18:13:48Z |          0.505203 | False            |              0      | v1.35.3                        |
| 17 | 68d5bb86-5c07-4677-8e81-248698d39195 | 2026-05-05T10:37:37Z |          0.49974  | False            |              0      | v1.35.3                        |
| 18 | cf7154e2-aa91-42f8-9cfd-2e856cebbb47 | 2026-05-05T19:25:42Z |          0.504501 | False            |              0      | v1.35.3                        |
| 19 | ef1ce21a-783a-4045-9c67-d431d9868c41 | 2026-05-06T01:26:34Z |          0.509253 | False            |              0      | v1.35.3                        |
| 20 | d5206e34-c18f-48aa-9a7e-56777e7bfc97 | 2026-05-06T07:44:14Z |          0.528662 | False            |              0      | v1.35.3                        |
| 21 | dd54c653-481e-4d68-bc6b-89d16b663eea | 2026-05-06T15:14:11Z |          0.524683 | False            |              0      | v1.35.3                        |
| 22 | 659d882b-0a72-4c31-b409-4dda99c8fbb9 | 2026-05-06T23:39:05Z |          0.522653 | False            |              0      | v1.35.3                        |
| 23 | c548267b-f223-4d3e-a989-9a82d3fcd4b9 | 2026-05-07T07:45:37Z |          0.530134 | False            |              0      | v1.35.3                        |
| 24 | 77ade3ba-8bbd-4a7b-9072-0b7a5ecba2c0 | 2026-05-07T13:52:50Z |          0.519633 | False            |              0      | v1.35.3                        |
| 25 | 65685bb4-c500-40ac-8db5-6f27c33900b6 | 2026-05-07T21:11:01Z |          0.543193 | False            |              0      | v1.35.3                        |
| 26 | cd5992f5-4485-4e40-bc39-1d1a0652b79d | 2026-05-08T04:51:12Z |          0.759586 | True             |             47.0102 | v1.35.3                        | -- changepoint
| 27 | 5421ba2d-423d-4e04-84a0-a36ef01f1102 | 2026-05-08T13:06:21Z |          0.77224  | False            |              0      | v1.35.3                        |
```


## Related Tickets & Documents

- Need #373 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata metrics: new metric type that fetches data but is excluded from regression analysis.
  * Build URL shortening: automatic, concurrent TinyURL shortening when enabled.

* **Bug Fixes**
  * Improved metric filtering so keys like "type" and aggregation flags are not misinterpreted as metrics.
  * Dynamic attribute handling to better capture and include relevant metadata fields.

* **Documentation**
  * Added Metadata Metrics section with configuration and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->