### PR TITLE
Missing filter

### DIFF
--- a/examples/udn-density-pods.yaml
+++ b/examples/udn-density-pods.yaml
@@ -34,6 +34,7 @@ tests:
 
       - name: containersStartedLatency
         metricName.keyword: podLatencyQuantilesMeasurement
+        jobName.keyword: udn-density-l2-pods
         quantileName: ContainersStarted
         labels:
           - "[Jira: PodLatency]"


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

This filter was missing in the udn-density-pods configuration, surprisingly, it affects other metrics

Before:
<img width="2221" height="1066" alt="image" src="https://github.com/user-attachments/assets/4a5beea4-7ae0-4477-befe-897690942599" />

After:
<img width="2221" height="1066" alt="image" src="https://github.com/user-attachments/assets/8e0adb0c-c82d-4f07-950f-48f6622152b4" />
