### PR TITLE
Add pylint make target

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -18,5 +18,4 @@ jobs:
           pip install -r requirements-test.txt
 
       - name: Analysing the code with pylint
-        run: |
-          pylint -d R0915 -d R1702 -d R0913 -d R0914 -d C0103 -d R0912 -d R0911 -d R0917 -d E0102 $(git ls-files '*/*.py' '*.py')
+        run: make pylint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint fmt install uninstall test deps deps-test
+.PHONY: help lint fmt install uninstall test deps deps-test pylint
 
 help:
 	@echo "Available targets:"
@@ -6,7 +6,8 @@ help:
 	@echo "  fmt       - Automatically fix common YAML linting issues"
 	@echo "  install   - Install orion and its dependencies"
 	@echo "  uninstall - Uninstall orion"
-	@echo "  test      - Run the test suite with pytest"
+	@echo "  test      - Run unit tests"
+	@echo "  pylint    - Run pylint on production (non-test) python code"
 	@echo "  help      - Show this help message"
 
 .DEFAULT_GOAL := help
@@ -37,3 +38,7 @@ uninstall:
 
 test: deps-test lint
 	pytest orion/tests/
+
+pylint:
+	pylint -d R0915 -d R1702 -d R0913 -d R0914 -d C0103 -d R0912 -d R0911 -d R0917 -d E0102 \
+		$$(git ls-files '*/*.py' '*.py' | grep -v '/tests/')


### PR DESCRIPTION
... and use it from github workflow.

Also, omit tests from pylint.

## Type of change

- [x] Refactor

## Description

This changes makes it easier for contributors to lint locally instead of relying on github workflow.

Also, removes tests from pylint, where we might tend to do things that won't satisfy linters, that we add pylint hints to ignore anyway. :)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.