### PR TITLE
Pr comparisson enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ etc.
 - **Regression Detection**: Identify performance regressions using advanced statistical methods
 - **Multiple Algorithms**: Support for Hunter, CMR, and anomaly detection
 - **Flexible Configuration**: YAML-based configuration with extensive customization options
-- **Multiple Output Formats**: JSON, CSV, and JUnit XML output support
+- **Multiple Output Formats**: JSON, text, and JUnit XML output support
+- **Multi-PR Comparison**: Analyze multiple pull requests side-by-side against the periodic baseline
 - **JIRA Integration**: Track and auto-create regression acknowledgments in JIRA
 
 ### JIRA Integration

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -552,7 +552,7 @@ When executing Orion with the flag `--pr-analysis` a pull request analysis will 
 
 1. An analysis section of all payload results (No PR data)
 2. An analysis section from all PR runs
-3. A comparison table summarizing AVG, changepoint values, and PR results per metric
+3. A comparison table summarizing Baseline AVG, changepoint values, and PR results per metric
 
 ### Multiple PR comparison
 
@@ -580,7 +580,7 @@ The legacy single `pull_number` in `--input-vars` continues to work for backward
 The comparison table provides a quick way to compare the PR results against the payload baseline and any detected changepoints. The columns are:
 
 - **Metric** — the metric name
-- **AVG** — the average of all periodic (payload) runs
+- **Baseline AVG** — the average of periodic (payload) runs **before** the first detected changepoint. When no changepoints are detected, it averages all runs. This excludes post-regression data so the baseline is not skewed by regressed values
 - **Pre-CP#N** — the metric value from the run **immediately before** the Nth changepoint (shown for every metric, as a baseline reference)
 - **CP#N** — the metric value **at** the Nth changepoint, but only for metrics where a regression was detected at that point. Metrics without a changepoint there show `-`
 - **PR#number** — the value from the latest run of each PR. When multiple PRs are analyzed, each gets its own column
@@ -590,7 +590,7 @@ The comparison table provides a quick way to compare the PR results against the 
 #### Single PR example
 
 ```text
-Metric                        AVG    Pre-CP#1    CP#1    PR#2394
+Metric                 Baseline AVG    Pre-CP#1    CP#1    PR#2394
 --------------------------  ------  ----------  ------  --------
 podReadyLatency_P99          15000       15000   18000     15000
 apiserverCPU_avg            4.776       4.834       -    4.7328
@@ -603,7 +603,7 @@ Here `ovnCPU_avg` jumped from `1.5497` (Pre-CP#1) to `2.4297` (CP#1), and the PR
 #### Multiple PR example
 
 ```text
-Metric                        AVG    Pre-CP#1    CP#1    PR#2394    PR#2387
+Metric                 Baseline AVG    Pre-CP#1    CP#1    PR#2394    PR#2387
 --------------------------  ------  ----------  ------  --------  --------
 podReadyLatency_P99          15000       15000   18000     15000     18000
 apiserverCPU_avg            4.776       4.834       -    4.7328    4.7328
@@ -674,7 +674,7 @@ time                       uuid                                  ocpVersion     
 
 payload-cluster-density-v2 | Comparison
 =======================================
-Metric                        AVG    Pre-CP#1    CP#1    PR#2394
+Metric                 Baseline AVG    Pre-CP#1    CP#1    PR#2394
 --------------------------  ------  ----------  ------  --------
 podReadyLatency_P99          15000       15000   15000     15000
 apiserverCPU_avg            4.776       4.834       -    4.7328

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -548,11 +548,34 @@ orion --config performance-config.yaml --hunter-analyze --ack known-issues.yaml
 ```
 
 ## Running from a pull request
-When executing Orion with the flag `--pr-analysis` a pull request analysis will executed and the output for it will contain three sections
+When executing Orion with the flag `--pr-analysis` a pull request analysis will be executed and the output for it will contain three sections
 
 1. An analysis section of all payload results (No PR data)
 2. An analysis section from all PR runs
 3. A comparison table summarizing AVG, changepoint values, and PR results per metric
+
+### Multiple PR comparison
+
+Orion supports analyzing multiple pull requests in a single run. Each PR is analyzed independently against the periodic baseline, and all results appear side-by-side in the comparison table. This is useful for comparing the performance impact of different PRs.
+
+There are three ways to specify multiple PRs (they can be combined — duplicates are automatically removed):
+
+```bash
+# Repeatable CLI flag
+orion --pr-analysis --pull-number 1234 --pull-number 5678 --config config.yaml --hunter-analyze
+
+# Comma-separated string in --input-vars
+orion --pr-analysis --input-vars='{"pull_number": "1234,5678", ...}' --config config.yaml --hunter-analyze
+
+# JSON array in --input-vars
+orion --pr-analysis --input-vars='{"pull_numbers": [1234, 5678], ...}' --config config.yaml --hunter-analyze
+```
+
+The legacy single `pull_number` in `--input-vars` continues to work for backward compatibility.
+
+> **Note:** Pull number `0` is reserved internally for periodic runs and is always filtered out.
+
+### Comparison table
 
 The comparison table provides a quick way to compare the PR results against the payload baseline and any detected changepoints. The columns are:
 
@@ -560,11 +583,11 @@ The comparison table provides a quick way to compare the PR results against the 
 - **AVG** — the average of all periodic (payload) runs
 - **Pre-CP#N** — the metric value from the run **immediately before** the Nth changepoint (shown for every metric, as a baseline reference)
 - **CP#N** — the metric value **at** the Nth changepoint, but only for metrics where a regression was detected at that point. Metrics without a changepoint there show `-`
-- **PR#number** — the value from the latest PR run
+- **PR#number** — the value from the latest run of each PR. When multiple PRs are analyzed, each gets its own column
 
 **How to read CP columns:** Changepoints are numbered in chronological order (`CP#1` is the earliest detected, `CP#2` the next, etc.). Each changepoint represents a moment in the payload history where a statistically significant shift was detected. To spot a regression, compare `Pre-CP#N` (the value just before the shift) with `CP#N` (the value at the shift). If `CP#N` shows `-`, that metric was stable at that point — only metrics that actually changed will have a value.
 
