### PR TITLE
Adds ES query batching to save time on Orion execution

### DIFF
--- a/examples/trt-external-payload-node-density.yaml
+++ b/examples/trt-external-payload-node-density.yaml
@@ -20,6 +20,13 @@ tests:
         stream: okd
 
     metrics:
+      - name: kubeBurnerVersion
+        metricName.keyword: jobSummary
+        metric_of_interest: k8sVersion
+        not:
+          jobConfig.name: "garbage-collection"
+        type: metadata
+
       - name: podReadyLatency
         metricName.keyword: podLatencyQuantilesMeasurement
         quantileName: Ready

--- a/orion/config.py
+++ b/orion/config.py
@@ -85,6 +85,13 @@ def load_config(config_path: str, input_vars: Dict[str, Any]) -> Dict[str, Any]:
         for metric in test["metrics"]:
             metric_name = test["name"] + ":" + metric["name"]
             if "agg" in metric:
+                if metric["agg"]["agg_type"] == "percentiles" and "percents" not in metric["agg"]:
+                    logger.error(
+                        "Metric '%s' in test '%s' has agg_type 'percentiles' "
+                        "but no 'percents' list defined in the agg block",
+                        metric["name"], test["name"]
+                    )
+                    sys.exit(1)
                 metric_name = f"{metric_name}:{metric['agg']['agg_type']}"
             elif "metric_of_interest" in metric:
                 metric_name = f"{metric_name}:{metric['metric_of_interest']}"

--- a/orion/constants.py
+++ b/orion/constants.py
@@ -25,3 +25,9 @@ CMR="cmr"
 #
 CHANGEPOINT_BUFFER = 5
 EXPAND_POINTS = 5
+
+# Maximum number of metrics to include in a single batched ES query.
+# Configs with many metrics (50+) can produce queries whose cross-product
+# exhausts memory during DataFrame merges. Chunking at 15 keeps each
+# round-trip manageable while still reducing total queries vs one-at-a-time.
+BATCH_METRIC_CHUNK_SIZE = 15

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -520,6 +520,9 @@ class Matcher:
                 field = metric["metric_of_interest"]
                 filtered = uuid_bucket[agg_name]
 
+                if filtered.doc_count == 0:
+                    continue
+
                 row = {
                     self.uuid_field: uuid_val,
                     timestamp_field: ts_val,
@@ -601,7 +604,10 @@ class Matcher:
         results = {m["name"]: [] for m in metrics_list}
         for doc in runs:
             for metric_name, match_fields in filter_fields_by_metric:
-                if all(doc.get(k) == v for k, v in match_fields.items()):
+                if all(
+                    doc.get(k.replace(".keyword", "")) == v
+                    for k, v in match_fields.items()
+                ):
                     results[metric_name].append(doc)
                     break
 

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -578,7 +578,8 @@ class Matcher:
                 for k, v in metric.get("not", {}).items()
             ]
             should_clauses.append(Q("bool", must=filter_clauses + not_clauses))
