### PR TITLE
Visualization improvements and PR analysis fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -748,9 +748,9 @@ def main(**kwargs):
                 )
                 generate_test_html(viz_data, output_file)
             if is_pull:
-                for viz_data in results_pull.viz_data:
+                for pr_num, viz_data in results_pull.viz_data:
                     output_file = build_viz_output_file(
-                        output_base_path, viz_data.test_name, "pull"
+                        output_base_path, viz_data.test_name, f"pull_{pr_num}"
                     )
                     generate_test_html(viz_data, output_file)
         except Exception as e:  # pylint: disable=broad-except
@@ -762,8 +762,9 @@ def main(**kwargs):
             output_base_path = str(Path(kwargs['save_output_path']).with_suffix(''))
             _attach_viz_to_jira(jira_provider, issue_keys_by_test, output_base_path,
                                 "periodic" if is_pull else "", logger)
-            _attach_viz_to_jira(jira_provider, issue_keys_by_test_pull, output_base_path,
-                                "pull", logger)
+            for pr_num in kwargs.get("pull_numbers", []):
+                _attach_viz_to_jira(jira_provider, issue_keys_by_test_pull, output_base_path,
+                                    f"pull_{pr_num}", logger)
         except Exception as e:  # pylint: disable=broad-except
             logger.warning("JIRA attachment failed: %s", e)
 

--- a/main.py
+++ b/main.py
@@ -634,7 +634,7 @@ def main(**kwargs):
 
     # Auto-create JIRA issues for regressions if enabled
     issue_keys_by_test = {}
-    issue_keys_by_test_pull = {}
+    issue_keys_by_test_pull_by_pr: dict[int, dict[str, list[str]]] = {}
     if kwargs.get("jira_auto_create") and jira_provider:
         formatter_for_regression = FormatterFactory.get_formatter(cnsts.JSON)
         if results.regression_flag:
@@ -652,17 +652,23 @@ def main(**kwargs):
                 )
         if is_pull and results_pull.regression_flag:
             logger.info("Auto-creating JIRA issues for pull request regressions...")
-            pull_reg_data = []
-            for analysis in results_pull.analyses:
-                pull_reg_data.extend(
-                    formatter_for_regression.extract_regression_data(analysis)
-                )
-            created, issue_keys_by_test_pull = auto_create_jira_issues(pull_reg_data, jira_provider, logger)
-            if created == 0 and pull_reg_data:
-                logger.warning(
-                    "No JIRA issues were created. This may be due to permissions. "
-                    "See JIRA_PERMISSIONS_TROUBLESHOOTING.md for help."
-                )
+            for pr_num, pr_analyses in analyses_by_pr.items():
+                pr_reg_data = []
+                for analysis in pr_analyses:
+                    if analysis.regression_flag:
+                        pr_reg_data.extend(
+                            formatter_for_regression.extract_regression_data(analysis)
+                        )
+                if not pr_reg_data:
+                    continue
+                created, issue_keys = auto_create_jira_issues(pr_reg_data, jira_provider, logger)
+                if created == 0 and pr_reg_data:
+                    logger.warning(
+                        "No JIRA issues were created for PR %s. This may be due to permissions. "
+                        "See JIRA_PERMISSIONS_TROUBLESHOOTING.md for help.",
+                        pr_num,
+                    )
+                issue_keys_by_test_pull_by_pr[pr_num] = issue_keys
 
     formatter = FormatterFactory.get_formatter(kwargs["output_format"])
     has_regression = False
@@ -763,7 +769,8 @@ def main(**kwargs):
             _attach_viz_to_jira(jira_provider, issue_keys_by_test, output_base_path,
                                 "periodic" if is_pull else "", logger)
             for pr_num in kwargs.get("pull_numbers", []):
