### PR TITLE
Split CI workflow to run PR-branch tests and gate integration tests

### DIFF
--- a/.github/workflows/builders.yaml
+++ b/.github/workflows/builders.yaml
@@ -9,7 +9,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 1
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Build and install
       run: |

--- a/.github/workflows/ci-integration-tests.yaml
+++ b/.github/workflows/ci-integration-tests.yaml
@@ -1,0 +1,16 @@
+name: CI integration tests
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI tests"]
+    types:
+      - completed
+
+jobs:
+  tester:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/tests.yaml
+    with:
+      checkout_ref: ${{ github.event.workflow_run.head_sha || '' }}
+      checkout_repo: ${{ github.event.workflow_run.head_repository.full_name || '' }}
+    secrets: inherit

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -1,34 +1,23 @@
-name: CI tests\
+name: CI tests
 on:
   workflow_dispatch:
   push:
     branches:
       - master
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - master
       - main
 
 jobs:
-  setup-python:
-    uses: ./.github/workflows/python-setup.yaml  # Path to reusable workflow
-    with:
-      python-version: 3.14
-
-  linter:
-    needs: setup-python
+  lint:
     uses: ./.github/workflows/pylint.yaml
 
-  builder:
-    needs: setup-python
+  build:
+    needs: lint
     uses: ./.github/workflows/builders.yaml
 
-  unit_tester:
-    needs: setup-python
+  unit_tests:
+    needs: lint
     uses: ./.github/workflows/unit_tests.yaml
-
-  tester:
-    needs: [setup-python, builder]
-    uses: ./.github/workflows/tests.yaml
-    secrets: inherit

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -10,7 +10,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-setup.yaml
+++ b/.github/workflows/python-setup.yaml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,15 @@
 name: Execute tests
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
+        default: ''
+      checkout_repo:
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
 jobs:
   tests:
@@ -23,7 +32,8 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 1
-        ref: ${{ github.event.pull_request.head.sha }}
+        repository: ${{ inputs.checkout_repo || github.repository }}
+        ref: ${{ inputs.checkout_ref || github.sha }}
         persist-credentials: false
 
     - name: Install dependencies
@@ -36,10 +46,10 @@ jobs:
       run: |
         bats -F pretty -T --print-output-on-failure test.bats --gather-test-outputs-in outputs
       env:
-        TERM: linux      
+        TERM: linux
         QE_ES_SERVER: ${{ secrets.QE_ES_SERVER }}
         QUAY_QE_ES_SERVER: ${{ secrets.QUAY_QE_ES_SERVER }}
-      
+
     - name: Upload outputs data
       if: ${{ success() || failure() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -11,7 +11,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 1
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Separate ci-tests.yaml from ci-integration-tests.yaml so lint, build, and unit tests run from the PR branch while integration tests with secrets remain gated behind main-branch

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