-For example, in the table below, `CP#1` corresponds to the 6th payload run (index 5). Only `podReadyLatency_P99` and `ovnCPU_avg` had changepoints detected there — so they show values, while the rest show `-`:
+#### Single PR example
 
 ```text
 Metric                        AVG    Pre-CP#1    CP#1    PR#2394
@@ -577,18 +600,18 @@ etcdCPU_avg                 3.4659      3.4602      -    3.4675
 
 Here `ovnCPU_avg` jumped from `1.5497` (Pre-CP#1) to `2.4297` (CP#1), and the PR value `1.7267` is consistent with the pre-changepoint level — so the PR is addressing this regression.
 
-On the other hand, you could have this:
+#### Multiple PR example
 
 ```text
-Metric                        AVG    Pre-CP#1    CP#1    PR#2387
---------------------------  ------  ----------  ------  --------
-podReadyLatency_P99          15000       15000   18000     18000
-apiserverCPU_avg            4.776       4.834       -    4.7328
-ovnCPU_avg                  1.4801      1.5497  2.4297    2.7267
-etcdCPU_avg                 3.4659      3.4602      -    3.4675
+Metric                        AVG    Pre-CP#1    CP#1    PR#2394    PR#2387
+--------------------------  ------  ----------  ------  --------  --------
+podReadyLatency_P99          15000       15000   18000     15000     18000
+apiserverCPU_avg            4.776       4.834       -    4.7328    4.7328
+ovnCPU_avg                  1.4801      1.5497  2.4297    1.7267    2.7267
+etcdCPU_avg                 3.4659      3.4602      -    3.4675    3.4675
 ```
 
-Here `ovnCPU_avg` jumped from `1.5497` (Pre-CP#1) to `2.4297` (CP#1), and the PR value `2.7267` is consistent with the changepoint level — so the PR is probably the culprit of the regression.
+Here you can compare two PRs at a glance: PR#2394 shows `ovnCPU_avg` at `1.7267` (close to the pre-changepoint baseline), while PR#2387 shows `2.7267` (worse than the changepoint) — suggesting PR#2387 may be the culprit.
 
 | The only section that can trigger a failure in the job is the one in section one, the payload data, and it is not related to the changes in the PR.
 
@@ -597,15 +620,41 @@ Here `ovnCPU_avg` jumped from `1.5497` (Pre-CP#1) to `2.4297` (CP#1), and the PR
 To achieve this the following input_vars should be provided
 
 - "jobtype"
-- "pull_number"
 - "organization"
 - "repository"
 
-### Input Example
+And at least one pull number via `--pull-number` flag or `pull_number`/`pull_numbers` in `--input-vars`.
 
-`--input-vars='{"jobtype": "pull","pull_number": "2790", "organization": "openshift", "repository": "test"}'`
+### Input Examples
+
+Single PR (legacy format):
+```bash
+orion --pr-analysis --input-vars='{"jobtype": "pull", "pull_number": "2790", "organization": "openshift", "repository": "test"}' --config config.yaml --hunter-analyze
+```
+
+Multiple PRs:
+```bash
+orion --pr-analysis --pull-number 2394 --pull-number 2387 --input-vars='{"jobtype": "pull", "organization": "openshift", "repository": "test"}' --config config.yaml --hunter-analyze
+```
 
 Add `--viz` to this workflow to generate interactive HTML visualizations for each analyzed dataset alongside the standard PR report output.
+
+### JSON output format
+
+When using `-o json` with `--pr-analysis`, the output structure is:
+
+```json
+{
+  "periodic": [ ... ],
+  "periodic_avg": { ... },
+  "pulls": [
+    { "pr": 2394, "data": [ ... ] },
+    { "pr": 2387, "data": [ ... ] }
+  ]
+}
+```
+
+Each entry in `pulls` contains the PR number and its full analysis data.
 
 ### Example
 ```

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from orion.logger import SingletonLogger
 from orion.run_test import run
 from orion.pipeline.formatters import FormatterFactory
 from orion import constants as cnsts
-from orion.config import load_config, auto_detect_ack_file_with_vars
+from orion.config import load_config, auto_detect_ack_file_with_vars, collect_pull_numbers
 from orion.visualization import generate_test_html
 from orion.reporting.standalone import load_json_files, generate_report
 from orion.reporting.summary import print_regression_summary
