### PR TITLE
Add workflow to notify orion-mcp on new releases

### DIFF
--- a/.github/workflows/notify-orion-mcp.yaml
+++ b/.github/workflows/notify-orion-mcp.yaml
@@ -1,0 +1,22 @@
+name: Notify orion-mcp of new release
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger orion-mcp rebuild
+        env:
+          GH_TOKEN: ${{ secrets.ORION_MCP_DISPATCH_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/cloud-bulldozer/orion-mcp/dispatches \
+            -d "{\"event_type\": \"orion-release\", \"client_payload\": {\"tag\": \"${{ github.ref_name }}\"}}"


### PR DESCRIPTION
## Summary
- Adds a new workflow that fires on release publish or `v*` tag push
- Sends a `repository_dispatch` event to `cloud-bulldozer/orion-mcp` with the release tag
- This triggers an orion-mcp image rebuild with the new orion version

## Setup required
- Create secret `ORION_MCP_DISPATCH_TOKEN` in this repo — a GitHub PAT with `contents:write` permission on `cloud-bulldozer/orion-mcp`

## Dependency
Companion PR: cloud-bulldozer/orion-mcp — adds the `repository_dispatch` trigger on the receiving side. **Merge that [PR](https://github.com/cloud-bulldozer/orion-mcp/pull/17) first.**

## Test plan
- [ ] Merge the companion orion-mcp PR first
- [ ] Merge this PR
- [ ] Create `ORION_MCP_DISPATCH_TOKEN` secret
- [ ] Publish a test release and verify orion-mcp image-push workflow fires