-                _attach_viz_to_jira(jira_provider, issue_keys_by_test_pull, output_base_path,
+                issue_keys_for_pr = issue_keys_by_test_pull_by_pr.get(pr_num, {})
+                _attach_viz_to_jira(jira_provider, issue_keys_for_pr, output_base_path,
                                     f"pull_{pr_num}", logger)
         except Exception as e:  # pylint: disable=broad-except
             logger.warning("JIRA attachment failed: %s", e)

--- a/orion/run_test.py
+++ b/orion/run_test.py
@@ -121,7 +121,7 @@ def run(**kwargs: dict[str, Any]) -> Tuple[
                             if pull_analysis.regression_flag:
                                 regression_flag_pull = True
                         if pull_viz is not None:
-                            all_viz_data_pull.append(pull_viz)
+                            all_viz_data_pull.append((pr_num, pull_viz))
             else:
                 result_tuple = analyze(test, kwargs)
                 analysis, viz_data = result_tuple

--- a/orion/tests/test_visualization.py
+++ b/orion/tests/test_visualization.py
@@ -78,7 +78,7 @@ def test_generate_test_html_writes_expected_file_and_injects_click_handler(
     assert "contextmenu" in html
     assert "clipboard" in html
     assert "orion-toast" in html
-    assert "right-click to copy UUID" in html
+    assert "right-click" in html
     assert "stopPropagation" in html
 
 
@@ -106,7 +106,7 @@ def test_build_test_figure_renders_changepoints_and_skips_out_of_range(sample_da
     fig = _build_test_figure(viz_data)
     changepoint_traces = [
         trace for trace in fig.data
-        if isinstance(trace.hovertext, str) and "CHANGEPOINT" in trace.hovertext
+        if isinstance(trace.hovertemplate, str) and "CHANGEPOINT" in trace.hovertemplate
     ]
 
     assert len(changepoint_traces) == 2
@@ -136,7 +136,7 @@ def test_build_test_figure_renders_only_matching_ack_markers(sample_dataframe):
     fig = _build_test_figure(viz_data)
     ack_traces = [
         trace for trace in fig.data
-        if isinstance(trace.hovertext, str) and "ACKed" in trace.hovertext
+        if isinstance(trace.hovertemplate, str) and "ACKed" in trace.hovertemplate
     ]
 
     assert len(ack_traces) == 1

--- a/orion/visualization.py
+++ b/orion/visualization.py
@@ -379,10 +379,25 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
         autosize=True,
     )
 
+    # Thin out x-axis ticks to avoid overcrowding
+    max_ticks = 20
+    n_points = len(x_indices)
+    if n_points > max_ticks:
+        step = n_points / max_ticks
+        shown = [int(round(i * step)) for i in range(max_ticks)]
+        shown = [i for i in shown if i < n_points]
+        if (n_points - 1) not in shown:
+            shown.append(n_points - 1)
+        shown_tickvals = [x_indices[i] for i in shown]
+        shown_ticktext = [tick_labels[i] for i in shown]
+    else:
+        shown_tickvals = x_indices
+        shown_ticktext = tick_labels
+
     for row_idx in range(1, n_metrics + 1):
         fig.update_xaxes(
-            tickvals=x_indices,
-            ticktext=tick_labels,
+            tickvals=shown_tickvals,
+            ticktext=shown_ticktext,
             tickangle=0,
             tickfont={"size": 9},
             gridcolor="rgba(255,255,255,0.08)",

--- a/orion/visualization.py
+++ b/orion/visualization.py
@@ -121,20 +121,25 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
         change_points = viz_data.change_points_by_metric.get(metric_name, [])
         line_color = line_colors[(row_idx - 1) % len(line_colors)]
 
-        # Rich hover with all relevant metadata
-        hover_texts = []
-        for i, (ts, v, u, val) in enumerate(
-            zip(timestamps, versions, uuids, values)
-        ):
-            url = build_urls.iloc[i] if i < len(build_urls) else ""
-            hover_texts.append(
-                f"<b>{metric_name}: {val}</b><br>"
-                f"Date: {ts.strftime('%Y-%m-%d %H:%M UTC')}<br>"
-                f"Version: {v}<br>"
-                f"UUID: {u}<br>"
-                f"Build: {url[-60:]}<br>"
-                f"<i>(right-click to copy UUID)</i>"
-            )
+        # Structured customdata for hover template and click handlers
+        custom = [
+            [
+                build_urls.iloc[i] if i < len(build_urls) else "",
+                str(uuids.iloc[i]),
+                str(timestamps.iloc[i].strftime('%Y-%m-%d %H:%M UTC')),
+                str(versions.iloc[i]),
+            ]
+            for i in range(len(df))
+        ]
+
+        hover_tpl = (
+            f"<b>{metric_name}: %{{y:,.2f}}</b><br>"
+            "Date: %{customdata[2]}<br>"
+            "Version: %{customdata[3]}<br>"
+            "UUID: %{customdata[1]}<br>"
+            "<i>click → build log  |  right-click → copy UUID</i>"
+            "<extra></extra>"
+        )
 
         # Main time-series trace
         fig.add_trace(
@@ -143,12 +148,8 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                 y=values,
                 mode="lines+markers",
                 name=metric_name,
-                hovertext=hover_texts,
-                hoverinfo="text",
-                customdata=[
-                    [build_urls.iloc[i], str(uuids.iloc[i])]
-                    for i in range(len(df))
-                ],
+                hovertemplate=hover_tpl,
+                customdata=custom,
                 marker={"size": 6, "color": line_color},
                 line={"width": 2, "color": line_color},
                 connectgaps=False,
@@ -202,16 +203,15 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                         "line": {"width": 2, "color": "white"},
                     },
                     showlegend=False,
-                    hovertext=(
+                    hovertemplate=(
                         f"<b>CHANGEPOINT</b><br>"
                         f"{pct_change:+.1f}% change<br>"
                         f"Mean before: {cp.stats.mean_1:,.2f}<br>"
                         f"Mean after: {cp.stats.mean_2:,.2f}<br>"
                         f"UUID: {uuids.iloc[idx]}<br>"
-                        f"Build: {cp_build_url[-60:]}<br>"
-                        f"<i>(right-click to copy UUID)</i>"
+                        f"<i>click → build log  |  right-click → copy UUID</i>"
+                        f"<extra></extra>"
                     ),
-                    hoverinfo="text",
                     customdata=[[cp_build_url, str(uuids.iloc[idx])]],
                 ),
                 row=row_idx,
@@ -262,13 +262,13 @@ def _build_test_figure(viz_data: VizData) -> go.Figure:
                         "line": {"width": 2, "color": "white"},
                     },
                     showlegend=False,
-                    hovertext=(
+                    hovertemplate=(
                         f"<b>ACKed</b><br>"
                         f"Reason: {ack['reason']}<br>"
                         f"UUID: {ack['uuid'][:8]}<br>"
-                        f"<i>(right-click to copy UUID)</i>"
+                        f"<i>click → build log  |  right-click → copy UUID</i>"
+                        f"<extra></extra>"
                     ),
-                    hoverinfo="text",
                     customdata=[[ack_build_url, ack['uuid']]],
                 ),
                 row=row_idx,


### PR DESCRIPTION
- Fix crowded x-axis labels — When charts have many data points (e.g. 76 runs), all tick labels were rendered causing overlap. Now limits to ~20 evenly-spaced labels, always including the last date.

 - Cleaner hover tooltips — Switch from manually built hovertext to plotly hovertemplate. Values render with comma separators (e.g. 4,231.50), the redundant secondary hover box is suppressed, and action hints are more concise (click → build log |   right-click → copy UUID).
 
 - Fix PR viz file overwrites — When --pr-analysis is used with multiple PRs, all viz files were written to the same _pull_viz.html, so only the last PR survived. Now each PR gets its own file (e.g. _pull_3185_viz.html). JIRA attachment also updated to  use the per-PR filenames.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull-request visualizations are now handled separately for each PR, making attached reports and outputs easier to match to the correct request.

* **Bug Fixes**
  * Improved chart tooltips and click behavior with clearer hover details for metrics, changepoints, and acknowledgements.
  * Reduced x-axis label crowding on charts with many points for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->