### PR TITLE
fix issue where numpy version mismatch with otava

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "Jinja2==3.1.3",
     "PyYAML==6.0.1",
     "pyshorteners==1.0.1",
-    "numpy==2.2.0",
+    "numpy>=2.2.0,<2.4",
     "scikit-learn==1.5.0",
     "pandas==2.3.3",
     "tabulate==0.9.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ opensearch-dsl==2.1.0
 opensearch-py==3.0.0
 Jinja2==3.1.3
 PyYAML==6.0.1
-numpy==2.2.0
+numpy>=2.2.0,<2.4
 scikit-learn==1.5.0
 pandas==2.3.3
 tabulate==0.9.0


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

fix related to change #428 
numpy cannot be installed  causing failure on main 
https://github.com/cloud-bulldozer/orion/actions/runs/28597247920/job/84795794904

```bash
$ uv sync
Using CPython 3.14.6 interpreter at: /opt/homebrew/opt/python@3.14/bin/python3.14
Creating virtual environment at: .venv
  × No solution found when resolving dependencies for split (markers: python_full_version == '3.14.*'):
  ╰─▶ Because only the following versions of numpy{python_full_version >= '3.14'} are available:
          numpy{python_full_version >= '3.14'}<=2.3.2
          numpy{python_full_version >= '3.14'}==2.3.3
          numpy{python_full_version >= '3.14'}==2.3.4
          numpy{python_full_version >= '3.14'}==2.3.5
          numpy{python_full_version >= '3.14'}>2.4
      and apache-otava==0.8.0 depends on numpy{python_full_version >= '3.14'}>=2.3.2,<2.4, we can conclude that apache-otava==0.8.0 depends on numpy>=2.3.2,<=2.3.5.
      And because your project depends on apache-otava==0.8.0 and numpy==2.2.0, we can conclude that your project's requirements are unsatisfiable.
```



## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
