### PR TITLE
Reject .keyword fields under wildcard: in config validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Orion — Guidance for AI Agents and LLMs
+
+This file contains rules and context for AI agents and LLMs contributing to or generating configurations for Orion. These rules supplement the project documentation and exist to prevent known anti-patterns.
+
+## Configuration Anti-Patterns
+
+### Do not combine `.keyword` fields with `wildcard:`
+
+The `wildcard:` section in Orion configs generates OpenSearch wildcard queries for pattern/glob matching. The `.keyword` suffix on a field name denotes an exact-match (not-analyzed) field in OpenSearch. Placing a `.keyword` field under `wildcard:` is contradictory and **will be rejected by config validation**.
+
+**Rules:**
+
+- `.keyword` fields belong in **top-level metadata** for exact matching — never under `wildcard:`.
+- `wildcard:` is **only** for fields that genuinely need glob/pattern matching (e.g., version prefixes like `ocpVersion: "4.17*"`).
+- Do not use `wildcard:` as a general-purpose filter. If the value is known exactly, use top-level metadata with an exact match.
+
+```yaml
+# WRONG — rejected by validation
+metadata:
+  wildcard:
+    upstreamJob.keyword: "*my-job-name*"
+
+# CORRECT — exact match on a keyword field
+metadata:
+  upstreamJob.keyword: periodic-ci-my-exact-job-name
+
+# CORRECT — pattern match on a non-keyword field
+metadata:
+  wildcard:
+    ocpVersion: "4.17*"
+```
+
+See `docs/configuration.md` (Wildcard Matching section) for full documentation.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -491,6 +491,27 @@ metadata:
 
 This matches any `ocpVersion` starting with `4.17` (e.g., `4.17.0`, `4.17.5-rc1`, etc.).
 
+> **Important:** The `wildcard` section is strictly for fields that need pattern/glob matching. Do not use it as a general-purpose filter for metadata fields that can be matched exactly.
+>
+> - **Do not** use `.keyword` fields under `wildcard`. The `.keyword` suffix denotes an exact-match field in OpenSearch — combining it with wildcard patterns is contradictory. Place `.keyword` fields directly in the top-level metadata for exact matching.
+> - **Do not** use `wildcard` for fields whose value is already known exactly. Put those in top-level metadata instead.
+>
+> ```yaml
+> # WRONG — .keyword field under wildcard
+> metadata:
+>   wildcard:
+>     upstreamJob.keyword: "*my-job-name*"
+>
+> # CORRECT — exact match in top-level metadata
+> metadata:
+>   upstreamJob.keyword: periodic-ci-my-exact-job-name
+>
+> # CORRECT — wildcard on a non-keyword field for prefix matching
+> metadata:
+>   wildcard:
+>     ocpVersion: "4.17*"
+> ```
+
 ## Labels and Filtering
 
 ### Labels

--- a/orion/config.py
+++ b/orion/config.py
@@ -68,6 +68,17 @@ def load_config(config_path: str, input_vars: Dict[str, Any]) -> Dict[str, Any]:
         if parent_metrics and not test["IgnoreGlobalMetrics"]:
             test["metrics"] = merge_lists(test.get("metrics", []), parent_metrics)
 
+        wildcard_fields = test.get("metadata", {}).get("wildcard", {})
+        keyword_wildcards = [f for f in wildcard_fields if f.endswith(".keyword")]
+        if keyword_wildcards:
+            logger.error(
+                "Test '%s': wildcard fields must not use .keyword suffix "
+                "(keyword fields are exact-match; put them in top-level metadata instead). "
+                "Found: %s",
+                test["name"], keyword_wildcards
+            )
+            sys.exit(1)
+
         for metric in test["metrics"]:
             metric_name = test["name"] + ":" + metric["name"]
             if "agg" in metric:

--- a/orion/tests/test_config.py
+++ b/orion/tests/test_config.py
@@ -103,6 +103,67 @@ class TestPercentileValidation:
             assert len(result["tests"]) == 1
 
 
+class TestWildcardKeywordValidation:
+    """Tests that .keyword fields under wildcard: are rejected."""
+
+    def test_keyword_field_in_wildcard_exits(self):
+        config = {
+            "tests": [
+                {
+                    "name": "test1",
+                    "metadata": {
+                        "platform": "AWS",
+                        "wildcard": {
+                            "upstreamJob.keyword": "*some-job*",
+                        },
+                    },
+                    "metrics": [
+                        {
+                            "name": "m1",
+                            "metricName": "test",
+                            "metric_of_interest": "value",
+                            "threshold": 10,
+                            "direction": 1,
+                        }
+                    ],
+                }
+            ]
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _write_config(tmp_dir, config)
+            with pytest.raises(SystemExit):
+                load_config(path, {})
+
+    def test_non_keyword_wildcard_field_passes(self):
+        config = {
+            "tests": [
+                {
+                    "name": "test1",
+                    "metadata": {
+                        "platform": "AWS",
+                        "wildcard": {
+                            "ocpVersion": "4.17*",
+                        },
+                    },
+                    "metrics": [
+                        {
+                            "name": "m1",
+                            "metricName": "test",
+                            "metric_of_interest": "value",
+                            "threshold": 10,
+                            "direction": 1,
+                        }
+                    ],
+                }
+            ]
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _write_config(tmp_dir, config)
+            result = load_config(path, {})
+            assert result is not None
+            assert len(result["tests"]) == 1
+
+
 class TestCollectPullNumbers:  # pylint: disable=missing-class-docstring
 
     def test_single_pull_number_from_input_vars(self):


### PR DESCRIPTION
The wildcard: section is for glob/pattern matching, but .keyword fields are exact-match in OpenSearch. Combining them is an anti-pattern that silently produces contradictory queries. Add config validation to catch this early, update docs with correct/incorrect examples, and add AGENTS.md to prevent AI tools from reproducing the pattern.

Assisted-by: Claude Code

## Type of change

- [x] Documentation Update

## Description

Several examples have popped up lately using a wildcard anti-pattern.

This PR attempts to prevent any future attempts and fails validation if a config attempts to do so.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
