### PR TITLE
Don't require metadata field in parent configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ Orion supports configuration inheritance to reduce duplication and improve maint
 The `parentConfig` field allows you to inherit metadata from a parent configuration file. This is useful when multiple test configurations share common metadata settings.
 
 **How it works:**
-- The parent configuration file should contain a `metadata` section
+- The parent configuration file should contain the metadata fields that are to be inherited
 - Metadata from the parent is merged into each test's metadata
 - **Child configuration takes precedence** - if a key exists in both parent and child, the child value is used
 - Paths can be relative (to the config file directory) or absolute
@@ -31,14 +31,13 @@ The `parentConfig` field allows you to inherit metadata from a parent configurat
 
 `parent.yaml`:
 ```yaml
-metadata:
-  platform: AWS
-  clusterType: self-managed
-  masterNodesType: m6a.xlarge
-  masterNodesCount: 3
-  workerNodesType: m6a.xlarge
-  workerNodesCount: 6
-  benchmark.keyword: node-density
+platform: AWS
+clusterType: self-managed
+masterNodesType: m6a.xlarge
+masterNodesCount: 3
+workerNodesType: m6a.xlarge
+workerNodesCount: 6
+benchmark.keyword: node-density
 ```
 
 `child.yaml`:

--- a/examples/config/ols-load-generator-config.yaml
+++ b/examples/config/ols-load-generator-config.yaml
@@ -4,19 +4,18 @@
 #   ols-load-generator.yaml
 
 # Common metadata for all ols-load-generator tests
-metadata:
-  olsTestWorkers: "{{ ols_test_workers }}"
-  platform: AWS
-  clusterType: self-managed
-  masterNodesType.keyword: m6a.xlarge
-  masterNodesCount: 3
-  workerNodesType.keyword: m6i.xlarge
-  workerNodesCount: 3
-  benchmark.keyword: ols-load-generator
-  wildcard:
-    ocpVersion: "{{ version }}*"
-  networkType: OVNKubernetes
-  mcpEnabled: false
-  fips: "{{ fips | default('false') }}"
-  not:
-    stream: okd
+olsTestWorkers: "{{ ols_test_workers }}"
+platform: AWS
+clusterType: self-managed
+masterNodesType.keyword: m6a.xlarge
+masterNodesCount: 3
+workerNodesType.keyword: m6i.xlarge
+workerNodesCount: 3
+benchmark.keyword: ols-load-generator
+wildcard:
+  ocpVersion: "{{ version }}*"
+networkType: OVNKubernetes
+mcpEnabled: false
+fips: "{{ fips | default('false') }}"
+not:
+  stream: okd

--- a/examples/parent.yaml
+++ b/examples/parent.yaml
@@ -1,8 +1,7 @@
-metadata:
-  platform: AWS
-  clusterType: self-managed
-  masterNodesType: m6a.xlarge
-  masterNodesCount: 3
-  workerNodesType: m6a.xlarge
-  workerNodesCount: 6
-  benchmark.keyword: node-density
+platform: AWS
+clusterType: self-managed
+masterNodesType: m6a.xlarge
+masterNodesCount: 3
+workerNodesType: m6a.xlarge
+workerNodesCount: 6
+benchmark.keyword: node-density

--- a/orion/config.py
+++ b/orion/config.py
@@ -40,7 +40,7 @@ def load_config(config_path: str, input_vars: Dict[str, Any]) -> Dict[str, Any]:
             logger
         )
 
-    parent_metrics = {}
+    parent_metrics = []
     if "metricsFile" in rendered_config:
         parent_metrics = load_config_file(
             rendered_config["metricsFile"],
@@ -51,27 +51,21 @@ def load_config(config_path: str, input_vars: Dict[str, Any]) -> Dict[str, Any]:
 
     metrics = []
     for test in rendered_config["tests"]:
-        skip_global_config = False
-        skip_global_metrics = False
+        test.setdefault("IgnoreGlobal", False)
+        test.setdefault("IgnoreGlobalMetrics", False)
         local_config = {}
         local_metrics = {}
-        if "IgnoreGlobal" in test:
-            skip_global_config = test["IgnoreGlobal"]
-        if "IgnoreGlobalMetrics" in test:
-            skip_global_metrics = test["IgnoreGlobalMetrics"]
-        if "uuid_field" not in test:
-            test["uuid_field"] = "uuid"
-        if "version_field" not in test:
-            test["version_field"] = "ocpVersion"
+        test.setdefault("uuid_field", "uuid")
+        test.setdefault("version_field", "ocpVersion")
         if "local_config" in test:
             local_config = load_config_file(test["local_config"], config_dir, env_vars, logger)
-            test["metadata"] = merge_configs(test.get("metadata", {}), local_config["metadata"])
+            test["metadata"] = merge_configs(test.get("metadata", {}), local_config)
         if "local_metrics" in test:
             local_metrics = load_config_file(test["local_metrics"], config_dir, env_vars, logger)
             test["metrics"] = merge_lists(test.get("metrics", []), local_metrics)
-        if parent_config and not skip_global_config:
-            test["metadata"] = merge_configs(test.get("metadata", {}), parent_config["metadata"])
-        if parent_metrics and not skip_global_metrics:
+        if parent_config and not test["IgnoreGlobal"]:
+            test["metadata"] = merge_configs(test.get("metadata", {}), parent_config)
+        if parent_metrics and not test["IgnoreGlobalMetrics"]:
             test["metrics"] = merge_lists(test.get("metrics", []), parent_metrics)
 
         for metric in test["metrics"]:


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

* Changed how parent metrics are loaded in `orion/config.py` by initializing `parent_metrics` as a list instead of a dictionary, ensuring correct merging behavior.
* Refactored test configuration merging in `orion/config.py`:
  - Used `setdefault` to provide default values for keys like `IgnoreGlobal`, `IgnoreGlobalMetrics`, `uuid_field`, and `version_field`.
  - Updated the merging logic so that parent and local configs are merged directly into the test's `metadata` without assuming a `metadata` section in the parent.
  - Ensured that global config and metrics are only merged if not explicitly ignored by the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how parent configuration inheritance works, including the expected placement of inherited fields.
  * Updated configuration examples to match the new structure.

* **Bug Fixes**
  * Improved configuration loading so inherited settings and metrics are merged more reliably.
  * Simplified handling of optional test-level overrides and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->