### PR TITLE
Add jobName.keyword wildcard filter to scale config metadata

### DIFF
--- a/examples/label-small-scale-cluster-density.yaml
+++ b/examples/label-small-scale-cluster-density.yaml
@@ -10,6 +10,7 @@ tests:
       fips: "{{ fips | default('false') }}"
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       not:
         stream: okd
         # networkType: OVNKubernetes

--- a/examples/large-scale-cluster-density.yaml
+++ b/examples/large-scale-cluster-density.yaml
@@ -9,6 +9,7 @@ tests:
       benchmark.keyword: cluster-density-v2
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/large-scale-cudn-density-l2.yaml
+++ b/examples/large-scale-cudn-density-l2.yaml
@@ -11,6 +11,7 @@ tests:
       benchmark.keyword: cudn-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/large-scale-cudn-density-l3.yaml
+++ b/examples/large-scale-cudn-density-l3.yaml
@@ -11,6 +11,7 @@ tests:
       benchmark.keyword: cudn-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/large-scale-node-density-cni.yaml
+++ b/examples/large-scale-node-density-cni.yaml
@@ -9,6 +9,7 @@ tests:
       benchmark.keyword: node-density-cni
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/large-scale-node-density.yaml
+++ b/examples/large-scale-node-density.yaml
@@ -9,6 +9,7 @@ tests:
       benchmark.keyword: node-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/large-scale-udn-l2.yaml
+++ b/examples/large-scale-udn-l2.yaml
@@ -11,6 +11,7 @@ tests:
       benchmark.keyword: udn-density-pods
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/large-scale-udn-l3.yaml
+++ b/examples/large-scale-udn-l3.yaml
@@ -11,6 +11,7 @@ tests:
       benchmark.keyword: udn-density-pods
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/med-scale-cluster-density.yaml
+++ b/examples/med-scale-cluster-density.yaml
@@ -9,6 +9,7 @@ tests:
       benchmark.keyword: cluster-density-v2
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/med-scale-cudn-density-l2.yaml
+++ b/examples/med-scale-cudn-density-l2.yaml
@@ -10,6 +10,7 @@ tests:
       benchmark.keyword: cudn-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/med-scale-cudn-density-l3.yaml
+++ b/examples/med-scale-cudn-density-l3.yaml
@@ -10,6 +10,7 @@ tests:
       benchmark.keyword: cudn-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/med-scale-node-density-cni.yaml
+++ b/examples/med-scale-node-density-cni.yaml
@@ -9,6 +9,7 @@ tests:
       benchmark.keyword: node-density-cni
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/med-scale-node-density.yaml
+++ b/examples/med-scale-node-density.yaml
@@ -9,6 +9,7 @@ tests:
       benchmark.keyword: node-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/med-scale-udn-l2.yaml
+++ b/examples/med-scale-udn-l2.yaml
@@ -10,6 +10,7 @@ tests:
       benchmark.keyword: udn-density-pods
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/med-scale-udn-l3.yaml
+++ b/examples/med-scale-udn-l3.yaml
@@ -10,6 +10,7 @@ tests:
       benchmark.keyword: udn-density-pods
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/small-scale-cluster-density-report.yaml
+++ b/examples/small-scale-cluster-density-report.yaml
@@ -3,6 +3,7 @@ tests:
     metadata:
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       platform: AWS
       benchmark.keyword: cluster-density-v2
       masterNodesCount: 3

--- a/examples/small-scale-cluster-density.yaml
+++ b/examples/small-scale-cluster-density.yaml
@@ -9,6 +9,7 @@ tests:
       benchmark.keyword: cluster-density-v2
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       fips: "{{ fips | default('false') }}"
       not:

--- a/examples/small-scale-cudn-density-l2-multi-ns.yaml
+++ b/examples/small-scale-cudn-density-l2-multi-ns.yaml
@@ -10,6 +10,7 @@ tests:
       benchmark.keyword: cudn-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
         upstreamJob.keyword: "*cudn-density-multi-ns-500*"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"

--- a/examples/small-scale-cudn-density-l2-single-ns.yaml
+++ b/examples/small-scale-cudn-density-l2-single-ns.yaml
@@ -10,6 +10,7 @@ tests:
       benchmark.keyword: cudn-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
         upstreamJob.keyword: "*cudn-density-single-ns-250*"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"

--- a/examples/small-scale-node-density-cni.yaml
+++ b/examples/small-scale-node-density-cni.yaml
@@ -9,6 +9,7 @@ tests:
       benchmark.keyword: node-density-cni
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/small-scale-node-density.yaml
+++ b/examples/small-scale-node-density.yaml
@@ -9,6 +9,7 @@ tests:
       benchmark.keyword: node-density
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/small-scale-udn-l2.yaml
+++ b/examples/small-scale-udn-l2.yaml
@@ -10,6 +10,7 @@ tests:
       benchmark.keyword: udn-density-pods
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"

--- a/examples/small-scale-udn-l3.yaml
+++ b/examples/small-scale-udn-l3.yaml
@@ -10,6 +10,7 @@ tests:
       benchmark.keyword: udn-density-pods
       wildcard:
         ocpVersion: "{{ version }}*"
+        jobName.keyword: "{{ jobname | default('*') }}"
       networkType: OVNKubernetes
       jobType: "{{ jobtype | default('periodic') }}"
       pullNumber: "{{ pull_number | default(0) }}"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [X] Optimization
- [ ] Documentation Update

## Description

Enables filtering ES queries by job name in all scale-based configs. Defaults to '*' (match all) for backward compatibility. When the jobname env var is set, only runs from matching CI jobs are compared, preventing data mixing across job variants (e.g., control-plane vs etcdencrypt vs loaded-upgrade).

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
I am merging this to test this PR https://github.com/openshift/release/pull/79477
