### PR TITLE
Change default direction from 0 to 1 to detect only increases

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -273,8 +273,8 @@ UUID field ensures that a set of test results from the same job are grouped toge
 ### Direction
 Controls which types of changes to detect:
 
-- `direction: 1` - Show only positive changes (increases)
-- `direction: 0` - Show both positive and negative changes (default)
+- `direction: 1` - Show only positive changes (increases) **(default)**
+- `direction: 0` - Show both positive and negative changes
 - `direction: -1` - Show only negative changes (decreases)
 
 ### Threshold
@@ -386,7 +386,7 @@ Orion supports aggregating metric values across multiple data points per test ru
   agg:
     agg_type: avg  # Calculate average CPU usage
   threshold: 10
-  direction: 1
+  direction: 1  # Optional: detect only increases (this is the default)
 ```
 
 **Count:**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,7 +50,7 @@ orion --cmr
 ```
 
 - If more than 1 previous run is found, values are averaged together
-- Use with `direction: 0` in config when using `-o json` to see percent differences
+- Use with `direction: 0` in config when using `-o json` to see percent differences for both increases and decreases (default is `direction: 1` which only shows increases)
 
 ### Anomaly Detection
 Detects anomalies in your data:

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -65,7 +65,7 @@ class Utils:
 
         for metric in metrics:
             labels = metric.pop("labels", None)
-            direction = int(metric.pop("direction", 0))
+            direction = int(metric.pop("direction", 1))
             threshold = abs(int(metric.pop("threshold", test_threshold)))
             ts = metric.pop("timestamp", global_timestamp_field)
             correlation = metric.pop("correlation", "")

--- a/orion/visualization.py
+++ b/orion/visualization.py
@@ -74,7 +74,7 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
         cps = viz_data.change_points_by_metric.get(m, [])
         if not cps:
             return (2, m)  # stable → bottom
-        direction = viz_data.metrics_config[m].get("direction", 0)
+        direction = viz_data.metrics_config[m].get("direction", 1)
         has_regression = any(
             _classify_changepoint(cp.stats, direction)[1] for cp in cps
         )
@@ -180,7 +180,7 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                 continue
             cp_value = values.iloc[idx]
 
-            direction = metric_config.get("direction", 0)
+            direction = metric_config.get("direction", 1)
             pct_change, is_regression = _classify_changepoint(
                 cp.stats, direction
             )
@@ -334,7 +334,7 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
         for cp in cps:
             direction = viz_data.metrics_config.get(
                 metric_name, {}
-            ).get("direction", 0)
+            ).get("direction", 1)
             pct, is_regression = _classify_changepoint(
                 cp.stats, direction
             )


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [X] Optimization
- [ ] Documentation Update

## Description

Most metrics (CPU, latency, memory, etc.) are regressions when they increase, so direction: 1 (positive changes only) is the more sensible default. Users who want to detect both increases and decreases can explicitly set direction: 0, and those tracking metrics where decreases are bad (like throughput) can use direction: -1.

Updated documentation to reflect the new default and clarify when direction: 0 is needed for bidirectional change detection.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