-            filter_fields_by_metric.append((metric["name"], match_fields))
+            not_fields = metric.get("not", {})
+            filter_fields_by_metric.append((metric["name"], match_fields, not_fields))
 
         query = Q(
             "bool",
@@ -603,13 +604,25 @@ class Matcher:
 
         results = {m["name"]: [] for m in metrics_list}
         for doc in runs:
-            for metric_name, match_fields in filter_fields_by_metric:
-                if all(
+            matched = False
+            for metric_name, match_fields, not_fields in filter_fields_by_metric:
+                matches_positive = all(
                     doc.get(k.replace(".keyword", "")) == v
                     for k, v in match_fields.items()
-                ):
+                )
+                matches_negative = all(
+                    doc.get(k.replace(".keyword", "")) != v
+                    for k, v in not_fields.items()
+                )
+                if matches_positive and matches_negative:
                     results[metric_name].append(doc)
+                    matched = True
                     break
+            if not matched:
+                self.logger.debug(
+                    "Document did not match any metric filter: %s",
+                    doc.get(self.uuid_field)
+                )
 
         return results
 

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -468,7 +468,7 @@ class Matcher:
             metric_filter_clauses = [
                 Q("match", **{k: v})
                 for k, v in metric.items()
-                if k not in ("name", "metric_of_interest", "not", "agg")
+                if k not in ("name", "metric_of_interest", "not", "agg", "type")
             ]
             not_clauses = [
                 ~Q("match", **{k: v})
@@ -575,7 +575,7 @@ class Matcher:
         if not metrics_list:
             return {}
 
-        excluded_keys = {"name", "metric_of_interest", "not"}
+        excluded_keys = {"name", "metric_of_interest", "not", "type"}
         filter_fields_by_metric = []
         should_clauses = []
         for metric in metrics_list:

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -353,8 +353,13 @@ class Matcher:
         uuid_bucket.metric("time", "avg", field=timestamp_field)
          # Handle percentile aggregations differently from single-value aggregations
         if agg_type == "percentiles":
-            # Get the percentile values from config (default to [50, 95, 99])
-            percents = metrics["agg"].get("percents", [50, 95, 99])
+            percents = metrics["agg"].get("percents")
+            if not percents:
+                self.logger.error(
+                    "Metric '%s' has agg_type 'percentiles' but no 'percents' list — skipping",
+                    metrics["name"]
+                )
+                return []
             uuid_bucket.metric(
                 metric_of_interest, "percentiles",
                 field=metrics["metric_of_interest"],
@@ -473,7 +478,13 @@ class Matcher:
             filtered_bucket = uuid_bucket.bucket(agg_name, "filter", metric_filter)
 
             if agg_type == "percentiles":
-                percents = metric["agg"].get("percents", [50, 95, 99])
+                percents = metric["agg"].get("percents")
+                if not percents:
+                    self.logger.error(
+                        "Metric '%s' has agg_type 'percentiles' but no 'percents' list — skipping",
+                        metric["name"]
+                    )
+                    continue
                 filtered_bucket.metric(field, "percentiles", field=field, percents=percents)
             elif agg_type == "count":
                 filtered_bucket.metric(field, "value_count", field=field)

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -420,6 +420,193 @@ class Matcher:
             res.append(data)
         return res
 
+    def get_agg_metrics_batch(
+        self, uuids: List[str],
+        metrics_list: List[Dict[str, Any]],
+        timestamp_field: str = "timestamp"
+    ) -> Dict[str, List[Dict[Any, Any]]]:
+        """Execute a single ES query with multiple sub-aggregations, one per metric.
+
+        Args:
+            uuids: List of UUIDs to filter on.
+            metrics_list: List of metric config dicts, each with 'name',
+                          'metric_of_interest', 'agg' block, and filter fields.
+            timestamp_field: Timestamp field name.
+
+        Returns:
+            Dict mapping metric name -> list of parsed result dicts.
+        """
+        if not metrics_list:
+            return {}
+
+        query = Q(
+            "bool",
+            must=[Q("terms", **{self.uuid_field + ".keyword": uuids})],
+        )
+        search = (
+            Search(using=self.es, index=self.index)
+            .query(query)
+            .extra(size=0)
+            .sort({timestamp_field: {"order": "desc"}})
+        )
+
+        uuid_bucket = search.aggs.bucket(
+            "uuid", "terms", field=self.uuid_field + ".keyword", size=len(uuids)
+        )
+        uuid_bucket.metric("time", "avg", field=timestamp_field)
+
+        for metric in metrics_list:
+            agg_name = metric["name"]
+            agg_type = metric["agg"]["agg_type"]
+            field = metric["metric_of_interest"]
+
+            metric_filter_clauses = [
+                Q("match", **{k: v})
+                for k, v in metric.items()
+                if k not in ("name", "metric_of_interest", "not", "agg")
+            ]
+            not_clauses = [
+                ~Q("match", **{k: v})
+                for k, v in metric.get("not", {}).items()
+            ]
+            metric_filter = Q("bool", must=metric_filter_clauses + not_clauses)
+            filtered_bucket = uuid_bucket.bucket(agg_name, "filter", metric_filter)
+
+            if agg_type == "percentiles":
+                percents = metric["agg"].get("percents", [50, 95, 99])
+                filtered_bucket.metric(field, "percentiles", field=field, percents=percents)
+            elif agg_type == "count":
+                filtered_bucket.metric(field, "value_count", field=field)
+            else:
+                filtered_bucket.metric(field, agg_type, field=field)
+
+        self.logger.info(
+            "Executing batched aggregation query for %d metrics against index %s",
+            len(metrics_list), self.index,
+        )
+        self.logger.debug("Executing query \r\n%s", search.to_dict())
+
+        result = search.execute()
+        return self.parse_batch_agg_results(result, metrics_list, timestamp_field)
+
+    def parse_batch_agg_results(
+        self, data, metrics_list: List[Dict[str, Any]],
+        timestamp_field: str = "timestamp"
+    ) -> Dict[str, List[Dict[Any, Any]]]:
+        """Parse a batched multi-aggregation response into per-metric result lists.
+
+        Args:
+            data: ES response object.
+            metrics_list: Same list passed to get_agg_metrics_batch.
+            timestamp_field: Timestamp field name.
+
+        Returns:
+            Dict mapping metric name -> list of result dicts (one per UUID).
+        """
+        results = {m["name"]: [] for m in metrics_list}
+
+        if "aggregations" not in data:
+            return results
+
+        uuid_buckets = data.aggregations.uuid.buckets
+
+        for uuid_bucket in uuid_buckets:
+            uuid_val = uuid_bucket.key
+            ts_val = uuid_bucket.time.value_as_string
+
+            for metric in metrics_list:
+                agg_name = metric["name"]
+                agg_type = metric["agg"]["agg_type"]
+                field = metric["metric_of_interest"]
+                filtered = uuid_bucket[agg_name]
+
+                row = {
+                    self.uuid_field: uuid_val,
+                    timestamp_field: ts_val,
+                }
+
+                if agg_type == "percentiles":
+                    pct_dict = filtered[field].to_dict().get("values", {})
+                    if "target_percentile" in metric.get("agg", {}):
+                        target = str(float(metric["agg"]["target_percentile"]))
+                        col = f"{field}_{agg_type}_{target}"
+                        row[col] = pct_dict.get(target)
+                    else:
+                        for k, v in pct_dict.items():
+                            row[f"{field}_{agg_type}_{k}"] = v
+                else:
+                    col = f"{field}_{agg_type}"
+                    row[col] = filtered[field].value
+
+                results[agg_name].append(row)
+
+        return results
+
+    def get_results_batch(
+        self,
+        uuids: List[str],
+        metrics_list: List[Dict[str, Any]],
+        timestamp_field: str = "timestamp"
+    ) -> Dict[str, List[Dict[Any, Any]]]:
+        """Fetch multiple standard metrics in a single ES query using an OR filter.
+
+        Args:
+            uuids: List of UUIDs.
+            metrics_list: List of metric config dicts.
+            timestamp_field: Timestamp field name.
+
+        Returns:
+            Dict mapping metric name -> list of hit _source dicts.
+        """
+        if not metrics_list:
+            return {}
+
+        excluded_keys = {"name", "metric_of_interest", "not"}
+        filter_fields_by_metric = []
+        should_clauses = []
+        for metric in metrics_list:
+            match_fields = {
+                k: v for k, v in metric.items()
+                if k not in excluded_keys
+            }
+            filter_clauses = [Q("match", **{k: v}) for k, v in match_fields.items()]
+            not_clauses = [
+                ~Q("match", **{k: v})
+                for k, v in metric.get("not", {}).items()
+            ]
+            should_clauses.append(Q("bool", must=filter_clauses + not_clauses))
+            filter_fields_by_metric.append((metric["name"], match_fields))
+
+        query = Q(
+            "bool",
+            must=[Q("terms", **{self.uuid_field + ".keyword": uuids})],
+            should=should_clauses,
+            minimum_should_match=1,
+        )
+        search = (
+            Search(using=self.es, index=self.index)
+            .query(query)
+            .extra(size=self.search_size)
+            .sort({timestamp_field: {"order": "desc"}})
+        )
+
+        self.logger.info(
+            "Executing batched standard query for %d metrics against index %s",
+            len(metrics_list), self.index,
+        )
+
+        all_hits = self.query_index(search, return_all=True)
+        runs = [hit.to_dict()["_source"] for hit in all_hits]
+
+        results = {m["name"]: [] for m in metrics_list}
+        for doc in runs:
+            for metric_name, match_fields in filter_fields_by_metric:
+                if all(doc.get(k) == v for k, v in match_fields.items()):
+                    results[metric_name].append(doc)
+                    break
+
+        return results
+
     def convert_to_df(
         self, data: Dict[Any, Any],
         columns: List[str] = None,

--- a/orion/tests/test_config.py
+++ b/orion/tests/test_config.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for config validation in orion/config.py
+"""
+
+# pylint: disable = redefined-outer-name
+# pylint: disable = missing-function-docstring
+
+import tempfile
+import os
+
+import pytest
+import yaml
+
+from orion.config import load_config
+
+
+def _write_config(tmp_dir, config_dict, filename="config.yaml"):
+    """Write a config dict as YAML to a temp file and return its path."""
+    path = os.path.join(tmp_dir, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.dump(config_dict, f)
+    return path
+
+
+def _minimal_config(metrics):
+    """Return a minimal valid config dict with the given metrics list."""
+    return {
+        "tests": [
+            {
+                "name": "test1",
+                "metadata": {
+                    "platform": "AWS",
+                    "benchmark.keyword": "test-bench",
+                    "ocpVersion": "4.17",
+                },
+                "metrics": metrics,
+            }
+        ]
+    }
+
+
+class TestPercentileValidation:
+    """Tests for percentile agg_type requiring percents in config."""
+
+    def test_percentile_without_percents_exits(self):
+        metric = {
+            "name": "latency_p95",
+            "metricName": "api_latency",
+            "metric_of_interest": "response_time_ms",
+            "agg": {
+                "value": "response_time_ms",
+                "agg_type": "percentiles",
+            },
+            "threshold": 10,
+            "direction": 1,
+        }
+        config = _minimal_config([metric])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _write_config(tmp_dir, config)
+            with pytest.raises(SystemExit):
+                load_config(path, {})
+
+    def test_percentile_with_percents_passes(self):
+        metric = {
+            "name": "latency_p95",
+            "metricName": "api_latency",
+            "metric_of_interest": "response_time_ms",
+            "agg": {
+                "value": "response_time_ms",
+                "agg_type": "percentiles",
+                "percents": [50, 95, 99],
+            },
+            "threshold": 10,
+            "direction": 1,
+        }
+        config = _minimal_config([metric])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _write_config(tmp_dir, config)
+            result = load_config(path, {})
+            assert result is not None
+            assert len(result["tests"]) == 1
+
+    def test_non_percentile_agg_without_percents_passes(self):
+        metric = {
+            "name": "avg_cpu",
+            "metricName": "containerCPU",
+            "metric_of_interest": "cpu",
+            "agg": {
+                "value": "cpu",
+                "agg_type": "avg",
+            },
+            "threshold": 10,
+            "direction": 1,
+        }
+        config = _minimal_config([metric])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _write_config(tmp_dir, config)
+            result = load_config(path, {})
+            assert result is not None
+            assert len(result["tests"]) == 1

--- a/orion/tests/test_matcher_batch.py
+++ b/orion/tests/test_matcher_batch.py
@@ -433,14 +433,14 @@ class TestGetResultsBatch:
             _make_fake_hit({
                 "uuid": "uuid1",
                 "metricName": "containerCPU",
-                "labels.namespace.keyword": "openshift-kube-apiserver",
+                "labels.namespace": "openshift-kube-apiserver",
                 "cpu": 0.42,
                 "timestamp": "2024-02-09T12:00:00",
             }),
             _make_fake_hit({
                 "uuid": "uuid2",
                 "metricName": "containerCPU",
-                "labels.namespace.keyword": "openshift-kube-apiserver",
+                "labels.namespace": "openshift-kube-apiserver",
                 "cpu": 0.55,
                 "timestamp": "2024-02-09T13:00:00",
             }),
@@ -476,14 +476,14 @@ class TestGetResultsBatch:
             {
                 "uuid": "uuid1",
                 "metricName": "containerCPU",
-                "labels.namespace.keyword": "openshift-kube-apiserver",
+                "labels.namespace": "openshift-kube-apiserver",
                 "cpu": 0.42,
                 "timestamp": "2024-02-09T12:00:00",
             },
             {
                 "uuid": "uuid2",
                 "metricName": "containerCPU",
-                "labels.namespace.keyword": "openshift-kube-apiserver",
+                "labels.namespace": "openshift-kube-apiserver",
                 "cpu": 0.55,
                 "timestamp": "2024-02-09T13:00:00",
             },

--- a/orion/tests/test_matcher_batch.py
+++ b/orion/tests/test_matcher_batch.py
@@ -1,0 +1,572 @@
+"""
+Unit Test file for batched queries in Matcher (aggregation and standard).
+"""
+
+# pylint: disable = redefined-outer-name
+# pylint: disable = missing-function-docstring
+# pylint: disable = import-error, duplicate-code
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from opensearch_dsl import Search
+from opensearch_dsl.response import Response
+
+from orion.tests.test_matcher import make_matcher_fixture
+
+
+@pytest.fixture
+def matcher_instance():
+    return make_matcher_fixture(index="ripsaw-kube-burner-*")
+
+
+@pytest.fixture
+def uuid_matcher_instance():
+    return make_matcher_fixture(
+        index="krkn-telemetry",
+        uuid_field="run_uuid",
+        version_field="cluster_version",
+    )
+
+
+def _make_metrics():
+    return [
+        {
+            "name": "apiserverCPU",
+            "metricName": "containerCPU",
+            "labels.namespace.keyword": "openshift-kube-apiserver",
+            "metric_of_interest": "cpu",
+            "agg": {"value": "cpu", "agg_type": "avg"},
+        },
+        {
+            "name": "etcdCPU",
+            "metricName": "containerCPU",
+            "labels.namespace.keyword": "openshift-etcd",
+            "metric_of_interest": "cpu",
+            "agg": {"value": "cpu", "agg_type": "avg"},
+        },
+        {
+            "name": "ovsMemory-Workers",
+            "metricName": "containerMemory",
+            "labels.namespace.keyword": "openshift-ovs",
+            "metric_of_interest": "memory",
+            "agg": {"value": "memory", "agg_type": "max"},
+        },
+    ]
+
+
+class TestGetAggMetricsBatch:
+    """Tests for Matcher.get_agg_metrics_batch."""
+
+    def test_returns_empty_for_no_metrics(self, matcher_instance):
+        result = matcher_instance.get_agg_metrics_batch(["uuid1"], [])
+        assert result == {}
+
+    def test_builds_single_query_with_multiple_aggs(self, matcher_instance):
+        metrics_list = _make_metrics()
+        data_dict = {
+            "aggregations": {
+                "uuid": {
+                    "buckets": [
+                        {
+                            "key": "uuid1",
+                            "time": {"value_as_string": "2024-02-09T12:00:00"},
+                            "apiserverCPU": {"doc_count": 5, "cpu": {"value": 0.42}},
+                            "etcdCPU": {"doc_count": 5, "cpu": {"value": 0.31}},
+                            "ovsMemory-Workers": {"doc_count": 5, "memory": {"value": 1024}},
+                        },
+                        {
+                            "key": "uuid2",
+                            "time": {"value_as_string": "2024-02-09T13:00:00"},
+                            "apiserverCPU": {"doc_count": 5, "cpu": {"value": 0.55}},
+                            "etcdCPU": {"doc_count": 5, "cpu": {"value": 0.38}},
+                            "ovsMemory-Workers": {"doc_count": 5, "memory": {"value": 2048}},
+                        },
+                    ]
+                }
+            }
+        }
+
+        def mock_execute(self):
+            return Response(response=data_dict, search=self)
+
+        with patch.object(Search, "execute", mock_execute):
+            result = matcher_instance.get_agg_metrics_batch(
+                ["uuid1", "uuid2"], metrics_list
+            )
+
+        assert isinstance(result, dict)
+        assert len(result) == 3
+        for m in metrics_list:
+            assert m["name"] in result
+
+        assert result["apiserverCPU"] == [
+            {"uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "cpu_avg": 0.42},
+            {"uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "cpu_avg": 0.55},
+        ]
+        assert result["etcdCPU"] == [
+            {"uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "cpu_avg": 0.31},
+            {"uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "cpu_avg": 0.38},
+        ]
+        assert result["ovsMemory-Workers"] == [
+            {"uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "memory_max": 1024},
+            {"uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "memory_max": 2048},
+        ]
+
+    def test_empty_buckets_returns_empty_lists(self, matcher_instance):
+        metrics_list = _make_metrics()
+        data_dict = {"aggregations": {"uuid": {"buckets": []}}}
+
+        def mock_execute(self):
+            return Response(response=data_dict, search=self)
+
+        with patch.object(Search, "execute", mock_execute):
+            result = matcher_instance.get_agg_metrics_batch(
+                ["uuid1"], metrics_list
+            )
+
+        for m in metrics_list:
+            assert result[m["name"]] == []
+
+    def test_no_aggregations_key_returns_empty_lists(self, matcher_instance):
+        metrics_list = _make_metrics()
+        data_dict = {"hits": {"hits": []}}
+
+        def mock_execute(self):
+            return Response(response=data_dict, search=self)
+
+        with patch.object(Search, "execute", mock_execute):
+            result = matcher_instance.get_agg_metrics_batch(
+                ["uuid1"], metrics_list
+            )
+
+        for m in metrics_list:
+            assert result[m["name"]] == []
+
+    def test_custom_uuid_field(self, uuid_matcher_instance):
+        metrics_list = [
+            {
+                "name": "apiserverCPU",
+                "metricName": "containerCPU",
+                "metric_of_interest": "cpu",
+                "agg": {"value": "cpu", "agg_type": "avg"},
+            },
+        ]
+        data_dict = {
+            "aggregations": {
+                "uuid": {
+                    "buckets": [
+                        {
+                            "key": "uuid1",
+                            "time": {"value_as_string": "2024-02-09T12:00:00"},
+                            "apiserverCPU": {"doc_count": 5, "cpu": {"value": 0.42}},
+                        },
+                    ]
+                }
+            }
+        }
+
+        def mock_execute(self):
+            return Response(response=data_dict, search=self)
+
+        with patch.object(Search, "execute", mock_execute):
+            result = uuid_matcher_instance.get_agg_metrics_batch(
+                ["uuid1"], metrics_list
+            )
+
+        assert result["apiserverCPU"] == [
+            {"run_uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "cpu_avg": 0.42},
+        ]
+
+
+class TestGetAggMetricsBatchPercentiles:
+    """Tests for percentile aggregations in batch mode."""
+
+    def test_percentile_with_target(self, matcher_instance):
+        metrics_list = [
+            {
+                "name": "api_latency_p99",
+                "metricName": "api_latency",
+                "metric_of_interest": "response_time_ms",
+                "agg": {
+                    "value": "response_time_ms",
+                    "agg_type": "percentiles",
+                    "percents": [50, 95, 99],
+                    "target_percentile": 99,
+                },
+            },
+        ]
+        data_dict = {
+            "aggregations": {
+                "uuid": {
+                    "buckets": [
+                        {
+                            "key": "uuid1",
+                            "time": {"value_as_string": "2024-02-09T12:00:00"},
+                            "api_latency_p99": {
+                                "doc_count": 10,
+                                "response_time_ms": {
+                                    "values": {
+                                        "50.0": 100.5,
+                                        "95.0": 250.3,
+                                        "99.0": 350.7,
+                                    }
+                                },
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+
+        def mock_execute(self):
+            return Response(response=data_dict, search=self)
+
+        with patch.object(Search, "execute", mock_execute):
+            result = matcher_instance.get_agg_metrics_batch(
+                ["uuid1"], metrics_list
+            )
+
+        assert result["api_latency_p99"] == [
+            {
+                "uuid": "uuid1",
+                "timestamp": "2024-02-09T12:00:00",
+                "response_time_ms_percentiles_99.0": 350.7,
+            },
+        ]
+
+    def test_percentile_without_target(self, matcher_instance):
+        metrics_list = [
+            {
+                "name": "api_latency_all",
+                "metricName": "api_latency",
+                "metric_of_interest": "response_time_ms",
+                "agg": {
+                    "value": "response_time_ms",
+                    "agg_type": "percentiles",
+                    "percents": [50, 95, 99],
+                },
+            },
+        ]
+        data_dict = {
+            "aggregations": {
+                "uuid": {
+                    "buckets": [
+                        {
+                            "key": "uuid1",
+                            "time": {"value_as_string": "2024-02-09T12:00:00"},
+                            "api_latency_all": {
+                                "doc_count": 10,
+                                "response_time_ms": {
+                                    "values": {
+                                        "50.0": 100.5,
+                                        "95.0": 250.3,
+                                        "99.0": 350.7,
+                                    }
+                                },
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+
+        def mock_execute(self):
+            return Response(response=data_dict, search=self)
+
+        with patch.object(Search, "execute", mock_execute):
+            result = matcher_instance.get_agg_metrics_batch(
+                ["uuid1"], metrics_list
+            )
+
+        assert result["api_latency_all"] == [
+            {
+                "uuid": "uuid1",
+                "timestamp": "2024-02-09T12:00:00",
+                "response_time_ms_percentiles_50.0": 100.5,
+                "response_time_ms_percentiles_95.0": 250.3,
+                "response_time_ms_percentiles_99.0": 350.7,
+            },
+        ]
+
+
+class TestGetAggMetricsBatchCount:
+    """Tests for count aggregation in batch mode."""
+
+    def test_count_aggregation(self, matcher_instance):
+        metrics_list = [
+            {
+                "name": "api_requests",
+                "metricName": "apiCalls",
+                "metric_of_interest": "request_id",
+                "agg": {"value": "request_id", "agg_type": "count"},
+            },
+        ]
+        data_dict = {
+            "aggregations": {
+                "uuid": {
+                    "buckets": [
+                        {
+                            "key": "uuid1",
+                            "time": {"value_as_string": "2024-02-09T12:00:00"},
+                            "api_requests": {
+                                "doc_count": 10,
+                                "request_id": {"value": 1250},
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+
+        def mock_execute(self):
+            return Response(response=data_dict, search=self)
+
+        with patch.object(Search, "execute", mock_execute):
+            result = matcher_instance.get_agg_metrics_batch(
+                ["uuid1"], metrics_list
+            )
+
+        assert result["api_requests"] == [
+            {"uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "request_id_count": 1250},
+        ]
+
+    def test_count_aggregation_multiple_uuids(self, matcher_instance):
+        metrics_list = [
+            {
+                "name": "api_requests",
+                "metricName": "apiCalls",
+                "metric_of_interest": "request_id",
+                "agg": {"value": "request_id", "agg_type": "count"},
+            },
+        ]
+        data_dict = {
+            "aggregations": {
+                "uuid": {
+                    "buckets": [
+                        {
+                            "key": "uuid1",
+                            "time": {"value_as_string": "2024-02-09T12:00:00"},
+                            "api_requests": {
+                                "doc_count": 10,
+                                "request_id": {"value": 1250},
+                            },
+                        },
+                        {
+                            "key": "uuid2",
+                            "time": {"value_as_string": "2024-02-09T13:00:00"},
+                            "api_requests": {
+                                "doc_count": 15,
+                                "request_id": {"value": 1520},
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+
+        def mock_execute(self):
+            return Response(response=data_dict, search=self)
+
+        with patch.object(Search, "execute", mock_execute):
+            result = matcher_instance.get_agg_metrics_batch(
+                ["uuid1", "uuid2"], metrics_list
+            )
+
+        assert result["api_requests"] == [
+            {"uuid": "uuid1", "timestamp": "2024-02-09T12:00:00", "request_id_count": 1250},
+            {"uuid": "uuid2", "timestamp": "2024-02-09T13:00:00", "request_id_count": 1520},
+        ]
+
+
+def _make_fake_hit(source_dict):
+    """Build a MagicMock that behaves like an opensearch-dsl hit."""
+    hit = MagicMock()
+    hit.to_dict.return_value = {"_source": source_dict}
+    return hit
+
+
+def _make_standard_metrics():
+    """Two standard metrics with different metricName values."""
+    return [
+        {
+            "name": "podReadyLatency",
+            "metricName": "podLatencyQuantilesMeasurement",
+            "quantileName": "Ready",
+            "metric_of_interest": "P99",
+            "not": {"jobConfig.name": "garbage-collection"},
+        },
+        {
+            "name": "apiserverCPU",
+            "metricName": "containerCPU",
+            "labels.namespace.keyword": "openshift-kube-apiserver",
+            "metric_of_interest": "cpu",
+        },
+    ]
+
+
+class TestGetResultsBatch:
+    """Tests for Matcher.get_results_batch."""
+
+    def test_returns_empty_for_no_metrics(self, matcher_instance):
+        result = matcher_instance.get_results_batch(["uuid1"], [])
+        assert result == {}
+
+    def test_partitioned_results_two_metrics(self, matcher_instance, monkeypatch):
+        metrics_list = _make_standard_metrics()
+
+        fake_hits = [
+            _make_fake_hit({
+                "uuid": "uuid1",
+                "metricName": "podLatencyQuantilesMeasurement",
+                "quantileName": "Ready",
+                "P99": 4500,
+                "timestamp": "2024-02-09T12:00:00",
+            }),
+            _make_fake_hit({
+                "uuid": "uuid2",
+                "metricName": "podLatencyQuantilesMeasurement",
+                "quantileName": "Ready",
+                "P99": 5200,
+                "timestamp": "2024-02-09T13:00:00",
+            }),
+            _make_fake_hit({
+                "uuid": "uuid1",
+                "metricName": "containerCPU",
+                "labels.namespace.keyword": "openshift-kube-apiserver",
+                "cpu": 0.42,
+                "timestamp": "2024-02-09T12:00:00",
+            }),
+            _make_fake_hit({
+                "uuid": "uuid2",
+                "metricName": "containerCPU",
+                "labels.namespace.keyword": "openshift-kube-apiserver",
+                "cpu": 0.55,
+                "timestamp": "2024-02-09T13:00:00",
+            }),
+        ]
+
+        monkeypatch.setattr(matcher_instance, "query_index",
+                            lambda *a, **k: fake_hits)
+
+        result = matcher_instance.get_results_batch(
+            ["uuid1", "uuid2"], metrics_list
+        )
+
+        assert isinstance(result, dict)
+        assert len(result) == 2
+
+        assert result["podReadyLatency"] == [
+            {
+                "uuid": "uuid1",
+                "metricName": "podLatencyQuantilesMeasurement",
+                "quantileName": "Ready",
+                "P99": 4500,
+                "timestamp": "2024-02-09T12:00:00",
+            },
+            {
+                "uuid": "uuid2",
+                "metricName": "podLatencyQuantilesMeasurement",
+                "quantileName": "Ready",
+                "P99": 5200,
+                "timestamp": "2024-02-09T13:00:00",
+            },
+        ]
+        assert result["apiserverCPU"] == [
+            {
+                "uuid": "uuid1",
+                "metricName": "containerCPU",
+                "labels.namespace.keyword": "openshift-kube-apiserver",
+                "cpu": 0.42,
+                "timestamp": "2024-02-09T12:00:00",
+            },
+            {
+                "uuid": "uuid2",
+                "metricName": "containerCPU",
+                "labels.namespace.keyword": "openshift-kube-apiserver",
+                "cpu": 0.55,
+                "timestamp": "2024-02-09T13:00:00",
+            },
+        ]
+
+    def test_no_hits_returns_empty_lists(self, matcher_instance, monkeypatch):
+        metrics_list = _make_standard_metrics()
+        monkeypatch.setattr(matcher_instance, "query_index",
+                            lambda *a, **k: [])
+
+        result = matcher_instance.get_results_batch(
+            ["uuid1"], metrics_list
+        )
+
+        for m in metrics_list:
+            assert result[m["name"]] == []
+
+    def test_custom_uuid_field(self, uuid_matcher_instance, monkeypatch):
+        metrics_list = [
+            {
+                "name": "nodeCPU",
+                "metricName": "nodeCPUSeconds-Infra",
+                "mode": "iowait",
+                "metric_of_interest": "value",
+            },
+        ]
+
+        fake_hits = [
+            _make_fake_hit({
+                "run_uuid": "uuid1",
+                "metricName": "nodeCPUSeconds-Infra",
+                "mode": "iowait",
+                "value": 3.14,
+                "timestamp": "2024-02-09T12:00:00",
+            }),
+        ]
+
+        monkeypatch.setattr(uuid_matcher_instance, "query_index",
+                            lambda *a, **k: fake_hits)
+
+        result = uuid_matcher_instance.get_results_batch(
+            ["uuid1"], metrics_list
+        )
+
+        assert result["nodeCPU"] == [
+            {
+                "run_uuid": "uuid1",
+                "metricName": "nodeCPUSeconds-Infra",
+                "mode": "iowait",
+                "value": 3.14,
+                "timestamp": "2024-02-09T12:00:00",
+            },
+        ]
+
+    def test_unmatched_metric_name_skipped(self, matcher_instance, monkeypatch):
+        """Hits with a metricName not in the metrics list are dropped."""
+        metrics_list = [
+            {
+                "name": "apiserverCPU",
+                "metricName": "containerCPU",
+                "metric_of_interest": "cpu",
+            },
+        ]
+
+        fake_hits = [
+            _make_fake_hit({
+                "uuid": "uuid1",
+                "metricName": "containerCPU",
+                "cpu": 0.42,
+            }),
+            _make_fake_hit({
+                "uuid": "uuid1",
+                "metricName": "unknownMetric",
+                "foo": "bar",
+            }),
+        ]
+
+        monkeypatch.setattr(matcher_instance, "query_index",
+                            lambda *a, **k: fake_hits)
+
+        result = matcher_instance.get_results_batch(
+            ["uuid1"], metrics_list
+        )
+
+        assert len(result["apiserverCPU"]) == 1
+        assert result["apiserverCPU"][0]["metricName"] == "containerCPU"

--- a/orion/tests/test_utils_batch.py
+++ b/orion/tests/test_utils_batch.py
@@ -122,7 +122,7 @@ class TestAggBatchDispatch:
             "apiserverCPU": _agg_batch_data(),
         }
 
-        df_list, config = utils.get_metric_data(
+        df_list, config, _ = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -141,7 +141,7 @@ class TestAggBatchDispatch:
             "cpuMetric2": _agg_batch_data(metric_of_interest="mem", agg_type="sum"),
         }
 
-        df_list, config = utils.get_metric_data(
+        df_list, config, _ = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -166,7 +166,7 @@ class TestStdBatchDispatch:
             "podLatencyMetric": _std_batch_data(),
         }
 
-        df_list, config = utils.get_metric_data(
+        df_list, config, _ = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -185,7 +185,7 @@ class TestStdBatchDispatch:
             "latency2": _std_batch_data(metric_of_interest="ms"),
         }
 
-        df_list, config = utils.get_metric_data(
+        df_list, config, _ = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -208,7 +208,7 @@ class TestBatchFallback:
         match_mock.get_agg_metrics_batch.side_effect = RuntimeError("batch fail")
         match_mock.get_agg_metric_query.return_value = _agg_batch_data()
 
-        df_list, config = utils.get_metric_data(
+        df_list, config, _ = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -224,7 +224,7 @@ class TestBatchFallback:
         match_mock.get_results_batch.side_effect = RuntimeError("batch fail")
         match_mock.get_results.return_value = _std_batch_data()
 
-        df_list, config = utils.get_metric_data(
+        df_list, config, _ = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -252,7 +252,7 @@ class TestMixedMetrics:
             "stdMetric": _std_batch_data(),
         }
 
-        df_list, config = utils.get_metric_data(
+        df_list, config, _ = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -429,7 +429,7 @@ class TestChunkedBatching:
 
         match_mock.get_agg_metrics_batch.side_effect = batch_side_effect
 
-        df_list, config = utils.get_metric_data(
+        df_list, config, _ = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -447,7 +447,7 @@ class TestChunkedBatching:
 
         match_mock.get_results_batch.side_effect = batch_side_effect
 
-        df_list, config = utils.get_metric_data(
+        df_list, config, _ = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -471,7 +471,7 @@ class TestChunkedBatching:
         match_mock.get_agg_metrics_batch.side_effect = batch_side_effect
         match_mock.get_agg_metric_query.return_value = _agg_batch_data()
 
-        df_list, _ = utils.get_metric_data(
+        df_list, _, _meta = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
@@ -487,9 +487,137 @@ class TestChunkedBatching:
             m["name"]: _agg_batch_data() for m in metrics
         }
 
-        df_list, _ = utils.get_metric_data(
+        df_list, _, _meta = utils.get_metric_data(
             UUIDS, metrics, match_mock, test_threshold=0
         )
 
         assert match_mock.get_agg_metrics_batch.call_count == 1
         assert len(df_list) == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests: metadata type metrics
+# ---------------------------------------------------------------------------
+
+def _agg_metadata_metric(name, metric_of_interest="version", agg_type="avg"):
+    m = _agg_metric(name, metric_of_interest, agg_type)
+    m["type"] = "metadata"
+    return m
+
+
+def _std_metadata_metric(name, metric_of_interest="value"):
+    m = _std_metric(name, metric_of_interest)
+    m["type"] = "metadata"
+    return m
+
+
+class TestMetadataTypeAgg:
+
+    def test_agg_metadata_excluded_from_metrics_config(self, utils, match_mock):
+        metrics = [copy.deepcopy(_agg_metadata_metric("k8sVersion"))]
+        match_mock.get_agg_metrics_batch.return_value = {
+            "k8sVersion": _agg_batch_data(metric_of_interest="version"),
+        }
+
+        _, config, meta_cols = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert len(config) == 0
+        assert "k8sVersion_avg" in meta_cols
+
+    def test_agg_metadata_dataframe_still_collected(self, utils, match_mock):
+        metrics = [copy.deepcopy(_agg_metadata_metric("k8sVersion"))]
+        match_mock.get_agg_metrics_batch.return_value = {
+            "k8sVersion": _agg_batch_data(metric_of_interest="version"),
+        }
+
+        df_list, _, _ = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert len(df_list) == 1
+
+
+class TestMetadataTypeStd:
+
+    def test_std_metadata_excluded_from_metrics_config(self, utils, match_mock):
+        metrics = [copy.deepcopy(_std_metadata_metric("clusterVersion"))]
+        match_mock.get_results_batch.return_value = {
+            "clusterVersion": _std_batch_data(),
+        }
+
+        _, config, meta_cols = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert len(config) == 0
+        assert "clusterVersion_value" in meta_cols
+
+    def test_std_metadata_dataframe_still_collected(self, utils, match_mock):
+        metrics = [copy.deepcopy(_std_metadata_metric("clusterVersion"))]
+        match_mock.get_results_batch.return_value = {
+            "clusterVersion": _std_batch_data(),
+        }
+
+        df_list, _, _ = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert len(df_list) == 1
+
+
+class TestMetadataTypeMixed:
+
+    def test_mixed_normal_and_metadata_routed_correctly(self, utils, match_mock):
+        normal = copy.deepcopy(_agg_metric("cpuUsage"))
+        meta = copy.deepcopy(_agg_metadata_metric("k8sVersion"))
+        metrics = [normal, meta]
+
+        match_mock.get_agg_metrics_batch.return_value = {
+            "cpuUsage": _agg_batch_data(),
+            "k8sVersion": _agg_batch_data(metric_of_interest="version"),
+        }
+
+        df_list, config, meta_cols = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert len(df_list) == 2
+        assert "cpuUsage_avg" in config
+        assert "k8sVersion_avg" not in config
+        assert "k8sVersion_avg" in meta_cols
+        assert "cpuUsage_avg" not in meta_cols
+
+    def test_mixed_std_normal_and_metadata(self, utils, match_mock):
+        normal = copy.deepcopy(_std_metric("podLatency"))
+        meta = copy.deepcopy(_std_metadata_metric("clusterVersion"))
+        metrics = [normal, meta]
+
+        match_mock.get_results_batch.return_value = {
+            "podLatency": _std_batch_data(),
+            "clusterVersion": _std_batch_data(),
+        }
+
+        df_list, config, meta_cols = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert len(df_list) == 2
+        assert "podLatency_value" in config
+        assert "clusterVersion_value" not in config
+        assert "clusterVersion_value" in meta_cols
+        assert "podLatency_value" not in meta_cols
+
+    def test_no_metadata_returns_empty_metadata_columns(self, utils, match_mock):
+        metrics = [copy.deepcopy(_agg_metric("cpuUsage"))]
+        match_mock.get_agg_metrics_batch.return_value = {
+            "cpuUsage": _agg_batch_data(),
+        }
+
+        _, config, meta_cols = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert len(meta_cols) == 0
+        assert "cpuUsage_avg" in config

--- a/orion/tests/test_utils_batch.py
+++ b/orion/tests/test_utils_batch.py
@@ -10,7 +10,7 @@ Unit tests for batched metric dispatch in orion/utils.py
 
 import copy
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -412,3 +412,84 @@ class TestMetadataPopBeforeBatch:
         match_mock.get_results_batch.side_effect = capture_batch_args
 
         utils.get_metric_data(UUIDS, metrics, match_mock, test_threshold=0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: chunked batching when metrics exceed BATCH_METRIC_CHUNK_SIZE
+# ---------------------------------------------------------------------------
+
+class TestChunkedBatching:
+
+    @patch("orion.utils.BATCH_METRIC_CHUNK_SIZE", 3)
+    def test_agg_metrics_split_into_chunks(self, utils, match_mock):
+        metrics = [copy.deepcopy(_agg_metric(f"agg_{i}")) for i in range(7)]
+
+        def batch_side_effect(_uuids, chunk, _ts):
+            return {m["name"]: _agg_batch_data() for m in chunk}
+
+        match_mock.get_agg_metrics_batch.side_effect = batch_side_effect
+
+        df_list, config = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert match_mock.get_agg_metrics_batch.call_count == 3  # ceil(7/3)
+        assert len(df_list) == 7
+        for i in range(7):
+            assert f"agg_{i}_avg" in config
+
+    @patch("orion.utils.BATCH_METRIC_CHUNK_SIZE", 3)
+    def test_std_metrics_split_into_chunks(self, utils, match_mock):
+        metrics = [copy.deepcopy(_std_metric(f"std_{i}")) for i in range(5)]
+
+        def batch_side_effect(_uuids, chunk, _ts):
+            return {m["name"]: _std_batch_data() for m in chunk}
+
+        match_mock.get_results_batch.side_effect = batch_side_effect
+
+        df_list, config = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert match_mock.get_results_batch.call_count == 2  # ceil(5/3)
+        assert len(df_list) == 5
+        for i in range(5):
+            assert f"std_{i}_value" in config
+
+    @patch("orion.utils.BATCH_METRIC_CHUNK_SIZE", 2)
+    def test_chunk_fallback_only_retries_failed_chunk(self, utils, match_mock):
+        metrics = [copy.deepcopy(_agg_metric(f"m_{i}")) for i in range(4)]
+
+        call_count = {"n": 0}
+
+        def batch_side_effect(_uuids, chunk, _ts):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("chunk 2 failed")
+            return {m["name"]: _agg_batch_data() for m in chunk}
+
+        match_mock.get_agg_metrics_batch.side_effect = batch_side_effect
+        match_mock.get_agg_metric_query.return_value = _agg_batch_data()
+
+        df_list, _ = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert match_mock.get_agg_metrics_batch.call_count == 2
+        assert match_mock.get_agg_metric_query.call_count == 2
+        assert len(df_list) == 4
+
+    @patch("orion.utils.BATCH_METRIC_CHUNK_SIZE", 5)
+    def test_fewer_metrics_than_chunk_size_single_call(self, utils, match_mock):
+        metrics = [copy.deepcopy(_agg_metric(f"small_{i}")) for i in range(3)]
+
+        match_mock.get_agg_metrics_batch.return_value = {
+            m["name"]: _agg_batch_data() for m in metrics
+        }
+
+        df_list, _ = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert match_mock.get_agg_metrics_batch.call_count == 1
+        assert len(df_list) == 3

--- a/orion/tests/test_utils_batch.py
+++ b/orion/tests/test_utils_batch.py
@@ -1,0 +1,414 @@
+"""
+Unit tests for batched metric dispatch in orion/utils.py
+"""
+
+# pylint: disable = redefined-outer-name
+# pylint: disable = missing-function-docstring
+# pylint: disable = import-error
+# pylint: disable = missing-class-docstring
+# pylint: disable = protected-access
+
+import copy
+import logging
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from orion.logger import SingletonLogger
+from orion.utils import Utils
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _init_logger():
+    """Ensure the singleton logger exists for every test."""
+    SingletonLogger(debug=logging.DEBUG, name="Orion")
+
+
+@pytest.fixture
+def utils():
+    return Utils()
+
+
+def _make_match_mock():
+    """Create a MagicMock that behaves like Matcher."""
+    match = MagicMock()
+    match.uuid_field = "uuid"
+
+    def _convert_to_df(data, columns=None, timestamp_field="timestamp"):
+        df = pd.json_normalize(data)
+        df = df.sort_values(by=[timestamp_field])
+        if columns is not None:
+            df = pd.DataFrame(df, columns=columns)
+        return df
+
+    match.convert_to_df.side_effect = _convert_to_df
+    return match
+
+
+@pytest.fixture
+def match_mock():
+    return _make_match_mock()
+
+
+# ---------------------------------------------------------------------------
+# Sample data helpers
+# ---------------------------------------------------------------------------
+
+def _agg_metric(name, metric_of_interest="cpu", agg_type="avg"):
+    """Return a metric config dict with agg key."""
+    return {
+        "name": name,
+        "metricName": "containerCPU",
+        "metric_of_interest": metric_of_interest,
+        "labels": ["ns=kube-system"],
+        "direction": 1,
+        "threshold": 10,
+        "correlation": "",
+        "context": 5,
+        "agg": {"value": metric_of_interest, "agg_type": agg_type},
+    }
+
+
+def _std_metric(name, metric_of_interest="value"):
+    """Return a standard metric config dict (no agg)."""
+    return {
+        "name": name,
+        "metricName": "podLatency",
+        "metric_of_interest": metric_of_interest,
+        "labels": ["ns=default"],
+        "direction": -1,
+        "threshold": 5,
+        "correlation": "corr",
+        "context": 3,
+    }
+
+
+def _agg_batch_data(metric_of_interest="cpu", agg_type="avg"):
+    """Return sample batch agg result list (one row per UUID)."""
+    col = f"{metric_of_interest}_{agg_type}"
+    return [
+        {"uuid": "u1", "timestamp": "2024-01-01T00:00:00Z", col: 0.5},
+        {"uuid": "u2", "timestamp": "2024-01-02T00:00:00Z", col: 0.7},
+    ]
+
+
+def _std_batch_data(metric_of_interest="value"):
+    """Return sample batch standard result list (one row per UUID)."""
+    return [
+        {"uuid": "u1", "timestamp": "2024-01-01T00:00:00Z", metric_of_interest: 100},
+        {"uuid": "u2", "timestamp": "2024-01-02T00:00:00Z", metric_of_interest: 200},
+    ]
+
+
+UUIDS = ["u1", "u2"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: aggregation metrics dispatched via batch
+# ---------------------------------------------------------------------------
+
+class TestAggBatchDispatch:
+
+    def test_single_agg_metric_uses_batch(self, utils, match_mock):
+        metric = _agg_metric("apiserverCPU")
+        metrics = [copy.deepcopy(metric)]
+
+        match_mock.get_agg_metrics_batch.return_value = {
+            "apiserverCPU": _agg_batch_data(),
+        }
+
+        df_list, config = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        match_mock.get_agg_metrics_batch.assert_called_once()
+        match_mock.get_agg_metric_query.assert_not_called()
+        assert len(df_list) == 1
+        assert "apiserverCPU_avg" in config
+
+    def test_multiple_agg_metrics_single_batch_call(self, utils, match_mock):
+        m1 = _agg_metric("cpuMetric1")
+        m2 = _agg_metric("cpuMetric2", metric_of_interest="mem", agg_type="sum")
+        metrics = [copy.deepcopy(m1), copy.deepcopy(m2)]
+
+        match_mock.get_agg_metrics_batch.return_value = {
+            "cpuMetric1": _agg_batch_data(),
+            "cpuMetric2": _agg_batch_data(metric_of_interest="mem", agg_type="sum"),
+        }
+
+        df_list, config = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        # Only one batch call for both agg metrics
+        assert match_mock.get_agg_metrics_batch.call_count == 1
+        assert len(df_list) == 2
+        assert "cpuMetric1_avg" in config
+        assert "cpuMetric2_sum" in config
+
+
+# ---------------------------------------------------------------------------
+# Tests: standard metrics dispatched via batch
+# ---------------------------------------------------------------------------
+
+class TestStdBatchDispatch:
+
+    def test_single_std_metric_uses_batch(self, utils, match_mock):
+        metric = _std_metric("podLatencyMetric")
+        metrics = [copy.deepcopy(metric)]
+
+        match_mock.get_results_batch.return_value = {
+            "podLatencyMetric": _std_batch_data(),
+        }
+
+        df_list, config = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        match_mock.get_results_batch.assert_called_once()
+        match_mock.get_results.assert_not_called()
+        assert len(df_list) == 1
+        assert "podLatencyMetric_value" in config
+
+    def test_multiple_std_metrics_single_batch_call(self, utils, match_mock):
+        m1 = _std_metric("latency1")
+        m2 = _std_metric("latency2", metric_of_interest="ms")
+        metrics = [copy.deepcopy(m1), copy.deepcopy(m2)]
+
+        match_mock.get_results_batch.return_value = {
+            "latency1": _std_batch_data(),
+            "latency2": _std_batch_data(metric_of_interest="ms"),
+        }
+
+        df_list, config = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        assert match_mock.get_results_batch.call_count == 1
+        assert len(df_list) == 2
+        assert "latency1_value" in config
+        assert "latency2_ms" in config
+
+
+# ---------------------------------------------------------------------------
+# Tests: fallback to single-query methods
+# ---------------------------------------------------------------------------
+
+class TestBatchFallback:
+
+    def test_agg_batch_failure_falls_back(self, utils, match_mock):
+        metric = _agg_metric("cpuFallback")
+        metrics = [copy.deepcopy(metric)]
+
+        match_mock.get_agg_metrics_batch.side_effect = RuntimeError("batch fail")
+        match_mock.get_agg_metric_query.return_value = _agg_batch_data()
+
+        df_list, config = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        match_mock.get_agg_metrics_batch.assert_called_once()
+        match_mock.get_agg_metric_query.assert_called_once()
+        assert len(df_list) == 1
+        assert "cpuFallback_avg" in config
+
+    def test_std_batch_failure_falls_back(self, utils, match_mock):
+        metric = _std_metric("latFallback")
+        metrics = [copy.deepcopy(metric)]
+
+        match_mock.get_results_batch.side_effect = RuntimeError("batch fail")
+        match_mock.get_results.return_value = _std_batch_data()
+
+        df_list, config = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        match_mock.get_results_batch.assert_called_once()
+        match_mock.get_results.assert_called_once()
+        assert len(df_list) == 1
+        assert "latFallback_value" in config
+
+
+# ---------------------------------------------------------------------------
+# Tests: mixed metrics (agg + standard)
+# ---------------------------------------------------------------------------
+
+class TestMixedMetrics:
+
+    def test_mixed_metrics_dispatch_separately(self, utils, match_mock):
+        agg = _agg_metric("aggMetric")
+        std = _std_metric("stdMetric")
+        metrics = [copy.deepcopy(agg), copy.deepcopy(std)]
+
+        match_mock.get_agg_metrics_batch.return_value = {
+            "aggMetric": _agg_batch_data(),
+        }
+        match_mock.get_results_batch.return_value = {
+            "stdMetric": _std_batch_data(),
+        }
+
+        df_list, config = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        # Each batch method called exactly once
+        match_mock.get_agg_metrics_batch.assert_called_once()
+        match_mock.get_results_batch.assert_called_once()
+        assert len(df_list) == 2
+        assert "aggMetric_avg" in config
+        assert "stdMetric_value" in config
+
+    def test_metadata_restored_after_batch(self, utils, match_mock):
+        """Verify popped metadata fields are restored on the metric dicts."""
+        agg = _agg_metric("aggRestore")
+        std = _std_metric("stdRestore")
+        metrics = [copy.deepcopy(agg), copy.deepcopy(std)]
+
+        match_mock.get_agg_metrics_batch.return_value = {
+            "aggRestore": _agg_batch_data(),
+        }
+        match_mock.get_results_batch.return_value = {
+            "stdRestore": _std_batch_data(),
+        }
+
+        utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        # Check the metric dicts have their metadata restored
+        for metric in metrics:
+            assert "labels" in metric
+            assert "direction" in metric
+            assert "threshold" in metric
+            assert "correlation" in metric
+            assert "context" in metric
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_agg_dataframe helper
+# ---------------------------------------------------------------------------
+
+class TestBuildAggDataframe:
+
+    def test_empty_data_returns_empty_df(self, utils, match_mock):
+        metric = {
+            "name": "testMetric",
+            "metric_of_interest": "cpu",
+            "agg": {"agg_type": "avg"},
+        }
+        df, names = utils._build_agg_dataframe([], metric, match_mock)
+        assert df.empty
+        assert names == ["testMetric_avg"]
+
+    def test_avg_aggregation(self, utils, match_mock):
+        metric = {
+            "name": "cpuAvg",
+            "metric_of_interest": "cpu",
+            "agg": {"agg_type": "avg"},
+        }
+        data = [
+            {"uuid": "u1", "timestamp": "2024-01-01T00:00:00Z", "cpu_avg": 0.5},
+        ]
+        df, names = utils._build_agg_dataframe(data, metric, match_mock)
+        assert not df.empty
+        assert "cpuAvg_avg" in df.columns
+        assert names == ["cpuAvg_avg"]
+
+    def test_percentile_aggregation(self, utils, match_mock):
+        metric = {
+            "name": "latP99",
+            "metric_of_interest": "latency",
+            "agg": {"agg_type": "percentiles"},
+        }
+        data = [
+            {
+                "uuid": "u1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "latency_percentiles_50.0": 10,
+                "latency_percentiles_99.0": 50,
+            },
+        ]
+        df, names = utils._build_agg_dataframe(data, metric, match_mock)
+        assert "latP99_percentiles_50.0" in df.columns
+        assert "latP99_percentiles_99.0" in df.columns
+        assert len(names) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: process_standard_metric with preloaded_data
+# ---------------------------------------------------------------------------
+
+class TestProcessStandardMetricPreloaded:
+
+    def test_preloaded_skips_es_call(self, utils, match_mock):
+        metric = {"name": "podLat", "metric_of_interest": "value", "metricName": "podLatency"}
+        data = _std_batch_data()
+
+        result_df, name = utils.process_standard_metric(
+            UUIDS, metric, match_mock, "value",
+            preloaded_data=data,
+        )
+
+        match_mock.get_results.assert_not_called()
+        assert name == "podLat_value"
+        assert not result_df.empty
+
+    def test_no_preloaded_calls_es(self, utils, match_mock):
+        metric = {"name": "podLat", "metric_of_interest": "value", "metricName": "podLatency"}
+        match_mock.get_results.return_value = _std_batch_data()
+
+        _, name = utils.process_standard_metric(
+            UUIDS, metric, match_mock, "value",
+        )
+
+        match_mock.get_results.assert_called_once()
+        assert name == "podLat_value"
+
+
+# ---------------------------------------------------------------------------
+# Tests: metadata fields popped before batch call
+# ---------------------------------------------------------------------------
+
+class TestMetadataPopBeforeBatch:
+
+    def test_agg_metrics_have_no_metadata_keys_during_batch(self, utils, match_mock):
+        """Labels/direction/etc must be popped before metrics hit the batch call."""
+        metric = _agg_metric("checkPop")
+        metrics = [copy.deepcopy(metric)]
+
+        def capture_batch_args(_uuids, metrics_list, _ts_field):
+            # At batch call time, metrics should NOT have popped keys
+            for m in metrics_list:
+                assert "labels" not in m, "labels should be popped"
+                assert "direction" not in m, "direction should be popped"
+                assert "threshold" not in m, "threshold should be popped"
+                assert "correlation" not in m, "correlation should be popped"
+                assert "context" not in m, "context should be popped"
+            return {"checkPop": _agg_batch_data()}
+
+        match_mock.get_agg_metrics_batch.side_effect = capture_batch_args
+
+        utils.get_metric_data(UUIDS, metrics, match_mock, test_threshold=0)
+
+    def test_std_metrics_have_no_metadata_keys_during_batch(self, utils, match_mock):
+        """Labels/direction/etc must be popped before metrics hit the batch call."""
+        metric = _std_metric("checkPopStd")
+        metrics = [copy.deepcopy(metric)]
+
+        def capture_batch_args(_uuids, metrics_list, _ts_field):
+            for m in metrics_list:
+                assert "labels" not in m, "labels should be popped"
+                assert "direction" not in m, "direction should be popped"
+                assert "threshold" not in m, "threshold should be popped"
+                assert "correlation" not in m, "correlation should be popped"
+                assert "context" not in m, "context should be popped"
+            return {"checkPopStd": _std_batch_data()}
+
+        match_mock.get_results_batch.side_effect = capture_batch_args
+
+        utils.get_metric_data(UUIDS, metrics, match_mock, test_threshold=0)

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -19,6 +19,7 @@ from tabulate import tabulate
 
 from orion.matcher import Matcher
 from orion.logger import SingletonLogger
+from orion.constants import BATCH_METRIC_CHUNK_SIZE
 
 
 class Utils:
@@ -118,90 +119,103 @@ class Utils:
     def _process_agg_batch(self, uuids, agg_metrics, match, meta_by_name,
                            dataframe_list, metrics_config, timestamp_field,
                            metadata_columns=None):
-        """Batch all aggregation metrics into a single ES query with fallback."""
-        try:
-            self.logger.info("Batching %d aggregation metrics", len(agg_metrics))
-            batch_results = match.get_agg_metrics_batch(
-                uuids, agg_metrics, timestamp_field
-            )
-            for metric in agg_metrics:
-                name = metric["name"]
-                data = batch_results.get(name, [])
-                meta = meta_by_name[name]
-                try:
-                    metric_df, col_names = self._build_agg_dataframe(
-                        data, metric, match, meta["timestamp"]
-                    )
-                    dataframe_list.append(metric_df)
-                    self._restore_meta(metric, meta)
-                    self._register_columns(col_names, metric, meta, metrics_config, metadata_columns)
-                except Exception as e:
-                    self.logger.error(
-                        "Couldn't process batched agg metric %s", name, exc_info=e
-                    )
-                    self._restore_meta(metric, meta)
-        except Exception as e:
-            self.logger.warning(
-                "Batch aggregation failed, falling back to single queries", exc_info=e
-            )
-            for metric in agg_metrics:
-                name = metric["name"]
-                meta = meta_by_name[name]
-                try:
-                    metric_df, col_names = self.process_aggregation_metric(
-                        uuids, metric, match, meta["timestamp"]
-                    )
-                    dataframe_list.append(metric_df)
-                    self._restore_meta(metric, meta)
-                    self._register_columns(col_names, metric, meta, metrics_config, metadata_columns)
-                except Exception as e2:
-                    self.logger.error("Couldn't get metric %s: %s", name, e2)
-                    self._restore_meta(metric, meta)
+        """Batch aggregation metrics into chunked ES queries with fallback."""
+        for i in range(0, len(agg_metrics), BATCH_METRIC_CHUNK_SIZE):
+            chunk = agg_metrics[i:i + BATCH_METRIC_CHUNK_SIZE]
+            try:
+                self.logger.info(
+                    "Batching aggregation metrics chunk %d-%d of %d",
+                    i + 1, i + len(chunk), len(agg_metrics),
+                )
+                batch_results = match.get_agg_metrics_batch(
+                    uuids, chunk, timestamp_field
+                )
+                for metric in chunk:
+                    name = metric["name"]
+                    data = batch_results.get(name, [])
+                    meta = meta_by_name[name]
+                    try:
+                        metric_df, col_names = self._build_agg_dataframe(
+                            data, metric, match, meta["timestamp"]
+                        )
+                        dataframe_list.append(metric_df)
+                        self._restore_meta(metric, meta)
+                        self._register_columns(col_names, metric, meta, metrics_config, metadata_columns)
+                    except Exception as e:
+                        self.logger.error(
+                            "Couldn't process batched agg metric %s", name, exc_info=e
+                        )
+                        self._restore_meta(metric, meta)
+            except Exception as e:
+                self.logger.warning(
+                    "Batch aggregation chunk failed, falling back to single queries",
+                    exc_info=e,
+                )
+                for metric in chunk:
+                    name = metric["name"]
+                    meta = meta_by_name[name]
+                    try:
+                        metric_df, col_names = self.process_aggregation_metric(
+                            uuids, metric, match, meta["timestamp"]
+                        )
+                        dataframe_list.append(metric_df)
+                        self._restore_meta(metric, meta)
+                        self._register_columns(col_names, metric, meta, metrics_config, metadata_columns)
+                    except Exception as e2:
+                        self.logger.error("Couldn't get metric %s: %s", name, e2)
+                        self._restore_meta(metric, meta)
 
     def _process_std_batch(self, uuids, std_metrics, match, meta_by_name,
                            dataframe_list, metrics_config, timestamp_field,
                            metadata_columns=None):
-        """Batch all standard metrics into a single ES query with fallback."""
-        try:
-            self.logger.info("Batching %d standard metrics", len(std_metrics))
-            batch_results = match.get_results_batch(
-                uuids, std_metrics, timestamp_field
-            )
-            for metric in std_metrics:
-                name = metric["name"]
-                data = batch_results.get(name, [])
-                meta = meta_by_name[name]
-                try:
-                    metric_df, single_name = self.process_standard_metric(
-                        uuids, metric, match, metric["metric_of_interest"],
-                        meta["timestamp"], preloaded_data=data,
-                    )
-                    dataframe_list.append(metric_df)
-                    self._restore_meta(metric, meta)
-                    self._register_columns([single_name], metric, meta, metrics_config, metadata_columns)
-                except Exception as e:
-                    self.logger.error(
-                        "Couldn't process batched standard metric %s", name, exc_info=e
-                    )
-                    self._restore_meta(metric, meta)
-        except Exception as e:
-            self.logger.warning(
-                "Batch standard query failed, falling back to single queries", exc_info=e
-            )
-            for metric in std_metrics:
-                name = metric["name"]
-                meta = meta_by_name[name]
-                try:
-                    metric_df, single_name = self.process_standard_metric(
-                        uuids, metric, match, metric["metric_of_interest"],
-                        meta["timestamp"],
-                    )
-                    dataframe_list.append(metric_df)
-                    self._restore_meta(metric, meta)
-                    self._register_columns([single_name], metric, meta, metrics_config, metadata_columns)
-                except Exception as e2:
-                    self.logger.error("Couldn't get metric %s: %s", name, e2)
-                    self._restore_meta(metric, meta)
+        """Batch standard metrics into chunked ES queries with fallback."""
+        for i in range(0, len(std_metrics), BATCH_METRIC_CHUNK_SIZE):
+            chunk = std_metrics[i:i + BATCH_METRIC_CHUNK_SIZE]
+            try:
+                self.logger.info(
+                    "Batching standard metrics chunk %d-%d of %d",
+                    i + 1, i + len(chunk), len(std_metrics),
+                )
+                batch_results = match.get_results_batch(
+                    uuids, chunk, timestamp_field
+                )
+                for metric in chunk:
+                    name = metric["name"]
+                    data = batch_results.get(name, [])
+                    meta = meta_by_name[name]
+                    try:
+                        metric_df, single_name = self.process_standard_metric(
+                            uuids, metric, match, metric["metric_of_interest"],
+                            meta["timestamp"], preloaded_data=data,
+                        )
+                        dataframe_list.append(metric_df)
+                        self._restore_meta(metric, meta)
+                        self._register_columns([single_name], metric, meta, metrics_config, metadata_columns)
+                    except Exception as e:
+                        self.logger.error(
+                            "Couldn't process batched standard metric %s", name,
+                            exc_info=e,
+                        )
+                        self._restore_meta(metric, meta)
+            except Exception as e:
+                self.logger.warning(
+                    "Batch standard chunk failed, falling back to single queries",
+                    exc_info=e,
+                )
+                for metric in chunk:
+                    name = metric["name"]
+                    meta = meta_by_name[name]
+                    try:
+                        metric_df, single_name = self.process_standard_metric(
+                            uuids, metric, match, metric["metric_of_interest"],
+                            meta["timestamp"],
+                        )
+                        dataframe_list.append(metric_df)
+                        self._restore_meta(metric, meta)
+                        self._register_columns([single_name], metric, meta, metrics_config, metadata_columns)
+                    except Exception as e2:
+                        self.logger.error("Couldn't get metric %s: %s", name, e2)
+                        self._restore_meta(metric, meta)
 
     def _build_agg_dataframe(self, data, metric, match, timestamp_field="timestamp"):
         """Build a DataFrame from pre-fetched aggregation data."""

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -58,48 +58,193 @@ class Utils:
         metadata_columns = []
         global_timestamp_field = timestamp_field
 
-        for metric in metrics:
-            metric_name = metric["name"]
-            metric_value_field = metric["metric_of_interest"]
+        agg_metrics = []
+        std_metrics = []
+        meta_by_name = {}
 
+        for metric in metrics:
             labels = metric.pop("labels", None)
             direction = int(metric.pop("direction", 0))
             threshold = abs(int(metric.pop("threshold", test_threshold)))
-            timestamp_field = metric.pop("timestamp", global_timestamp_field)
+            ts = metric.pop("timestamp", global_timestamp_field)
             correlation = metric.pop("correlation", "")
             context = metric.pop("context", 5)
             metric_type = metric.get("type")
-            self.logger.info("Collecting %s", metric_name)
-            try:
-                if "agg" in metric:
-                    metric_df, metric_dataframe_names = self.process_aggregation_metric(
-                        uuids, metric, match, timestamp_field
-                    )
-                else:
-                    metric_df, single_name = self.process_standard_metric(
-                        uuids, metric, match, metric_value_field, timestamp_field
-                    )
-                    metric_dataframe_names = [single_name]
-                metric["labels"] = labels
-                metric["direction"] = direction
-                metric["threshold"] = threshold
-                metric["timestamp"] = timestamp_field
-                metric["correlation"] = correlation
-                metric["context"] = context
-                if metric_type != "metadata":
-                    for metric_dataframe_name in metric_dataframe_names:
-                        metrics_config[metric_dataframe_name] = metric
-                else:
-                    metadata_columns.extend(metric_dataframe_names)
-                dataframe_list.append(metric_df)
-                self.logger.debug(metric_df)
-            except Exception as e:
-                self.logger.error(
-                    "Couldn't get metrics %s, exception %s",
-                    metric_name,
-                    e,
-                )
+
+            meta_by_name[metric["name"]] = {
+                "labels": labels, "direction": direction, "threshold": threshold,
+                "correlation": correlation, "context": context, "timestamp": ts,
+                "type": metric_type,
+            }
+
+            if "agg" in metric:
+                agg_metrics.append(metric)
+            else:
+                std_metrics.append(metric)
+
+        if agg_metrics:
+            self._process_agg_batch(
+                uuids, agg_metrics, match, meta_by_name,
+                dataframe_list, metrics_config, global_timestamp_field,
+                metadata_columns
+            )
+
+        if std_metrics:
+            self._process_std_batch(
+                uuids, std_metrics, match, meta_by_name,
+                dataframe_list, metrics_config, global_timestamp_field,
+                metadata_columns
+            )
+
         return dataframe_list, metrics_config, metadata_columns
+
+    def _restore_meta(self, metric, meta):
+        """Re-attach popped metadata fields to metric dict."""
+        metric["labels"] = meta["labels"]
+        metric["direction"] = meta["direction"]
+        metric["threshold"] = meta["threshold"]
+        metric["timestamp"] = meta["timestamp"]
+        metric["correlation"] = meta["correlation"]
+        metric["context"] = meta["context"]
+
+    def _register_columns(self, col_names, metric, meta, metrics_config, metadata_columns):
+        """Route column names to metrics_config or metadata_columns based on type."""
+        if meta.get("type") == "metadata" and metadata_columns is not None:
+            metadata_columns.extend(col_names)
+        else:
+            for col_name in col_names:
+                metrics_config[col_name] = metric
+
+    def _process_agg_batch(self, uuids, agg_metrics, match, meta_by_name,
+                           dataframe_list, metrics_config, timestamp_field,
+                           metadata_columns=None):
+        """Batch all aggregation metrics into a single ES query with fallback."""
+        try:
+            self.logger.info("Batching %d aggregation metrics", len(agg_metrics))
+            batch_results = match.get_agg_metrics_batch(
+                uuids, agg_metrics, timestamp_field
+            )
+            for metric in agg_metrics:
+                name = metric["name"]
+                data = batch_results.get(name, [])
+                meta = meta_by_name[name]
+                try:
+                    metric_df, col_names = self._build_agg_dataframe(
+                        data, metric, match, meta["timestamp"]
+                    )
+                    dataframe_list.append(metric_df)
+                    self._restore_meta(metric, meta)
+                    self._register_columns(col_names, metric, meta, metrics_config, metadata_columns)
+                except Exception as e:
+                    self.logger.error(
+                        "Couldn't process batched agg metric %s", name, exc_info=e
+                    )
+                    self._restore_meta(metric, meta)
+        except Exception as e:
+            self.logger.warning(
+                "Batch aggregation failed, falling back to single queries", exc_info=e
+            )
+            for metric in agg_metrics:
+                name = metric["name"]
+                meta = meta_by_name[name]
+                try:
+                    metric_df, col_names = self.process_aggregation_metric(
+                        uuids, metric, match, meta["timestamp"]
+                    )
+                    dataframe_list.append(metric_df)
+                    self._restore_meta(metric, meta)
+                    self._register_columns(col_names, metric, meta, metrics_config, metadata_columns)
+                except Exception as e2:
+                    self.logger.error("Couldn't get metric %s: %s", name, e2)
+                    self._restore_meta(metric, meta)
+
+    def _process_std_batch(self, uuids, std_metrics, match, meta_by_name,
+                           dataframe_list, metrics_config, timestamp_field,
+                           metadata_columns=None):
+        """Batch all standard metrics into a single ES query with fallback."""
+        try:
+            self.logger.info("Batching %d standard metrics", len(std_metrics))
+            batch_results = match.get_results_batch(
+                uuids, std_metrics, timestamp_field
+            )
+            for metric in std_metrics:
+                name = metric["name"]
+                data = batch_results.get(name, [])
+                meta = meta_by_name[name]
+                try:
+                    metric_df, single_name = self.process_standard_metric(
+                        uuids, metric, match, metric["metric_of_interest"],
+                        meta["timestamp"], preloaded_data=data,
+                    )
+                    dataframe_list.append(metric_df)
+                    self._restore_meta(metric, meta)
+                    self._register_columns([single_name], metric, meta, metrics_config, metadata_columns)
+                except Exception as e:
+                    self.logger.error(
+                        "Couldn't process batched standard metric %s", name, exc_info=e
+                    )
+                    self._restore_meta(metric, meta)
+        except Exception as e:
+            self.logger.warning(
+                "Batch standard query failed, falling back to single queries", exc_info=e
+            )
+            for metric in std_metrics:
+                name = metric["name"]
+                meta = meta_by_name[name]
+                try:
+                    metric_df, single_name = self.process_standard_metric(
+                        uuids, metric, match, metric["metric_of_interest"],
+                        meta["timestamp"],
+                    )
+                    dataframe_list.append(metric_df)
+                    self._restore_meta(metric, meta)
+                    self._register_columns([single_name], metric, meta, metrics_config, metadata_columns)
+                except Exception as e2:
+                    self.logger.error("Couldn't get metric %s: %s", name, e2)
+                    self._restore_meta(metric, meta)
+
+    def _build_agg_dataframe(self, data, metric, match, timestamp_field="timestamp"):
+        """Build a DataFrame from pre-fetched aggregation data."""
+        aggregation_value = metric["metric_of_interest"]
+        aggregation_type = metric["agg"]["agg_type"]
+
+        if aggregation_type == "percentiles":
+            percentile_prefix = f"{aggregation_value}_{aggregation_type}_"
+            agg_columns = [k for k in data[0].keys()
+                           if k.startswith(percentile_prefix)] if data else []
+        else:
+            agg_columns = [f"{aggregation_value}_{aggregation_type}"]
+
+        all_columns = [self.uuid_field, timestamp_field] + agg_columns
+
+        if not data:
+            aggregated_df = pd.DataFrame(columns=all_columns)
+        else:
+            aggregated_df = match.convert_to_df(
+                data, columns=all_columns, timestamp_field=timestamp_field
+            )
+            aggregated_df.loc[:, timestamp_field] = aggregated_df[timestamp_field].apply(
+                self.standardize_timestamp
+            )
+
+        aggregated_df = aggregated_df.drop_duplicates(subset=[self.uuid_field], keep="first")
+
+        rename_map = {}
+        names = []
+        for col in agg_columns:
+            if aggregation_type == "percentiles":
+                suffix = col[len(f"{aggregation_value}_{aggregation_type}_"):]
+                new_name = f"{metric['name']}_{aggregation_type}_{suffix}"
+            else:
+                new_name = f"{metric['name']}_{aggregation_type}"
+            rename_map[col] = new_name
+            names.append(new_name)
+
+        aggregated_df = aggregated_df.rename(columns=rename_map)
+        if timestamp_field != "timestamp":
+            aggregated_df = aggregated_df.rename(columns={timestamp_field: "timestamp"})
+
+        return aggregated_df, names
 
 
     def process_aggregation_metric(
@@ -190,7 +335,8 @@ class Utils:
         metric: Dict[str, Any],
         match: Matcher,
         metric_value_field: str,
-        timestamp_field: str="timestamp"
+        timestamp_field: str="timestamp",
+        preloaded_data: List[Dict[Any, Any]] = None
     ) -> pd.DataFrame:
         """Method to get dataframe of standard metric
 
@@ -199,11 +345,15 @@ class Utils:
             metric (Dict[str, Any]): _description_
             match (Matcher): _description_
             metric_value_field (str): _description_
+            preloaded_data (list, optional): Pre-fetched data from batch query.
 
         Returns:
             pd.DataFrame: _description_
         """
-        standard_metric_data = match.get_results("", uuids, metric, timestamp_field=timestamp_field)
+        if preloaded_data is not None:
+            standard_metric_data = preloaded_data
+        else:
+            standard_metric_data = match.get_results("", uuids, metric, timestamp_field=timestamp_field)
         if len(standard_metric_data) == 0:
             standard_metric_df = pd.DataFrame(columns=[self.uuid_field, timestamp_field, metric_value_field])
         else:


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds ES query batching to save time on Orion execution

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-request batched retrieval for aggregated and standard metrics, with configurable UUID field and percentile/count support.

* **Refactor**
  * Metric processing reorganized to prefer chunked batch dispatch, preserve/restore per-metric metadata, and centralize aggregation-to-table construction.

* **Bug Fixes**
  * Percentile aggregations now require an explicit percents list; missing percents are reported and skipped. Config validation enforces this.

* **Tests**
  * Expanded coverage for batching, chunking, fallback behavior, percentiles, counts, and config validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/orion/pull/385)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->