### PR TITLE
fix: support nested field traversal in get_results_batch metric routing

### DIFF
--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -618,11 +618,11 @@ class Matcher:
             matched = False
             for metric_name, match_fields, not_fields in filter_fields_by_metric:
                 matches_positive = all(
-                    doc.get(k.replace(".keyword", "")) == v
+                    self._get_nested(doc, k.replace(".keyword", "")) == v
                     for k, v in match_fields.items()
                 )
                 matches_negative = all(
-                    doc.get(k.replace(".keyword", "")) != v
+                    self._get_nested(doc, k.replace(".keyword", "")) != v
                     for k, v in not_fields.items()
                 )
                 if matches_positive and matches_negative:
@@ -670,6 +670,19 @@ class Matcher:
         if columns is not None:
             df = pd.DataFrame(df, columns=columns)
         df.to_csv(csv_file_path)
+
+    @staticmethod
+    def _get_nested(doc: dict, key: str):
+        """Retrieve a value from a nested dict using dot-notation key.
+
+        Falls back to flat key lookup so plain (non-nested) fields still work.
+        """
+        if "." in key:
+            parts = key.split(".", 1)
+            sub = doc.get(parts[0])
+            if isinstance(sub, dict):
+                return Matcher._get_nested(sub, parts[1])
+        return doc.get(key)
 
     def dotDictFind(self, data: dict, find: str) -> str:
         """

--- a/orion/tests/test_matcher_batch.py
+++ b/orion/tests/test_matcher_batch.py
@@ -12,6 +12,7 @@ import pytest
 from opensearch_dsl import Search
 from opensearch_dsl.response import Response
 
+from orion.matcher import Matcher
 from orion.tests.test_matcher import make_matcher_fixture
 
 
@@ -570,3 +571,100 @@ class TestGetResultsBatch:
 
         assert len(result["apiserverCPU"]) == 1
         assert result["apiserverCPU"][0]["metricName"] == "containerCPU"
+
+    def test_nested_field_filter_matches(self, matcher_instance, monkeypatch):
+        """Hits are routed correctly when the match field is a nested dict traversed by dot-notation."""
+        metrics_list = [
+            {
+                "name": "apiserverCPU",
+                "metricName": "containerCPU",
+                "labels.namespace.keyword": "openshift-kube-apiserver",
+                "metric_of_interest": "cpu",
+            },
+        ]
+
+        fake_hits = [
+            _make_fake_hit({
+                "uuid": "uuid1",
+                "metricName": "containerCPU",
+                "labels": {"namespace": "openshift-kube-apiserver"},
+                "cpu": 0.42,
+            }),
+            _make_fake_hit({
+                "uuid": "uuid1",
+                "metricName": "containerCPU",
+                "labels": {"namespace": "openshift-etcd"},
+                "cpu": 0.10,
+            }),
+        ]
+
+        monkeypatch.setattr(matcher_instance, "query_index",
+                            lambda *a, **k: fake_hits)
+
+        result = matcher_instance.get_results_batch(["uuid1"], metrics_list)
+
+        assert len(result["apiserverCPU"]) == 1
+        assert result["apiserverCPU"][0]["cpu"] == 0.42
+
+    def test_nested_field_not_filter_excludes(self, matcher_instance, monkeypatch):
+        """Hits are excluded when a not-field nested value matches the exclusion value."""
+        metrics_list = [
+            {
+                "name": "podReadyLatency",
+                "metricName": "podLatencyQuantilesMeasurement",
+                "quantileName": "Ready",
+                "metric_of_interest": "P99",
+                "not": {"labels.jobName.keyword": "garbage-collection"},
+            },
+        ]
+
+        fake_hits = [
+            _make_fake_hit({
+                "uuid": "uuid1",
+                "metricName": "podLatencyQuantilesMeasurement",
+                "quantileName": "Ready",
+                "labels": {"jobName": "normal-job"},
+                "P99": 4500,
+            }),
+            _make_fake_hit({
+                "uuid": "uuid1",
+                "metricName": "podLatencyQuantilesMeasurement",
+                "quantileName": "Ready",
+                "labels": {"jobName": "garbage-collection"},
+                "P99": 9999,
+            }),
+        ]
+
+        monkeypatch.setattr(matcher_instance, "query_index",
+                            lambda *a, **k: fake_hits)
+
+        result = matcher_instance.get_results_batch(["uuid1"], metrics_list)
+
+        assert len(result["podReadyLatency"]) == 1
+        assert result["podReadyLatency"][0]["P99"] == 4500
+
+
+class TestGetNested:
+    """Unit tests for Matcher._get_nested."""
+
+    @pytest.mark.parametrize("doc,key,expected", [
+        ({"a": 1}, "a", 1),
+        ({"a": {"b": 2}}, "a.b", 2),
+        ({"a": {"b": {"c": 3}}}, "a.b.c", 3),
+        ({"a": 1}, "missing", None),
+        ({"a": {"b": 2}}, "a.missing", None),
+        ({"a": {"b": 2}}, "missing.b", None),
+        ({"a.b": 99}, "a.b", 99),          # literal dotted key — "a" missing so falls back to doc.get("a.b")
+        ({"a": None}, "a.b", None),        # sub-value is not a dict
+        ({"a": "string"}, "a.b", None),    # sub-value is a scalar
+        ({}, "a", None),
+    ])
+    def test_get_nested(self, doc, key, expected):
+        assert Matcher._get_nested(doc, key) == expected
+
+    def test_flat_key_without_dot(self):
+        assert Matcher._get_nested({"x": 42}, "x") == 42
+
+    def test_deeply_nested(self):
+        doc = {"a": {"b": {"c": {"d": "deep"}}}}
+        assert Matcher._get_nested(doc, "a.b.c.d") == "deep"


### PR DESCRIPTION


## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

  Problem

  When metric configs reference nested OpenSearch fields using dot-notation (e.g. tags.namespace, tags.pod), get_results_batch silently drops all matching documents.

  The batch query correctly retrieves documents from OpenSearch using dot-notation field paths (e.g. Q("match", **{"tags.namespace": "openshift-apiserver"})), but the subsequent Python-side routing step uses doc.get("tags.namespace") to assign each document to the right metric. Since OpenSearch returns documents with nested structure
  ({"tags": {"namespace": "..."}, ...}), a flat dict.get() with a dotted key always returns None, so no document ever matches any metric and all metrics silently return empty data.

  Indexes with flat top-level fields (e.g. resource_type, component) are unaffected — this only manifests when metric filter fields are nested under an object like tags.

  Fix

  Added a _get_nested() static helper that traverses nested dicts using dot-notation keys, and replaced the two doc.get() calls in the Python-side routing loop with it. For non-nested fields, the helper falls back to plain doc.get(), so existing tests are unaffected.

  Impact

  Without this fix, any metric config that filters on nested fields (e.g. tags.namespace: openshift-apiserver) produces a dataframe with all-NaN values, and EDivisive finds no changepoints — resulting in 0 reported failures even when clear regressions exist in the data.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
