### PR TITLE
Update node types in small-scale configs to match current CI environm…

### DIFF
--- a/examples/small-scale-cluster-density-report.yaml
+++ b/examples/small-scale-cluster-density-report.yaml
@@ -9,7 +9,7 @@ tests:
       workerNodesCount: 24
       infraNodesCount: 3
       masterNodesType: m5.2xlarge
-      workerNodesType: m5.xlarge
+      workerNodesType: m6a.xlarge
       infraNodesType: r5.xlarge
       totalNodesCount: 30
       networkType: OVNKubernetes

--- a/examples/small-scale-cudn-density-l2-multi-ns.yaml
+++ b/examples/small-scale-cudn-density-l2-multi-ns.yaml
@@ -1,15 +1,16 @@
 # This is a template file
 tests:
-  - name: aws-small-scale-cudn-density-l3-pods
+  - name: aws-small-scale-cudn-density-l2-multi-ns
     metadata:
       platform: AWS
-      masterNodesType: m6a.xlarge
+      masterNodesType: m6a.2xlarge
       masterNodesCount: 3
       workerNodesType: m6a.2xlarge
       workerNodesCount: 24
       benchmark.keyword: cudn-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        upstreamJob.keyword: "*cudn-density-multi-ns-500*"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"
@@ -25,7 +26,7 @@ tests:
       - name: podReadyLatency
         metricName.keyword: podLatencyQuantilesMeasurement
         quantileName: Ready
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         metric_of_interest: P99
         not:
           jobConfig.name: "garbage-collection"
@@ -35,7 +36,7 @@ tests:
         threshold: 10
       - name: ovsCPU-irate-all
         metricName.keyword: cgroupCPU
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
@@ -47,7 +48,7 @@ tests:
 
       - name: ovnkCPU-overall
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
@@ -59,7 +60,7 @@ tests:
 
       - name: ovnCPU-ovncontroller
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
         metric_of_interest: value
@@ -72,7 +73,7 @@ tests:
 
       - name: ovnCPU-northd
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
         metric_of_interest: value
@@ -85,7 +86,7 @@ tests:
 
       - name: ovnCPU-nbdb
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
         metric_of_interest: value
@@ -98,7 +99,7 @@ tests:
 
       - name: ovnCPU-sbdb
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
         metric_of_interest: value
@@ -111,7 +112,7 @@ tests:
 
       - name: ovnCPU-ovnk-controller
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
@@ -124,7 +125,7 @@ tests:
 
       - name: ovsMemory-Workers
         metricName.keyword: cgroupMemoryRSS-Workers
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
@@ -136,7 +137,7 @@ tests:
 
       - name: ovsMemory-Masters
         metricName.keyword: cgroupMemoryRSS-Masters
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
@@ -148,7 +149,7 @@ tests:
 
       - name: ovsMemory-all
         metricName.keyword: cgroupMemoryRSS
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
@@ -160,7 +161,7 @@ tests:
 
       - name: ovnkMem-overall
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
@@ -172,7 +173,7 @@ tests:
 
       - name: ovnMem-ovncontroller
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
         metric_of_interest: value
@@ -185,7 +186,7 @@ tests:
 
       - name: ovnMem-northd
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
         metric_of_interest: value
@@ -198,7 +199,7 @@ tests:
 
       - name: ovnMem-nbdb
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
         metric_of_interest: value
@@ -211,7 +212,7 @@ tests:
 
       - name: ovnMem-sbdb
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
         metric_of_interest: value
@@ -224,7 +225,7 @@ tests:
 
       - name: ovnMem-ovnk-controller
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l3-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value

--- a/examples/small-scale-cudn-density-l2-single-ns.yaml
+++ b/examples/small-scale-cudn-density-l2-single-ns.yaml
@@ -1,15 +1,16 @@
 # This is a template file
 tests:
-  - name: aws-small-scale-cudn-density-l2-pods
+  - name: aws-small-scale-cudn-density-l2-single-ns
     metadata:
       platform: AWS
-      masterNodesType: m6a.xlarge
+      masterNodesType: m6a.2xlarge
       masterNodesCount: 3
       workerNodesType: m6a.2xlarge
       workerNodesCount: 24
       benchmark.keyword: cudn-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        upstreamJob.keyword: "*cudn-density-single-ns-250*"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"
@@ -25,7 +26,7 @@ tests:
       - name: podReadyLatency
         metricName.keyword: podLatencyQuantilesMeasurement
         quantileName: Ready
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         metric_of_interest: P99
         not:
           jobConfig.name: "garbage-collection"