@@ -501,6 +501,7 @@ def get_ack_providers(kwargs: dict, config: dict, logger) -> tuple[list[AckProvi
 @click.option("--input-vars", type=Dictionary(), default="{}", help='Arbitrary input variables to use in the config template, for example: {"version": "4.18"}')
 @click.option("--display", type=List(), default=["buildUrl"], help="Add metadata field as a column in the output (e.g. ocpVirt, upstreamJob)")
 @click.option("--pr-analysis", is_flag=True, help="Analyze PRs for regressions", default=False)
+@click.option("--pull-number", type=int, multiple=True, help="PR number(s) to analyze (repeatable, e.g. --pull-number 1234 --pull-number 5678)")
 @click.option("--viz", is_flag=True, default=False, help="Generate interactive HTML visualizations alongside output")
 @click.option(
     "--report",
@@ -591,16 +592,24 @@ def main(**kwargs):
         missing_vars = []
         if "jobtype" not in input_vars:
             missing_vars.append("jobtype")
-        if "pull_number" not in input_vars:
-            missing_vars.append("pull_number")
         if "organization" not in input_vars:
             missing_vars.append("organization")
         if "repository" not in input_vars:
             missing_vars.append("repository")
+
+        pull_numbers = collect_pull_numbers(kwargs, input_vars)
+        if not pull_numbers:
+            missing_vars.append("pull_number (via --pull-number, "
+                                "--input-vars pull_number, or pull_numbers)")
         if missing_vars:
-            logger.error("Missing required input variables: %s", ", ".join(missing_vars))
+            logger.error(
+                "Missing required input variables: %s",
+                ", ".join(missing_vars),
+            )
             sys.exit(1)
-    results, results_pull = run(**kwargs)
+        kwargs["pull_numbers"] = pull_numbers
+        logger.info("PR analysis for pull numbers: %s", pull_numbers)
+    results, results_pull, analyses_by_pr = run(**kwargs)
     is_pull = bool(results_pull.analyses)
 
     # Auto-create JIRA issues for regressions if enabled
@@ -644,16 +653,20 @@ def main(**kwargs):
         sys.exit(0)
 
     if is_pull:
-        pull_analyses_by_test = {
-            a.test_name: a for a in results_pull.analyses
-        }
         for analysis in results.analyses:
-            pull_analysis = pull_analyses_by_test.get(analysis.test_name)
+            test_name = analysis.test_name
+            pulls = []
+            for pr_num in results_pull.prs:
+                pr_analyses = analyses_by_pr.get(pr_num, [])
+                pull_analysis = next(
+                    (a for a in pr_analyses if a.test_name == test_name),
+                    None,
+                )
+                pulls.append((pr_num, pull_analysis))
             formatter.print_and_save_pr(
                 analysis,
-                pull_analysis,
+                pulls,
                 kwargs["save_output_path"],
-                pr=results_pull.pr,
             )
 
             if analysis.regression_flag:

--- a/main.py
+++ b/main.py
@@ -597,7 +597,11 @@ def main(**kwargs):
         if "repository" not in input_vars:
             missing_vars.append("repository")
 
-        pull_numbers = collect_pull_numbers(kwargs, input_vars)
+        try:
+            pull_numbers = collect_pull_numbers(kwargs, input_vars)
+        except ValueError as exc:
+            logger.error("Invalid pull number: %s", exc)
+            sys.exit(1)
         if not pull_numbers:
             missing_vars.append("pull_number (via --pull-number, "
                                 "--input-vars pull_number, or pull_numbers)")

--- a/orion/config.py
+++ b/orion/config.py
@@ -383,28 +383,52 @@ def merge_lists(metrics: List[Any], inherited_metrics: List[Any]) -> List[Any]:
     return merged
 
 
+def _parse_pull_number(token) -> int:
+    """Validate and convert a single pull number token.
+
+    Raises:
+        ValueError: if the token is not a positive integer.
+    """
+    try:
+        num = int(token)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"invalid pull number: '{token}'") from exc
+    if num < 0:
+        raise ValueError(f"invalid pull number: '{token}'")
+    return num
+
+
 def collect_pull_numbers(kwargs: dict, input_vars: dict) -> list:
     """Collect and deduplicate pull numbers from CLI flags and input-vars.
 
     Zero is filtered out — pullNumber 0 means "periodic" internally.
+
+    Raises:
+        ValueError: if any token is non-numeric or negative.
     """
     numbers = set()
     for num in kwargs.get("pull_number", ()):
-        if num:
-            numbers.add(int(num))
+        parsed = _parse_pull_number(num)
+        if parsed > 0:
+            numbers.add(parsed)
     for key in ("pull_numbers", "pull_number"):
         if key not in input_vars:
             continue
         val = input_vars[key]
         if isinstance(val, list):
             for v in val:
-                if int(v) != 0:
-                    numbers.add(int(v))
+                parsed = _parse_pull_number(v)
+                if parsed > 0:
+                    numbers.add(parsed)
         elif isinstance(val, str):
             for part in val.split(","):
                 part = part.strip()
-                if part and int(part) != 0:
-                    numbers.add(int(part))
-        elif val and int(val) != 0:
-            numbers.add(int(val))
+                if part:
+                    parsed = _parse_pull_number(part)
+                    if parsed > 0:
+                        numbers.add(parsed)
+        else:
+            parsed = _parse_pull_number(val)
+            if parsed > 0:
+                numbers.add(parsed)
     return sorted(numbers)

--- a/orion/config.py
+++ b/orion/config.py
@@ -381,3 +381,30 @@ def merge_lists(metrics: List[Any], inherited_metrics: List[Any]) -> List[Any]:
 
     logger.debug(f"merged metrics: {merged}")
     return merged
+
+
+def collect_pull_numbers(kwargs: dict, input_vars: dict) -> list:
+    """Collect and deduplicate pull numbers from CLI flags and input-vars.
+
+    Zero is filtered out — pullNumber 0 means "periodic" internally.
+    """
+    numbers = set()
+    for num in kwargs.get("pull_number", ()):
+        if num:
+            numbers.add(int(num))
+    for key in ("pull_numbers", "pull_number"):
+        if key not in input_vars:
+            continue
+        val = input_vars[key]
+        if isinstance(val, list):
+            for v in val:
+                if int(v) != 0:
+                    numbers.add(int(v))
+        elif isinstance(val, str):
+            for part in val.split(","):
+                part = part.strip()
+                if part and int(part) != 0:
+                    numbers.add(int(part))
+        elif val and int(val) != 0:
+            numbers.add(int(val))
+    return sorted(numbers)

--- a/orion/pipeline/formatters/base.py
+++ b/orion/pipeline/formatters/base.py
@@ -1,7 +1,7 @@
 """Base formatter ABC with shared regression data extraction."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, List, Optional, Tuple
 
 from orion.pipeline.analysis_result import AnalysisResult
 from orion.github_client import GitHubClient
@@ -31,11 +31,13 @@ class BaseFormatter(ABC):
         """Print formatted output to stdout."""
 
     @abstractmethod
-    def print_and_save_pr(self, periodic: AnalysisResult,
-                          pull: Optional[AnalysisResult],
-                          save_output_path: str,
-                          pr: int = 0) -> None:
-        """Format, print, and save combined PR output (periodic + pull)."""
+    def print_and_save_pr(
+        self,
+        periodic: AnalysisResult,
+        pulls: List[Tuple[int, Optional[AnalysisResult]]],
+        save_output_path: str,
+    ) -> None:
+        """Format, print, and save combined PR output (periodic + pulls)."""
 
     def extract_regression_data(self, data: AnalysisResult) -> list:
         """Extract regression data from raw change points and dataframe."""

--- a/orion/pipeline/formatters/json_formatter.py
+++ b/orion/pipeline/formatters/json_formatter.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from typing import Any, Optional
+from typing import Any, List, Optional, Tuple
 
 from orion.pipeline.analysis_result import AnalysisResult
 from orion.pipeline.formatters.base import BaseFormatter
@@ -102,21 +102,29 @@ class JsonFormatter(BaseFormatter):
                      is_pull: bool = False) -> None:
         print(formatted)
 
-    def print_and_save_pr(self, periodic: AnalysisResult,
-                          pull: Optional[AnalysisResult],
-                          save_output_path: str,
-                          pr: int = 0) -> None:
+    def print_and_save_pr(
+        self,
+        periodic: AnalysisResult,
+        pulls: List[Tuple[int, Optional[AnalysisResult]]],
+        save_output_path: str,
+    ) -> None:
         formatted_periodic = self.format(periodic)
         avg_formatted = self.format_average(periodic)
         results_json = {
             "periodic": json.loads(formatted_periodic[periodic.test_name]),
             "periodic_avg": json.loads(avg_formatted),
         }
-        if pull:
-            formatted_pull = self.format(pull)
-            results_json["pull"] = json.loads(
-                formatted_pull[pull.test_name]
-            )
+        pulls_data = []
+        for pr_num, pull in pulls:
+            if pull:
+                formatted_pull = self.format(pull)
+                pulls_data.append({
+                    "pr": pr_num,
+                    "data": json.loads(formatted_pull[pull.test_name]),
+                })
+            else:
+                pulls_data.append({"pr": pr_num, "data": []})
+        results_json["pulls"] = pulls_data
         combined = json.dumps(results_json, indent=2)
         print(combined)
         base = os.path.splitext(save_output_path)[0]

--- a/orion/pipeline/formatters/junit_formatter.py
+++ b/orion/pipeline/formatters/junit_formatter.py
@@ -4,7 +4,7 @@ import json
 import os
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
-from typing import Any, Optional
+from typing import Any, List, Optional, Tuple
 
 from orion.pipeline.analysis_result import AnalysisResult
 from orion.pipeline.formatters.base import BaseFormatter
@@ -65,21 +65,25 @@ class JUnitFormatter(BaseFormatter):
         dom = xml.dom.minidom.parseString(xml_str)
         print(dom.toprettyxml())
 
-    def print_and_save_pr(self, periodic: AnalysisResult,
-                          pull: Optional[AnalysisResult],
-                          save_output_path: str,
-                          pr: int = 0) -> None:
+    def print_and_save_pr(
+        self,
+        periodic: AnalysisResult,
+        pulls: List[Tuple[int, Optional[AnalysisResult]]],
+        save_output_path: str,
+    ) -> None:
         formatted_periodic = self.format(periodic)
         avg_formatted = self.format_average(periodic)
         testsuites = ET.Element("testsuites")
         testsuites.append(formatted_periodic[periodic.test_name])
         avg_formatted.tag = "periodic_avg"
         testsuites.append(avg_formatted)
-        if pull:
-            formatted_pull = self.format(pull)
-            pull_el = formatted_pull[pull.test_name]
-            pull_el.tag = "pull"
-            testsuites.append(pull_el)
+        for pr_num, pull in pulls:
+            if pull:
+                formatted_pull = self.format(pull)
+                pull_el = formatted_pull[pull.test_name]
+                pull_el.tag = "pull"
+                pull_el.set("pr", str(pr_num))
+                testsuites.append(pull_el)
         xml_str = ET.tostring(
             testsuites, encoding="utf8", method="xml"
         ).decode()

--- a/orion/pipeline/formatters/text_formatter.py
+++ b/orion/pipeline/formatters/text_formatter.py
@@ -114,8 +114,9 @@ class TextFormatter(BaseFormatter):
         for pr_num, pull in pulls:
             if pull:
                 formatted_pull = self.format(pull)
+                save_name = f"{pull.test_name}_pr_{pr_num}"
                 self.save(
-                    pull.test_name,
+                    save_name,
                     formatted_pull[pull.test_name],
                     save_output_path,
                 )

--- a/orion/pipeline/formatters/text_formatter.py
+++ b/orion/pipeline/formatters/text_formatter.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from typing import Any, Optional
+from typing import Any, List, Optional, Tuple
 
 import pandas as pd
 from tabulate import tabulate
@@ -94,10 +94,12 @@ class TextFormatter(BaseFormatter):
             print("=" * len(text))
             print(formatted)
 
-    def print_and_save_pr(self, periodic: AnalysisResult,
-                          pull: Optional[AnalysisResult],
-                          save_output_path: str,
-                          pr: int = 0) -> None:
+    def print_and_save_pr(
+        self,
+        periodic: AnalysisResult,
+        pulls: List[Tuple[int, Optional[AnalysisResult]]],
+        save_output_path: str,
+    ) -> None:
         formatted_periodic = self.format(periodic)
         self.save(
             periodic.test_name,
@@ -109,21 +111,22 @@ class TextFormatter(BaseFormatter):
             formatted_periodic[periodic.test_name],
             periodic,
         )
-        if pull:
-            formatted_pull = self.format(pull)
-            self.save(
-                pull.test_name,
-                formatted_pull[pull.test_name],
-                save_output_path,
-            )
-            self.print_output(
-                pull.test_name,
-                formatted_pull[pull.test_name],
-                pull,
-                pr=pr,
-                is_pull=True,
-            )
-        comparison = _format_comparison_table(periodic, pull, pr)
+        for pr_num, pull in pulls:
+            if pull:
+                formatted_pull = self.format(pull)
+                self.save(
+                    pull.test_name,
+                    formatted_pull[pull.test_name],
+                    save_output_path,
+                )
+                self.print_output(
+                    pull.test_name,
+                    formatted_pull[pull.test_name],
+                    pull,
+                    pr=pr_num,
+                    is_pull=True,
+                )
+        comparison = _format_comparison_table(periodic, pulls)
         if comparison:
             text = periodic.test_name + " | Comparison"
             print("\n" + text)
@@ -169,10 +172,9 @@ def tabulate_average_values(
 
 def _format_comparison_table(
     periodic: AnalysisResult,
-    pull: Optional[AnalysisResult],
-    pr: int = 0,
+    pulls: List[Tuple[int, Optional[AnalysisResult]]],
 ) -> str:
-    """Build a metric comparison table: AVG | pre-CP | CP | ... | PR value."""
+    """Build a metric comparison table: AVG | pre-CP | CP | ... | PR values."""
     metrics = list(periodic.avg_values.index)
     if not metrics:
         return ""
@@ -194,14 +196,15 @@ def _format_comparison_table(
     for cp_num, idx in enumerate(cp_indices, start=1):
         headers.append(f"Pre-CP#{cp_num}")
         headers.append(f"CP#{cp_num}")
-    if pull is not None:
-        pr_label = f"PR#{pr}" if pr else "PR"
+
+    pull_last_rows = []
+    for pr_num, pull in pulls:
+        pr_label = f"PR#{pr_num}" if pr_num else "PR"
         headers.append(pr_label)
-        pull_last_row = (
-            pull.dataframe.iloc[-1] if len(pull.dataframe) > 0 else None
-        )
-    else:
-        pull_last_row = None
+        if pull is not None and len(pull.dataframe) > 0:
+            pull_last_rows.append(pull.dataframe.iloc[-1])
+        else:
+            pull_last_rows.append(None)
 
     rows = []
     for metric in metrics:
@@ -213,10 +216,11 @@ def _format_comparison_table(
                 row.append(df.iloc[idx][metric] if idx < len(df) else "-")
             else:
                 row.append("-")
-        if pull_last_row is not None:
-            row.append(pull_last_row.get(metric, "-"))
-        elif pull is not None:
-            row.append("-")
+        for last_row in pull_last_rows:
+            if last_row is not None:
+                row.append(last_row.get(metric, "-"))
+            else:
+                row.append("-")
         rows.append(row)
 
     num_value_cols = len(headers) - 1

--- a/orion/pipeline/formatters/text_formatter.py
+++ b/orion/pipeline/formatters/text_formatter.py
@@ -192,7 +192,7 @@ def _format_comparison_table(
 
     df = periodic.dataframe
 
-    headers = ["Metric", "AVG"]
+    headers = ["Metric", "Baseline AVG"]
     for cp_num, idx in enumerate(cp_indices, start=1):
         headers.append(f"Pre-CP#{cp_num}")
         headers.append(f"CP#{cp_num}")

--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -364,7 +364,17 @@ def analyze(test, kwargs, is_pull=False):
         )
 
     series = final_algorithm.setup_series()
-    avg_values = final_algorithm.dataframe[metrics].mean()
+
+    min_cp_index = None
+    for cps in change_points_by_metric.values():
+        for cp in cps:
+            if min_cp_index is None or cp.index < min_cp_index:
+                min_cp_index = cp.index
+
+    if min_cp_index is not None and min_cp_index > 0:
+        avg_values = final_algorithm.dataframe[metrics].iloc[:min_cp_index].mean()
+    else:
+        avg_values = final_algorithm.dataframe[metrics].mean()
 
     analysis_result = AnalysisResult(
         test_name=test["name"],

--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -4,7 +4,7 @@ run test
 import sys
 import copy
 import concurrent.futures
-from typing import Any, Dict, NamedTuple, Tuple
+from typing import Any, Dict, List, NamedTuple, Tuple
 from orion.matcher import Matcher
 from orion.logger import SingletonLogger
 from orion.algorithms import AlgorithmFactory
@@ -20,7 +20,7 @@ class TestResults(NamedTuple):
     __test__ = False
     analyses: list
     regression_flag: bool
-    pr: int
+    prs: list
     viz_data: list
 
 
@@ -44,65 +44,84 @@ def get_algorithm_type(kwargs):
     return algorithm_name
 
 # pylint: disable=too-many-locals
-def run(**kwargs: dict[str, Any]) -> Tuple[TestResults, TestResults]:
+def run(**kwargs: dict[str, Any]) -> Tuple[
+    TestResults, TestResults, Dict[int, List]
+]:
     """Run tests and return raw analysis results.
 
-    Returns two TestResults: (standard_results, pull_request_results).
+    Returns (standard_results, pull_request_results, analyses_by_pr).
+    analyses_by_pr maps PR number -> list of AnalysisResult for that PR.
     """
     config = kwargs["config"]
     pr_analysis = kwargs["pr_analysis"]
+    pull_numbers = kwargs.get("pull_numbers", [])
 
     logger = SingletonLogger.get_logger("Orion")
     analyses = []
-    analyses_pull = []
+    analyses_pull = {}
     regression_flag = False
     regression_flag_pull = False
     all_viz_data = []
     all_viz_data_pull = []
-    pr = 0
 
     for test in config["tests"]:
         if "metadata" in test:
             if pr_analysis:
+                prs_to_analyze = pull_numbers or [
+                    int(test["metadata"].get("pullNumber", 0))
+                ]
+                max_workers = len(prs_to_analyze) + 1
                 with concurrent.futures.ThreadPoolExecutor(
-                    max_workers=2
+                    max_workers=max_workers
                 ) as executor:
                     logger.info("Executing tasks in parallel...")
-                    logger.info("Ensuring jobType is set to pull")
-                    test["metadata"]["jobType"] = "pull"
-                    futures_pull = executor.submit(
-                        analyze, test, kwargs, True
-                    )
-                    pr = int(test["metadata"]["pullNumber"])
+
                     test_periodic = copy.deepcopy(test)
                     test_periodic["metadata"]["jobType"] = "periodic"
                     test_periodic["metadata"]["pullNumber"] = 0
                     test_periodic["metadata"]["organization"] = ""
                     test_periodic["metadata"]["repository"] = ""
-                    futures_periodic = executor.submit(
+                    future_periodic = executor.submit(
                         analyze, test_periodic, kwargs, False
                     )
-                    concurrent.futures.wait(
-                        [futures_pull, futures_periodic]
+
+                    pull_futures = {}
+                    for pr_num in prs_to_analyze:
+                        logger.info(
+                            "Submitting pull analysis for PR#%d", pr_num
+                        )
+                        test_pull = copy.deepcopy(test)
+                        test_pull["metadata"]["jobType"] = "pull"
+                        test_pull["metadata"]["pullNumber"] = pr_num
+                        pull_futures[pr_num] = executor.submit(
+                            analyze, test_pull, kwargs, True
+                        )
+
+                    all_futures = [future_periodic] + list(
+                        pull_futures.values()
                     )
-                    pull_result_tuple = futures_pull.result()
-                    periodic_result_tuple = futures_periodic.result()
+                    concurrent.futures.wait(all_futures)
 
-                    pull_analysis, pull_viz = pull_result_tuple
-                    periodic_analysis, periodic_viz = periodic_result_tuple
-
-                    if pull_analysis is not None:
-                        analyses_pull.append(pull_analysis)
-                        if pull_analysis.regression_flag:
-                            regression_flag_pull = True
+                    periodic_analysis, periodic_viz = (
+                        future_periodic.result()
+                    )
                     if periodic_analysis is not None:
                         analyses.append(periodic_analysis)
                         if periodic_analysis.regression_flag:
                             regression_flag = True
-                    if pull_viz is not None:
-                        all_viz_data_pull.append(pull_viz)
                     if periodic_viz is not None:
                         all_viz_data.append(periodic_viz)
+
+                    for pr_num, future in pull_futures.items():
+                        pull_analysis, pull_viz = future.result()
+                        if pull_analysis is not None:
+                            analyses_pull.setdefault(
+                                pr_num, []
+                            ).append(pull_analysis)
+                            if pull_analysis.regression_flag:
+                                regression_flag_pull = True
+                        if pull_viz is not None:
+                            all_viz_data_pull.append(pull_viz)
             else:
                 result_tuple = analyze(test, kwargs)
                 analysis, viz_data = result_tuple
@@ -113,19 +132,23 @@ def run(**kwargs: dict[str, Any]) -> Tuple[TestResults, TestResults]:
                 if viz_data is not None:
                     all_viz_data.append(viz_data)
 
+    flat_pull_analyses = [
+        a for pr_analyses in analyses_pull.values()
+        for a in pr_analyses
+    ]
     results_pull = TestResults(
-        analyses=analyses_pull,
+        analyses=flat_pull_analyses,
         regression_flag=regression_flag_pull,
-        pr=pr,
+        prs=list(analyses_pull.keys()),
         viz_data=all_viz_data_pull,
     )
     results = TestResults(
         analyses=analyses,
         regression_flag=regression_flag,
-        pr=0,
+        prs=[],
         viz_data=all_viz_data,
     )
-    return results, results_pull
+    return results, results_pull, analyses_pull
 
 
 def get_start_timestamp(kwargs: Dict[str, Any], test: Dict[str, Any], is_pull: bool) -> str:

--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -139,7 +139,7 @@ def run(**kwargs: dict[str, Any]) -> Tuple[
     results_pull = TestResults(
         analyses=flat_pull_analyses,
         regression_flag=regression_flag_pull,
-        prs=list(analyses_pull.keys()),
+        prs=pull_numbers,
         viz_data=all_viz_data_pull,
     )
     results = TestResults(

--- a/orion/tests/test_config.py
+++ b/orion/tests/test_config.py
@@ -11,7 +11,7 @@ import os
 import pytest
 import yaml
 
-from orion.config import load_config
+from orion.config import load_config, collect_pull_numbers
 
 
 def _write_config(tmp_dir, config_dict, filename="config.yaml"):
@@ -101,3 +101,81 @@ class TestPercentileValidation:
             result = load_config(path, {})
             assert result is not None
             assert len(result["tests"]) == 1
+
+
+class TestCollectPullNumbers:
+
+    def test_single_pull_number_from_input_vars(self):
+        result = collect_pull_numbers({}, {"pull_number": "1234"})
+        assert result == [1234]
+
+    def test_multiple_from_cli_flag(self):
+        result = collect_pull_numbers(
+            {"pull_number": (1234, 5678)}, {}
+        )
+        assert result == [1234, 5678]
+
+    def test_pull_numbers_list_from_input_vars(self):
+        result = collect_pull_numbers(
+            {}, {"pull_numbers": [1111, 2222, 3333]}
+        )
+        assert result == [1111, 2222, 3333]
+
+    def test_pull_numbers_csv_string_from_input_vars(self):
+        result = collect_pull_numbers(
+            {}, {"pull_numbers": "100,200,300"}
+        )
+        assert result == [100, 200, 300]
+
+    def test_pull_number_csv_string_from_input_vars(self):
+        result = collect_pull_numbers(
+            {}, {"pull_number": "100,200"}
+        )
+        assert result == [100, 200]
+
+    def test_merge_cli_and_input_vars_deduplicated(self):
+        result = collect_pull_numbers(
+            {"pull_number": (1234, 5678)},
+            {"pull_number": "5678", "pull_numbers": [9999]},
+        )
+        assert result == [1234, 5678, 9999]
+
+    def test_empty_when_nothing_provided(self):
+        result = collect_pull_numbers({}, {})
+        assert result == []
+
+    def test_returns_sorted(self):
+        result = collect_pull_numbers(
+            {"pull_number": (9000, 100, 5000)}, {}
+        )
+        assert result == [100, 5000, 9000]
+
+    def test_ignores_zero_in_cli_flag(self):
+        result = collect_pull_numbers(
+            {"pull_number": (0, 1234)}, {}
+        )
+        assert result == [1234]
+
+    def test_integer_value_in_input_vars(self):
+        result = collect_pull_numbers({}, {"pull_number": 4567})
+        assert result == [4567]
+
+    def test_ignores_zero_in_string_input_var(self):
+        result = collect_pull_numbers({}, {"pull_number": "0"})
+        assert result == []
+
+    def test_ignores_zero_in_csv_string(self):
+        result = collect_pull_numbers(
+            {}, {"pull_number": "0,1234,0"}
+        )
+        assert result == [1234]
+
+    def test_ignores_zero_in_list(self):
+        result = collect_pull_numbers(
+            {}, {"pull_numbers": [0, 1234, 0]}
+        )
+        assert result == [1234]
+
+    def test_ignores_zero_integer_input_var(self):
+        result = collect_pull_numbers({}, {"pull_number": 0})
+        assert result == []

--- a/orion/tests/test_config.py
+++ b/orion/tests/test_config.py
@@ -179,3 +179,23 @@ class TestCollectPullNumbers:
     def test_ignores_zero_integer_input_var(self):
         result = collect_pull_numbers({}, {"pull_number": 0})
         assert result == []
+
+    def test_rejects_non_numeric_string(self):
+        with pytest.raises(ValueError, match="invalid pull number"):
+            collect_pull_numbers({}, {"pull_number": "abc"})
+
+    def test_rejects_non_numeric_csv_token(self):
+        with pytest.raises(ValueError, match="invalid pull number"):
+            collect_pull_numbers({}, {"pull_number": "123,abc"})
+
+    def test_rejects_negative_number(self):
+        with pytest.raises(ValueError, match="invalid pull number"):
+            collect_pull_numbers({}, {"pull_number": -1})
+
+    def test_rejects_negative_in_csv(self):
+        with pytest.raises(ValueError, match="invalid pull number"):
+            collect_pull_numbers({}, {"pull_number": "-2,3"})
+
+    def test_rejects_negative_in_list(self):
+        with pytest.raises(ValueError, match="invalid pull number"):
+            collect_pull_numbers({}, {"pull_numbers": [100, -5]})

--- a/orion/tests/test_formatters.py
+++ b/orion/tests/test_formatters.py
@@ -13,7 +13,10 @@ from orion.pipeline.formatters import FormatterFactory
 from orion.pipeline.formatters.base import BaseFormatter
 from orion.pipeline.formatters.json_formatter import JsonFormatter
 from orion.pipeline.formatters.junit_formatter import JUnitFormatter
-from orion.pipeline.formatters.text_formatter import TextFormatter
+from orion.pipeline.formatters.text_formatter import (
+    TextFormatter,
+    _format_comparison_table,
+)
 from orion.tests.conftest import make_change_point
 
 
@@ -81,7 +84,7 @@ class TestExtractRegressionData:
                 pass
             def print_output(self, test_name, formatted, data, pr=0, is_pull=False):
                 pass
-            def print_and_save_pr(self, periodic, pull, save_output_path, pr=0):
+            def print_and_save_pr(self, periodic, pulls, save_output_path):
                 pass
 
         formatter = ConcreteFormatter()
@@ -110,7 +113,7 @@ class TestExtractRegressionData:
                 pass
             def print_output(self, test_name, formatted, data, pr=0, is_pull=False):
                 pass
-            def print_and_save_pr(self, periodic, pull, save_output_path, pr=0):
+            def print_and_save_pr(self, periodic, pulls, save_output_path):
                 pass
 
         formatter = ConcreteFormatter()
@@ -130,7 +133,7 @@ class TestExtractRegressionData:
                 pass
             def print_output(self, test_name, formatted, data, pr=0, is_pull=False):
                 pass
-            def print_and_save_pr(self, periodic, pull, save_output_path, pr=0):
+            def print_and_save_pr(self, periodic, pulls, save_output_path):
                 pass
 
         formatter = ConcreteFormatter()
@@ -252,6 +255,194 @@ class TestJUnitFormatter:
         avg = formatter.format_average(data)
 
         assert isinstance(avg, ET.Element)
+
+
+def _make_pull_analysis(cpu_values, test_name="test-workload"):
+    """Build a minimal pull AnalysisResult with given cpu values."""
+    n = len(cpu_values)
+    df = pd.DataFrame({
+        "uuid": [f"pr-uuid-{i}" for i in range(n)],
+        "ocpVersion": ["4.18"] * n,
+        "timestamp": [1700000000 + i * 100000 for i in range(n)],
+        "buildUrl": [f"http://pr-b{i}" for i in range(n)],
+        "prs": [None] * n,
+        "cpu": cpu_values,
+    })
+    series = Series(
+        test_name="test",
+        branch=None,
+        time=list(df["timestamp"]),
+        metrics={"cpu": Metric(1, 1.0)},
+        data={"cpu": df["cpu"]},
+        attributes={
+            "uuid": df["uuid"],
+            "ocpVersion": df["ocpVersion"],
+        },
+    )
+    return AnalysisResult(
+        test_name=test_name,
+        test={"name": test_name, "uuid_field": "uuid",
+              "version_field": "ocpVersion", "metadata": {}},
+        dataframe=df,
+        metrics_config={
+            "cpu": {"direction": 1, "labels": ["infra"], "threshold": 0,
+                    "correlation": "", "context": None},
+        },
+        change_points_by_metric={"cpu": []},
+        series=series,
+        regression_flag=False,
+        avg_values=pd.Series({"cpu": sum(cpu_values) / len(cpu_values)}),
+        collapse=False,
+        display_fields=[],
+        column_group_size=5,
+        uuid_field="uuid",
+        version_field="ocpVersion",
+        sippy_pr_search=False,
+        github_repos=[],
+    )
+
+
+class TestMultiPrJson:
+    def test_json_pr_output_has_pulls_list(self, tmp_path):
+        periodic = _make_analysis_result()
+        pull_a = _make_pull_analysis([15.0, 25.0])
+        pull_b = _make_pull_analysis([12.0, 22.0])
+        pulls = [(1111, pull_a), (2222, pull_b)]
+
+        formatter = JsonFormatter()
+        save_path = str(tmp_path / "output.json")
+        formatter.print_and_save_pr(periodic, pulls, save_path)
+
+        with open(str(tmp_path / "output_test-workload.json"),
+                  encoding="utf-8") as f:
+            result = json.loads(f.read())
+
+        assert "pulls" in result
+        assert isinstance(result["pulls"], list)
+        assert len(result["pulls"]) == 2
+        assert result["pulls"][0]["pr"] == 1111
+        assert result["pulls"][1]["pr"] == 2222
+        assert isinstance(result["pulls"][0]["data"], list)
+        assert isinstance(result["pulls"][1]["data"], list)
+
+    def test_json_pr_output_with_none_pull(self, tmp_path):
+        periodic = _make_analysis_result()
+        pull_a = _make_pull_analysis([15.0])
+        pulls = [(1111, pull_a), (2222, None)]
+
+        formatter = JsonFormatter()
+        save_path = str(tmp_path / "output.json")
+        formatter.print_and_save_pr(periodic, pulls, save_path)
+
+        with open(str(tmp_path / "output_test-workload.json"),
+                  encoding="utf-8") as f:
+            result = json.loads(f.read())
+
+        assert len(result["pulls"]) == 2
+        assert result["pulls"][1]["pr"] == 2222
+        assert result["pulls"][1]["data"] == []
+
+    def test_json_single_pr_backward_compat(self, tmp_path):
+        periodic = _make_analysis_result()
+        pull = _make_pull_analysis([18.0, 28.0])
+        pulls = [(3333, pull)]
+
+        formatter = JsonFormatter()
+        save_path = str(tmp_path / "output.json")
+        formatter.print_and_save_pr(periodic, pulls, save_path)
+
+        with open(str(tmp_path / "output_test-workload.json"),
+                  encoding="utf-8") as f:
+            result = json.loads(f.read())
+
+        assert len(result["pulls"]) == 1
+        assert result["pulls"][0]["pr"] == 3333
+        assert "periodic" in result
+        assert "periodic_avg" in result
+
+
+class TestMultiPrText:
+    def test_comparison_table_has_multiple_pr_columns(self):
+        periodic = _make_analysis_result()
+        pull_a = _make_pull_analysis([15.0, 25.0])
+        pull_b = _make_pull_analysis([12.0, 22.0])
+        pulls = [(1111, pull_a), (2222, pull_b)]
+
+        table = _format_comparison_table(periodic, pulls)
+
+        assert "PR#1111" in table
+        assert "PR#2222" in table
+        assert "cpu" in table
+
+    def test_comparison_table_single_pr(self):
+        periodic = _make_analysis_result()
+        pull = _make_pull_analysis([18.0])
+        pulls = [(5555, pull)]
+
+        table = _format_comparison_table(periodic, pulls)
+
+        assert "PR#5555" in table
+
+    def test_comparison_table_with_none_pull(self):
+        periodic = _make_analysis_result()
+        pull_a = _make_pull_analysis([15.0])
+        pulls = [(1111, pull_a), (2222, None)]
+
+        table = _format_comparison_table(periodic, pulls)
+
+        assert "PR#1111" in table
+        assert "PR#2222" in table
+        lines = table.strip().split("\n")
+        data_line = [l for l in lines if "cpu" in l][0]
+        assert "-" in data_line
+
+    def test_comparison_table_empty_pulls_list(self):
+        periodic = _make_analysis_result()
+
+        table = _format_comparison_table(periodic, [])
+
+        assert "PR" not in table
+        assert "cpu" in table
+
+
+class TestMultiPrJUnit:
+    def test_junit_pr_output_has_multiple_pull_elements(self, tmp_path):
+        periodic = _make_analysis_result()
+        pull_a = _make_pull_analysis([15.0, 25.0])
+        pull_b = _make_pull_analysis([12.0, 22.0])
+        pulls = [(1111, pull_a), (2222, pull_b)]
+
+        formatter = JUnitFormatter()
+        save_path = str(tmp_path / "output.xml")
+        formatter.print_and_save_pr(periodic, pulls, save_path)
+
+        with open(str(tmp_path / "output_test-workload.xml"),
+                  encoding="utf-8") as f:
+            tree = ET.parse(f)
+
+        root = tree.getroot()
+        pull_elements = root.findall(".//pull")
+        assert len(pull_elements) == 2
+        assert pull_elements[0].get("pr") == "1111"
+        assert pull_elements[1].get("pr") == "2222"
+
+    def test_junit_pr_output_skips_none_pulls(self, tmp_path):
+        periodic = _make_analysis_result()
+        pull_a = _make_pull_analysis([15.0])
+        pulls = [(1111, pull_a), (2222, None)]
+
+        formatter = JUnitFormatter()
+        save_path = str(tmp_path / "output.xml")
+        formatter.print_and_save_pr(periodic, pulls, save_path)
+
+        with open(str(tmp_path / "output_test-workload.xml"),
+                  encoding="utf-8") as f:
+            tree = ET.parse(f)
+
+        root = tree.getroot()
+        pull_elements = root.findall(".//pull")
+        assert len(pull_elements) == 1
+        assert pull_elements[0].get("pr") == "1111"
 
 
 class TestFormatterFactory:

--- a/orion/tests/test_formatters.py
+++ b/orion/tests/test_formatters.py
@@ -393,7 +393,7 @@ class TestMultiPrText:
         assert "PR#1111" in table
         assert "PR#2222" in table
         lines = table.strip().split("\n")
-        data_line = [l for l in lines if "cpu" in l][0]
+        data_line = [line for line in lines if "cpu" in line][0]
         assert "-" in data_line
 
     def test_comparison_table_empty_pulls_list(self):
@@ -458,7 +458,7 @@ class TestMultiPrText:
         table = _format_comparison_table(data, [])
 
         lines = table.strip().split("\n")
-        cpu_line = [l for l in lines if "cpu" in l][0]
+        cpu_line = [line for line in lines if "cpu" in line][0]
         assert "15" in cpu_line
         assert "100" not in cpu_line or "Pre-CP" in table
 
@@ -471,7 +471,7 @@ class TestMultiPrText:
         table = _format_comparison_table(data, [])
 
         lines = table.strip().split("\n")
-        cpu_line = [l for l in lines if "cpu" in l][0]
+        cpu_line = [line for line in lines if "cpu" in line][0]
         assert "20" in cpu_line
 
 

--- a/orion/tests/test_formatters.py
+++ b/orion/tests/test_formatters.py
@@ -404,6 +404,76 @@ class TestMultiPrText:
         assert "PR" not in table
         assert "cpu" in table
 
+    def test_comparison_table_header_says_baseline_avg(self):
+        periodic = _make_analysis_result()
+
+        table = _format_comparison_table(periodic, [])
+
+        assert "Baseline AVG" in table
+
+    def test_baseline_avg_excludes_post_changepoint(self):
+        df = pd.DataFrame({
+            "uuid": ["u1", "u2", "u3", "u4"],
+            "ocpVersion": ["4.17", "4.18", "4.19", "4.20"],
+            "timestamp": [1700000000, 1700100000, 1700200000, 1700300000],
+            "buildUrl": ["http://b1", "http://b2", "http://b3", "http://b4"],
+            "prs": [None, None, None, None],
+            "cpu": [10.0, 20.0, 100.0, 200.0],
+        })
+        series = Series(
+            test_name="test",
+            branch=None,
+            time=list(df["timestamp"]),
+            metrics={"cpu": Metric(1, 1.0)},
+            data={"cpu": df["cpu"]},
+            attributes={
+                "uuid": df["uuid"],
+                "ocpVersion": df["ocpVersion"],
+            },
+        )
+        # Changepoint at index 2 — baseline avg should be (10+20)/2 = 15
+        data = AnalysisResult(
+            test_name="test-workload",
+            test={"name": "test-workload", "uuid_field": "uuid",
+                  "version_field": "ocpVersion",
+                  "metadata": {"benchmark.keyword": "test"}},
+            dataframe=df,
+            metrics_config={
+                "cpu": {"direction": 1, "labels": [], "threshold": 0,
+                        "correlation": "", "context": None},
+            },
+            change_points_by_metric={"cpu": [make_change_point("cpu", index=2)]},
+            series=series,
+            regression_flag=True,
+            avg_values=pd.Series({"cpu": 15.0}),
+            collapse=False,
+            display_fields=[],
+            column_group_size=5,
+            uuid_field="uuid",
+            version_field="ocpVersion",
+            sippy_pr_search=False,
+            github_repos=[],
+        )
+
+        table = _format_comparison_table(data, [])
+
+        lines = table.strip().split("\n")
+        cpu_line = [l for l in lines if "cpu" in l][0]
+        assert "15" in cpu_line
+        assert "100" not in cpu_line or "Pre-CP" in table
+
+    def test_baseline_avg_uses_all_when_no_changepoints(self):
+        data = _make_analysis_result(
+            change_points={"cpu": []}, regression_flag=False
+        )
+        # _make_analysis_result sets avg_values to 20.0 (mean of 10,20,30)
+
+        table = _format_comparison_table(data, [])
+
+        lines = table.strip().split("\n")
+        cpu_line = [l for l in lines if "cpu" in l][0]
+        assert "20" in cpu_line
+
 
 class TestMultiPrJUnit:
     def test_junit_pr_output_has_multiple_pull_elements(self, tmp_path):


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds support to multi PR comparison
Changes AVG calculation to stop before a CP

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Multi-PR Comparison feature to analyze multiple pull requests against a periodic baseline in a single run.
  * Introduced `--pull-number` CLI option (repeatable) for specifying multiple PR numbers.
  * Updated output formats (JSON, text, JUnit XML) to support multi-PR result display with per-PR comparison columns.

* **Documentation**
  * Revised PR analysis documentation with multi-PR workflow guidance, output structure details, and updated examples.
  * Updated supported output format description from "JSON, CSV, and JUnit XML" to "JSON, text, and JUnit XML".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/orion/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->