@@ -35,7 +36,7 @@ tests:
         threshold: 10
       - name: ovsCPU-irate-all
         metricName.keyword: cgroupCPU
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
@@ -47,7 +48,7 @@ tests:
 
       - name: ovnkCPU-overall
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
@@ -59,7 +60,7 @@ tests:
 
       - name: ovnCPU-ovncontroller
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
         metric_of_interest: value
@@ -72,7 +73,7 @@ tests:
 
       - name: ovnCPU-northd
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
         metric_of_interest: value
@@ -85,7 +86,7 @@ tests:
 
       - name: ovnCPU-nbdb
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
         metric_of_interest: value
@@ -98,7 +99,7 @@ tests:
 
       - name: ovnCPU-sbdb
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
         metric_of_interest: value
@@ -111,7 +112,7 @@ tests:
 
       - name: ovnCPU-ovnk-controller
         metricName.keyword: containerCPU
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value
@@ -124,7 +125,7 @@ tests:
 
       - name: ovsMemory-Workers
         metricName.keyword: cgroupMemoryRSS-Workers
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
@@ -136,7 +137,7 @@ tests:
 
       - name: ovsMemory-Masters
         metricName.keyword: cgroupMemoryRSS-Masters
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
@@ -148,7 +149,7 @@ tests:
 
       - name: ovsMemory-all
         metricName.keyword: cgroupMemoryRSS
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.id.keyword: /system.slice/ovs-vswitchd.service
         metric_of_interest: value
         agg:
@@ -160,7 +161,7 @@ tests:
 
       - name: ovnkMem-overall
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         metric_of_interest: value
         agg:
@@ -172,7 +173,7 @@ tests:
 
       - name: ovnMem-ovncontroller
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovn-controller
         metric_of_interest: value
@@ -185,7 +186,7 @@ tests:
 
       - name: ovnMem-northd
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: northd
         metric_of_interest: value
@@ -198,7 +199,7 @@ tests:
 
       - name: ovnMem-nbdb
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: nbdb
         metric_of_interest: value
@@ -211,7 +212,7 @@ tests:
 
       - name: ovnMem-sbdb
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: sbdb
         metric_of_interest: value
@@ -224,7 +225,7 @@ tests:
 
       - name: ovnMem-ovnk-controller
         metricName.keyword: containerMemory
-        jobName.keyword: cudn-density-l2-pods
+        jobName.keyword: cudn-density-workload
         labels.namespace.keyword: openshift-ovn-kubernetes
         labels.container.keyword: ovnkube-controller
         metric_of_interest: value

--- a/examples/small-scale-udn-l2.yaml
+++ b/examples/small-scale-udn-l2.yaml
@@ -5,7 +5,7 @@ tests:
       platform: AWS
       masterNodesType: m6a.xlarge
       masterNodesCount: 3
-      workerNodesType: m5.xlarge
+      workerNodesType: m6a.xlarge
       workerNodesCount: 24
       benchmark.keyword: udn-density-pods
       wildcard:

--- a/examples/small-scale-udn-l3.yaml
+++ b/examples/small-scale-udn-l3.yaml
@@ -5,7 +5,7 @@ tests:
       platform: AWS
       masterNodesType: m6a.xlarge
       masterNodesCount: 3
-      workerNodesType: m5.xlarge
+      workerNodesType: m6a.xlarge
       workerNodesCount: 24
       benchmark.keyword: udn-density-pods
       wildcard:


### PR DESCRIPTION
 Type of change                                                                                                                                                                                                                                              
                                                                                         
  - Bug fix                                                                                                                                                                                                                                                   
   
  Description                                                                                                                                                                                                                                                 
                                                                                         
  Updated small-scale configs to match current CI environments. Without these changes, metadata queries return no matching runs because the instance types and job names have changed.

  - UDN & cluster-density configs: Updated workerNodesType from m5.xlarge to m6a.xlarge in small-scale-udn-l2.yaml, small-scale-udn-l3.yaml, and small-scale-cluster-density-report.yaml                                                                      
  - CUDN-density configs: Updated masterNodesType from m6a.xlarge to m6a.2xlarge and fixed jobName.keyword from cudn-density-l2/l3-pods to cudn-density-workload to match actual ES data
  - Renamed CUDN configs: Both were actually L2, so renamed small-scale-cudn-density-l2.yaml to small-scale-cudn-density-l2-multi-ns.yaml and small-scale-cudn-density-l3.yaml to small-scale-cudn-density-l2-single-ns.yaml, with upstreamJob.keyword        
  wildcard filters to differentiate multi-ns-500 vs single-ns-250 runs  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example test configurations to use m6a.xlarge AWS worker nodes instead of m5.xlarge.
  * Renamed test scenario definitions and updated associated metric collection filters for improved workload identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->