### PR TITLE
Add static and dynamic metric expansion

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -540,6 +540,104 @@ not:
     - "sidecar"
 ```
 
+## Metric Expansion
+
+Orion provides two ways to create multiple metrics from a single template, reducing duplication in configuration files.
+
+### `fan_out` — Static Expansion
+
+Use `fan_out` when you know the exact values you want to expand. Each entry in the `fan_out` list produces one metric, with `${var}` placeholders substituted and matching fields overridden.
+
+```yaml
+metrics:
+  - name: "${label}CPU"
+    metricName.keyword: containerCPU
+    labels.namespace.keyword: "${namespace}"
+    metric_of_interest: value
+    agg:
+      agg_type: avg
+    labels:
+      - "[Jira: ${jira}]"
+    direction: 1
+    threshold: 10
+    fan_out:
+      - label: apiserver
+        namespace: openshift-kube-apiserver
+        jira: kube-apiserver
+      - label: multus
+        namespace: openshift-multus
+        jira: multus
+      - label: ovn
+        namespace: openshift-ovn-kubernetes
+        jira: ovn-kubernetes
+```
+
+This expands into three metrics: `apiserverCPU`, `multusCPU`, and `ovnCPU`, each with the correct namespace filter and JIRA label. Without `fan_out`, you would need to write each metric definition separately.
+
+**How it works:**
+
+1. Each `fan_out` entry is a dict of variable names to values
+2. All `${var}` placeholders in string values are replaced recursively (including nested dicts and lists)
+3. If a `fan_out` entry key matches an existing metric field, the entry value overrides it directly
+4. Each expanded metric is a deep copy — mutations to one do not affect others
+5. The `fan_out` key is removed after expansion
+
+**Field override example:**
+
+```yaml
+- name: "ovnCPU-${container}"
+  metricName.keyword: containerCPU
+  labels.container.keyword: "${container}"
+  fan_out:
+    - container: northd
+    - container: ovncontroller
+      labels.container.keyword: ovn-controller  # overrides the substituted value
+```
+
+The second entry uses the override value `ovn-controller` instead of the substituted value `ovncontroller`.
+
+### `group_by` — Dynamic Expansion
+
+Use `group_by` when you don't know the values ahead of time and want Orion to discover them from OpenSearch. Orion queries for all distinct values of the specified field, scoped by the metric's other filters and the test's UUIDs, then creates one metric per discovered value.
+
+```yaml
+metrics:
+  - name: "${labels.namespace.keyword}CPU"
+    metricName.keyword: containerCPU
+    metric_of_interest: value
+    agg:
+      agg_type: avg
+    direction: 1
+    threshold: 10
+    group_by:
+      - labels.namespace.keyword
+```
+
+If the OpenSearch data contains `containerCPU` documents with namespaces `openshift-etcd`, `openshift-kube-apiserver`, and `openshift-multus`, this expands into three metrics — one per namespace — with `labels.namespace.keyword` set as both a filter and a `${labels.namespace.keyword}` substitution variable.
+
+**How it works:**
+
+1. `group_by` accepts a list with exactly one field name (multi-field support is planned)
+2. Orion runs a terms aggregation on that field, filtered by the metric's other fields (e.g., `metricName.keyword`) and the test's UUIDs
+3. For each discovered value, a deep copy of the template is created with:
+   - The `group_by` field set as a filter (e.g., `labels.namespace.keyword: openshift-etcd`)
+   - All `${field.name}` placeholders substituted with the discovered value
+4. If no values are found, the metric is skipped with a warning
+5. The `group_by` key is removed after expansion
+
+**When to use `group_by` vs `fan_out`:**
+
+| | `fan_out` | `group_by` |
+|---|---|---|
+| Values known ahead of time | Yes | No — discovered at runtime |
+| Supports multiple variables per entry | Yes | No — one field per `group_by` |
+| Requires OpenSearch connection | No — expands at config load | Yes — queries during test processing |
+| Use case | Fixed set of components | Discover all namespaces/containers/labels |
+
+**Combining with other features:**
+
+`group_by` works with all other metric features — aggregations, correlation, labels, `not` filters, and metadata metrics. The expanded metrics are identical to hand-written metrics after expansion.
+
 ## Test-Level Settings
 
 Settings that can be applied at the test level and inherited by all metrics:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -582,20 +582,6 @@ This expands into three metrics: `apiserverCPU`, `multusCPU`, and `ovnCPU`, each
 4. Each expanded metric is a deep copy — mutations to one do not affect others
 5. The `fan_out` key is removed after expansion
 
-**Field override example:**
-
-```yaml
-- name: "ovnCPU-${container}"
-  metricName.keyword: containerCPU
-  labels.container.keyword: "${container}"
-  fan_out:
-    - container: northd
-    - container: ovncontroller
-      labels.container.keyword: ovn-controller  # overrides the substituted value
-```
-
-The second entry uses the override value `ovn-controller` instead of the substituted value `ovncontroller`.
-
 ### `group_by` — Dynamic Expansion
 
 Use `group_by` when you don't know the values ahead of time and want Orion to discover them from OpenSearch. Orion queries for all distinct values of the specified field, scoped by the metric's other filters and the test's UUIDs, then creates one metric per discovered value.

--- a/examples/trt-external-payload-cluster-density-group-by.yaml
+++ b/examples/trt-external-payload-cluster-density-group-by.yaml
@@ -1,0 +1,58 @@
+tests:
+  - name: payload-cluster-density-v2
+    metadata:
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6a.xlarge
+      masterNodesCount: 3
+      workerNodesType: m6a.xlarge
+      workerNodesCount: 6
+      benchmark.keyword: cluster-density-v2
+      wildcard:
+        ocpVersion: "{{ version }}*"
+      networkType: OVNKubernetes
+      jobType: "{{ jobtype | default('periodic') }}"
+      pullNumber: "{{ pull_number | default(0) }}"
+      organization: "{{ organization | default('') }}"
+      repository: "{{ repository | default('') }}"
+      fips: "{{ fips | default('false') }}"
+      not:
+        stream: okd
+
+    metrics:
+      - name: containerCPU-${labels.container.keyword}
+        metricName.keyword: containerCPU
+        metric_of_interest: value
+        group_by:
+          - labels.container.keyword
+        agg:
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: containerMemory-${labels.container.keyword}
+        metricName.keyword: containerMemory
+        metric_of_interest: value
+        group_by:
+          - labels.container.keyword
+        agg:
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: containerMemory-${labels.namespace.keyword}
+        metricName.keyword: containerMemory
+        metric_of_interest: value
+        group_by:
+          - labels.namespace.keyword
+        agg:
+          agg_type: sum
+        direction: 1
+        threshold: 10
+      - name: nodeCPU-Workers-${labels.mode.keyword}
+        metricName.keyword: nodeCPU-Workers
+        metric_of_interest: value
+        group_by:
+          - labels.mode.keyword
+        agg:
+          agg_type: avg
+        direction: 1
+        threshold: 10

--- a/orion/config.py
+++ b/orion/config.py
@@ -5,6 +5,8 @@ Module file for config reading and loading
 
 import sys
 import os
+import re
+import copy
 from typing import Any, Dict, List
 from collections import Counter
 import jinja2
@@ -78,6 +80,9 @@ def load_config(config_path: str, input_vars: Dict[str, Any]) -> Dict[str, Any]:
                 test["name"], keyword_wildcards
             )
             sys.exit(1)
+
+        # Expand fan_out metric templates into individual metrics
+        test["metrics"] = expand_fan_out(test["metrics"], logger)
 
         for metric in test["metrics"]:
             metric_name = test["name"] + ":" + metric["name"]
@@ -363,3 +368,149 @@ def collect_pull_numbers(kwargs: dict, input_vars: dict) -> list:
             if parsed > 0:
                 numbers.add(parsed)
     return sorted(numbers)
+
+def expand_fan_out(metrics: List[Dict[str, Any]], logger: SingletonLogger) -> List[Dict[str, Any]]:
+    """Expands metrics with fan_out into multiple individual metrics.
+
+    For each metric containing a 'fan_out' key, creates one copy per
+    fan_out entry with ${var} placeholders substituted and field overrides applied.
+    Metrics without fan_out are passed through unchanged.
+
+    Args:
+        metrics (List[Dict[str, Any]]): list of metric definitions
+        logger (SingletonLogger): logger instance
+
+    Returns:
+        List[Dict[str, Any]]: expanded list of metric definitions
+    """
+    expanded = []
+    for metric in metrics:
+        if "fan_out" not in metric:
+            expanded.append(metric)
+            continue
+
+        fan_out_entries = metric.pop("fan_out")
+        template = metric
+
+        for entry in fan_out_entries:
+            new_metric = copy.deepcopy(template)
+
+            # Apply ${var} substitutions in all string values
+            _substitute_vars(new_metric, entry)
+
+            # Apply direct field overrides (entry keys matching metric fields)
+            for key, value in entry.items():
+                if key in new_metric:
+                    new_metric[key] = value
+
+            expanded.append(new_metric)
+
+        logger.info("Expanded fan_out metric template into %d metrics", len(fan_out_entries))
+
+    return expanded
+
+
+def _substitute_vars(obj, variables: Dict[str, str]):
+    """Recursively substitutes ${var} placeholders in all string values.
+
+    Args:
+        obj: dict or list to process in-place
+        variables (Dict[str, str]): variable name to value mapping
+    """
+    if isinstance(obj, dict):
+        for key in obj:
+            if isinstance(obj[key], str):
+                obj[key] = _replace_placeholders(obj[key], variables)
+            elif isinstance(obj[key], (dict, list)):
+                _substitute_vars(obj[key], variables)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            if isinstance(item, str):
+                obj[i] = _replace_placeholders(item, variables)
+            elif isinstance(item, (dict, list)):
+                _substitute_vars(item, variables)
+
+
+def _replace_placeholders(s: str, variables: Dict[str, str]) -> str:
+    """Replaces ${var} patterns in a string with values from variables dict.
+
+    Unmatched placeholders are left as-is.
+
+    Args:
+        s (str): string containing ${var} placeholders
+        variables (Dict[str, str]): variable name to value mapping
+
+    Returns:
+        str: string with placeholders replaced
+    """
+    def replacer(match):
+        var_name = match.group(1)
+        if var_name in variables:
+            return str(variables[var_name])
+        return match.group(0)
+    return re.sub(r'\$\{([\w.]+)\}', replacer, s)
+
+
+def expand_group_by(
+    metrics: List[Dict[str, Any]],
+    matcher,
+    uuids: List[str],
+    logger: SingletonLogger,
+) -> List[Dict[str, Any]]:
+    """Expand metrics containing 'group_by' by discovering distinct values from OpenSearch.
+
+    For each metric with a 'group_by' key, queries OpenSearch for distinct values
+    of the specified field, scoped by the metric's other filter fields and the
+    given UUIDs. Creates one metric copy per discovered value.
+
+    Args:
+        metrics: list of metric definitions
+        matcher: Matcher instance with active OpenSearch connection
+        uuids: list of UUIDs to scope the discovery query
+        logger: logger instance
+        timestamp_field: timestamp field name
+
+    Returns:
+        Expanded list of metric definitions with group_by resolved.
+    """
+    expanded = []
+    for metric in metrics:
+        if "group_by" not in metric:
+            expanded.append(metric)
+            continue
+
+        group_by_fields = metric.pop("group_by")
+        if not isinstance(group_by_fields, list):
+            group_by_fields = [group_by_fields]
+
+        if len(group_by_fields) != 1:
+            logger.error(
+                "group_by currently supports exactly one field, got %d: %s",
+                len(group_by_fields), group_by_fields
+            )
+            sys.exit(1)
+
+        field = group_by_fields[0]
+        values = matcher.discover_field_values(metric, field, uuids)
+
+        if not values:
+            logger.warning(
+                "group_by on field '%s' returned no values for metric template '%s'; "
+                "metric will be skipped",
+                field, metric.get("name", "<unnamed>")
+            )
+            continue
+
+        template = metric
+        for value in values:
+            new_metric = copy.deepcopy(template)
+            new_metric[field] = value
+            _substitute_vars(new_metric, {field: value})
+            expanded.append(new_metric)
+
+        logger.info(
+            "Expanded group_by metric template '%s' into %d metrics (field=%s)",
+            template.get("name", "<unnamed>"), len(values), field
+        )
+
+    return expanded

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -282,7 +282,7 @@ class Matcher:
         metric_queries = [
             Q("match", **{metric_key: metric_value})
             for metric_key, metric_value in metrics.items()
-            if metric_key not in ["name", "metric_of_interest", "not", "type"]
+            if metric_key not in ["name", "metric_of_interest", "not", "type", "group_by"]
         ]
         exists_queries = []
         if exists_fields:
@@ -331,7 +331,7 @@ class Matcher:
         metric_queries = [
             Q("match", **{metric_key: metric_value})
             for metric_key, metric_value in metrics.items()
-            if metric_key not in ["name", "metric_of_interest", "not", "agg", "type"]
+            if metric_key not in ["name", "metric_of_interest", "not", "agg", "type", "group_by"]
         ]
         metric_query = Q("bool", must=metric_queries + not_queries)
         query = Q(
@@ -468,7 +468,7 @@ class Matcher:
             metric_filter_clauses = [
                 Q("match", **{k: v})
                 for k, v in metric.items()
-                if k not in ("name", "metric_of_interest", "not", "agg", "type")
+                if k not in ("name", "metric_of_interest", "not", "agg", "type", "group_by")
             ]
             not_clauses = [
                 ~Q("match", **{k: v})
@@ -575,7 +575,7 @@ class Matcher:
         if not metrics_list:
             return {}
 
-        excluded_keys = {"name", "metric_of_interest", "not", "type"}
+        excluded_keys = {"name", "metric_of_interest", "not", "type", "group_by"}
         filter_fields_by_metric = []
         should_clauses = []
         for metric in metrics_list:
@@ -705,3 +705,60 @@ class Matcher:
             if not isinstance(v, dict):
                 return v
         return v
+
+    def discover_field_values(
+        self,
+        metric: Dict[str, Any],
+        field: str,
+        uuids: List[str],
+    ) -> List[str]:
+        """Query OpenSearch for distinct values of a field, scoped by metric filters.
+
+        Builds a bool query from the metric's filter fields (excluding reserved
+        keys) and the UUID list, then runs a terms aggregation on the target field.
+
+        Args:
+            metric: metric dict (group_by already popped)
+            field: the OpenSearch field to aggregate on
+            uuids: UUIDs to scope the query
+
+        Returns:
+            Sorted list of distinct string values.
+        """
+        reserved_keys = {
+            "name", "metric_of_interest", "not", "agg", "type",
+            "labels", "direction", "threshold", "timestamp",
+            "correlation", "context",
+        }
+
+        must_clauses = [Q("terms", **{self.uuid_field + ".keyword": uuids})]
+
+        for key, value in metric.items():
+            if key in reserved_keys:
+                continue
+            must_clauses.append(Q("match", **{key: value}))
+
+        not_clauses = [
+            Q("match", **{k: v})
+            for k, v in metric.get("not", {}).items()
+        ]
+
+        query = Q("bool", must=must_clauses, must_not=not_clauses)
+
+        search = (
+            Search(using=self.es, index=self.index)
+            .query(query)
+            .extra(size=0)
+        )
+        search.aggs.bucket("group_values", "terms", field=field, size=1000)
+
+        self.logger.debug("group_by discovery query for field '%s': %s", field, search.to_dict())
+        result = search.execute()
+
+        if not hasattr(result, "aggregations"):
+            return []
+
+        buckets = result.aggregations.group_values.buckets
+        values = sorted([bucket.key for bucket in buckets])
+        self.logger.info("Discovered %d distinct values for field '%s'", len(values), field)
+        return values

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -8,8 +8,10 @@ from typing import List, Dict, Any
 # pylint: disable=import-error
 import pandas as pd
 from opensearchpy import OpenSearch
+from opensearchpy.exceptions import ConnectionError as OpenSearchConnectionError
 from opensearch_dsl import Search, Q
 from orion.logger import SingletonLogger
+
 
 
 class Matcher:
@@ -753,7 +755,15 @@ class Matcher:
         search.aggs.bucket("group_values", "terms", field=field, size=1000)
 
         self.logger.debug("group_by discovery query for field '%s': %s", field, search.to_dict())
-        result = search.execute()
+        try:
+            result = search.execute()
+        except OpenSearchConnectionError as e:
+            self.logger.warning(
+                "Error discovering field values for metric '%s': %s"
+                ,metric, e
+            )
+            return []
+
 
         if not hasattr(result, "aggregations"):
             return []

--- a/orion/tests/test_fan_out.py
+++ b/orion/tests/test_fan_out.py
@@ -1,0 +1,223 @@
+"""
+Unit tests for fan_out metric expansion in config.py
+"""
+
+# pylint: disable = missing-function-docstring
+
+import logging
+import pytest
+
+from orion.config import expand_fan_out, _substitute_vars, _replace_placeholders
+from orion.logger import SingletonLogger
+
+
+@pytest.fixture(autouse=True)
+def logger():
+    SingletonLogger(debug=logging.INFO, name="Orion")
+    return SingletonLogger.get_logger("Orion")
+
+
+class TestReplacePlaceholders:
+    def test_single_placeholder(self):
+        assert _replace_placeholders("${name}CPU", {"name": "apiserver"}) == "apiserverCPU"
+
+    def test_multiple_placeholders(self):
+        result = _replace_placeholders("${prefix}-${suffix}", {"prefix": "ovn", "suffix": "cpu"})
+        assert result == "ovn-cpu"
+
+    def test_unmatched_placeholder_left_as_is(self):
+        assert _replace_placeholders("${missing}", {"other": "val"}) == "${missing}"
+
+    def test_no_placeholders(self):
+        assert _replace_placeholders("plain string", {"name": "val"}) == "plain string"
+
+    def test_placeholder_in_middle(self):
+        result = _replace_placeholders("[Jira: ${label}]", {"label": "etcd"})
+        assert result == "[Jira: etcd]"
+
+    def test_numeric_value(self):
+        assert _replace_placeholders("threshold-${val}", {"val": 10}) == "threshold-10"
+
+
+class TestSubstituteVars:
+    def test_dict_values(self):
+        obj = {"name": "${n}", "other": "fixed"}
+        _substitute_vars(obj, {"n": "test"})
+        assert obj == {"name": "test", "other": "fixed"}
+
+    def test_nested_dict(self):
+        obj = {"agg": {"value": "${field}", "agg_type": "avg"}}
+        _substitute_vars(obj, {"field": "cpu"})
+        assert obj == {"agg": {"value": "cpu", "agg_type": "avg"}}
+
+    def test_list_values(self):
+        obj = {"labels": ["[Jira: ${label}]"]}
+        _substitute_vars(obj, {"label": "etcd"})
+        assert obj == {"labels": ["[Jira: etcd]"]}
+
+    def test_list_of_dicts(self):
+        obj = [{"name": "${n}"}]
+        _substitute_vars(obj, {"n": "test"})
+        assert obj == [{"name": "test"}]
+
+    def test_non_string_values_unchanged(self):
+        obj = {"direction": 1, "threshold": 10}
+        _substitute_vars(obj, {"direction": "99"})
+        assert obj == {"direction": 1, "threshold": 10}
+
+
+class TestExpandFanOut:
+    def test_no_fan_out_passthrough(self, logger):
+        metrics = [
+            {"name": "cpuMetric", "metricName.keyword": "containerCPU", "direction": 1}
+        ]
+        result = expand_fan_out(metrics, logger)
+        assert len(result) == 1
+        assert result[0]["name"] == "cpuMetric"
+
+    def test_basic_fan_out(self, logger):
+        metrics = [{
+            "name": "${label}CPU",
+            "metricName.keyword": "containerCPU",
+            "labels.namespace.keyword": "${namespace}",
+            "metric_of_interest": "value",
+            "direction": 1,
+            "threshold": 10,
+            "fan_out": [
+                {"label": "apiserver", "namespace": "openshift-kube-apiserver"},
+                {"label": "multus", "namespace": "openshift-multus"},
+            ]
+        }]
+        result = expand_fan_out(metrics, logger)
+        assert len(result) == 2
+        assert result[0]["name"] == "apiserverCPU"
+        assert result[0]["labels.namespace.keyword"] == "openshift-kube-apiserver"
+        assert result[1]["name"] == "multusCPU"
+        assert result[1]["labels.namespace.keyword"] == "openshift-multus"
+        # fan_out key should be removed
+        assert "fan_out" not in result[0]
+        assert "fan_out" not in result[1]
+
+    def test_field_override(self, logger):
+        metrics = [{
+            "name": "ovnCPU-${container}",
+            "metricName.keyword": "containerCPU",
+            "labels.container.keyword": "${container}",
+            "direction": 1,
+            "fan_out": [
+                {"container": "northd"},
+                {"container": "ovncontroller", "labels.container.keyword": "ovn-controller"},
+            ]
+        }]
+        result = expand_fan_out(metrics, logger)
+        assert len(result) == 2
+        # First entry: no override, substitution applies
+        assert result[0]["name"] == "ovnCPU-northd"
+        assert result[0]["labels.container.keyword"] == "northd"
+        # Second entry: override takes precedence
+        assert result[1]["name"] == "ovnCPU-ovncontroller"
+        assert result[1]["labels.container.keyword"] == "ovn-controller"
+
+    def test_nested_substitution_in_agg(self, logger):
+        metrics = [{
+            "name": "${label}-${agg_type}",
+            "metricName.keyword": "containerCPU",
+            "metric_of_interest": "value",
+            "agg": {"value": "${resource}", "agg_type": "${agg_type}"},
+            "direction": 1,
+            "fan_out": [
+                {"label": "apiserverCPU", "resource": "cpu", "agg_type": "avg"},
+                {"label": "apiserverMem", "resource": "mem", "agg_type": "max"},
+            ]
+        }]
+        result = expand_fan_out(metrics, logger)
+        assert len(result) == 2
+        assert result[0]["agg"] == {"value": "cpu", "agg_type": "avg"}
+        assert result[1]["agg"] == {"value": "mem", "agg_type": "max"}
+
+    def test_substitution_in_labels_list(self, logger):
+        metrics = [{
+            "name": "${name}",
+            "metricName.keyword": "containerCPU",
+            "direction": 1,
+            "labels": ["[Jira: ${jira}]"],
+            "fan_out": [
+                {"name": "apiserverCPU", "jira": "kube-apiserver"},
+            ]
+        }]
+        result = expand_fan_out(metrics, logger)
+        assert result[0]["labels"] == ["[Jira: kube-apiserver]"]
+
+    def test_mixed_metrics_with_and_without_fan_out(self, logger):
+        metrics = [
+            {"name": "standalone", "metricName.keyword": "podLatency", "direction": 1},
+            {
+                "name": "${label}CPU",
+                "metricName.keyword": "containerCPU",
+                "direction": 1,
+                "fan_out": [
+                    {"label": "apiserver"},
+                    {"label": "multus"},
+                ]
+            },
+            {"name": "anotherStandalone", "metricName.keyword": "kubeletCPU", "direction": 1},
+        ]
+        result = expand_fan_out(metrics, logger)
+        assert len(result) == 4
+        assert result[0]["name"] == "standalone"
+        assert result[1]["name"] == "apiserverCPU"
+        assert result[2]["name"] == "multusCPU"
+        assert result[3]["name"] == "anotherStandalone"
+
+    def test_empty_fan_out_produces_no_metrics(self, logger):
+        metrics = [{
+            "name": "${label}CPU",
+            "metricName.keyword": "containerCPU",
+            "direction": 1,
+            "fan_out": []
+        }]
+        result = expand_fan_out(metrics, logger)
+        assert len(result) == 0
+
+    def test_unmatched_placeholders_preserved(self, logger):
+        metrics = [{
+            "name": "${defined}-${undefined}",
+            "metricName.keyword": "containerCPU",
+            "direction": 1,
+            "fan_out": [
+                {"defined": "test"},
+            ]
+        }]
+        result = expand_fan_out(metrics, logger)
+        assert result[0]["name"] == "test-${undefined}"
+
+    def test_fan_out_entries_are_independent(self, logger):
+        """Verify that modifying one expanded metric doesn't affect others."""
+        metrics = [{
+            "name": "${label}CPU",
+            "metricName.keyword": "containerCPU",
+            "agg": {"value": "cpu", "agg_type": "avg"},
+            "direction": 1,
+            "fan_out": [
+                {"label": "apiserver"},
+                {"label": "multus"},
+            ]
+        }]
+        result = expand_fan_out(metrics, logger)
+        # Mutate one result's nested dict
+        result[0]["agg"]["value"] = "mem"
+        # Other result should be unaffected (deep copy)
+        assert result[1]["agg"]["value"] == "cpu"
+
+    def test_substitution_in_not_dict(self, logger):
+        metrics = [{
+            "name": "${label}",
+            "metricName.keyword": "containerCPU",
+            "direction": 1,
+            "not": {"jobConfig.name": "${exclude}"},
+            "fan_out": [
+                {"label": "test", "exclude": "garbage-collection"},
+            ]
+        }]
+        result = expand_fan_out(metrics, logger)
+        assert result[0]["not"] == {"jobConfig.name": "garbage-collection"}

--- a/orion/tests/test_group_by.py
+++ b/orion/tests/test_group_by.py
@@ -1,0 +1,225 @@
+"""
+Unit tests for group_by dynamic metric expansion
+"""
+
+# pylint: disable = missing-function-docstring
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from orion.config import expand_group_by, _replace_placeholders
+from orion.matcher import Matcher
+from orion.logger import SingletonLogger
+
+
+@pytest.fixture(autouse=True)
+def logger():
+    SingletonLogger(debug=logging.INFO, name="Orion")
+    return SingletonLogger.get_logger("Orion")
+
+
+def _make_matcher(index="perf-scale-ci"):
+    matcher = MagicMock(spec=Matcher)
+    matcher.index = index
+    matcher.uuid_field = "uuid"
+    matcher.es = MagicMock()
+    matcher.logger = MagicMock()
+    return matcher
+
+
+def _mock_agg_response(values):
+    buckets = [SimpleNamespace(key=v) for v in values]
+    aggs = SimpleNamespace(group_values=SimpleNamespace(buckets=buckets))
+    resp = MagicMock()
+    resp.aggregations = aggs
+    return resp
+
+
+class TestDottedPlaceholders:
+    def test_dotted_field_name_substitution(self):
+        result = _replace_placeholders(
+            "${labels.namespace.keyword}CPU",
+            {"labels.namespace.keyword": "etcd"}
+        )
+        assert result == "etcdCPU"
+
+    def test_dotted_and_simple_mixed(self):
+        result = _replace_placeholders(
+            "${labels.namespace.keyword}-${name}",
+            {"labels.namespace.keyword": "etcd", "name": "cpu"}
+        )
+        assert result == "etcd-cpu"
+
+    def test_simple_placeholder_still_works(self):
+        result = _replace_placeholders("${label}CPU", {"label": "apiserver"})
+        assert result == "apiserverCPU"
+
+
+class TestDiscoverFieldValues:
+    @patch("orion.matcher.Search")
+    def test_returns_sorted_values(self, mock_search_cls, logger):
+        matcher = Matcher.__new__(Matcher)
+        matcher.uuid_field = "uuid"
+        matcher.es = MagicMock()
+        matcher.index = "perf-scale-ci"
+        matcher.logger = MagicMock()
+
+        resp = _mock_agg_response(["openshift-multus", "openshift-etcd", "openshift-kube-apiserver"])
+        mock_search_instance = MagicMock()
+        mock_search_cls.return_value.query.return_value.extra.return_value = mock_search_instance
+        mock_search_instance.aggs = MagicMock()
+        mock_search_instance.execute.return_value = resp
+
+        metric = {"name": "${labels.namespace.keyword}CPU", "metricName.keyword": "containerCPU"}
+        values = matcher.discover_field_values(metric, "labels.namespace.keyword", ["uuid1", "uuid2"])
+
+        assert values == ["openshift-etcd", "openshift-kube-apiserver", "openshift-multus"]
+
+    @patch("orion.matcher.Search")
+    def test_empty_response(self, mock_search_cls, logger):
+        matcher = Matcher.__new__(Matcher)
+        matcher.uuid_field = "uuid"
+        matcher.es = MagicMock()
+        matcher.index = "perf-scale-ci"
+        matcher.logger = MagicMock()
+
+        resp = MagicMock()
+        resp.aggregations = SimpleNamespace(group_values=SimpleNamespace(buckets=[]))
+        mock_search_instance = MagicMock()
+        mock_search_cls.return_value.query.return_value.extra.return_value = mock_search_instance
+        mock_search_instance.aggs = MagicMock()
+        mock_search_instance.execute.return_value = resp
+
+        metric = {"name": "test", "metricName.keyword": "containerCPU"}
+        values = matcher.discover_field_values(metric, "labels.namespace.keyword", ["uuid1"])
+
+        assert values == []
+
+    @patch("orion.matcher.Search")
+    def test_no_aggregations_attr(self, mock_search_cls, logger):
+        matcher = Matcher.__new__(Matcher)
+        matcher.uuid_field = "uuid"
+        matcher.es = MagicMock()
+        matcher.index = "perf-scale-ci"
+        matcher.logger = MagicMock()
+
+        resp = MagicMock(spec=[])
+        mock_search_instance = MagicMock()
+        mock_search_cls.return_value.query.return_value.extra.return_value = mock_search_instance
+        mock_search_instance.aggs = MagicMock()
+        mock_search_instance.execute.return_value = resp
+
+        metric = {"name": "test", "metricName.keyword": "containerCPU"}
+        values = matcher.discover_field_values(metric, "labels.namespace.keyword", ["uuid1"])
+
+        assert values == []
+
+
+class TestExpandGroupBy:
+    def test_no_group_by_passthrough(self, logger):
+        metrics = [{"name": "cpuMetric", "metricName.keyword": "containerCPU"}]
+        matcher = _make_matcher()
+        result = expand_group_by(metrics, matcher, ["uuid1"], logger)
+        assert len(result) == 1
+        assert result[0]["name"] == "cpuMetric"
+
+    def test_single_field_expansion(self, logger):
+        matcher = _make_matcher()
+        matcher.discover_field_values.return_value = ["openshift-etcd", "openshift-kube-apiserver"]
+        metrics = [{
+            "name": "${labels.namespace.keyword}CPU",
+            "metricName.keyword": "containerCPU",
+            "metric_of_interest": "value",
+            "group_by": ["labels.namespace.keyword"],
+        }]
+        result = expand_group_by(metrics, matcher, ["uuid1"], logger)
+
+        assert len(result) == 2
+        assert result[0]["name"] == "openshift-etcdCPU"
+        assert result[0]["labels.namespace.keyword"] == "openshift-etcd"
+        assert result[1]["name"] == "openshift-kube-apiserverCPU"
+        assert result[1]["labels.namespace.keyword"] == "openshift-kube-apiserver"
+
+    def test_group_by_key_stripped(self, logger):
+        matcher = _make_matcher()
+        matcher.discover_field_values.return_value = ["val1"]
+        metrics = [{
+            "name": "${labels.namespace.keyword}",
+            "metricName.keyword": "containerCPU",
+            "group_by": ["labels.namespace.keyword"],
+        }]
+        result = expand_group_by(metrics, matcher, ["uuid1"], logger)
+
+        assert len(result) == 1
+        assert "group_by" not in result[0]
+
+    def test_no_values_skips_metric(self, logger):
+        matcher = _make_matcher()
+        matcher.discover_field_values.return_value = []
+        metrics = [{
+            "name": "${labels.namespace.keyword}CPU",
+            "metricName.keyword": "containerCPU",
+            "group_by": ["labels.namespace.keyword"],
+        }]
+        result = expand_group_by(metrics, matcher, ["uuid1"], logger)
+
+        assert len(result) == 0
+
+    def test_mixed_metrics(self, logger):
+        matcher = _make_matcher()
+        matcher.discover_field_values.return_value = ["ns1", "ns2"]
+        metrics = [
+            {"name": "standalone", "metricName.keyword": "podLatency"},
+            {
+                "name": "${labels.namespace.keyword}CPU",
+                "metricName.keyword": "containerCPU",
+                "group_by": ["labels.namespace.keyword"],
+            },
+            {"name": "anotherStandalone", "metricName.keyword": "kubeletCPU"},
+        ]
+        result = expand_group_by(metrics, matcher, ["uuid1"], logger)
+
+        assert len(result) == 4
+        assert result[0]["name"] == "standalone"
+        assert result[1]["name"] == "ns1CPU"
+        assert result[2]["name"] == "ns2CPU"
+        assert result[3]["name"] == "anotherStandalone"
+
+    def test_entries_are_independent(self, logger):
+        matcher = _make_matcher()
+        matcher.discover_field_values.return_value = ["ns1", "ns2"]
+        metrics = [{
+            "name": "${labels.namespace.keyword}",
+            "metricName.keyword": "containerCPU",
+            "agg": {"value": "cpu", "agg_type": "avg"},
+            "group_by": ["labels.namespace.keyword"],
+        }]
+        result = expand_group_by(metrics, matcher, ["uuid1"], logger)
+
+        result[0]["agg"]["value"] = "mem"
+        assert result[1]["agg"]["value"] == "cpu"
+
+    def test_string_group_by_coerced_to_list(self, logger):
+        matcher = _make_matcher()
+        matcher.discover_field_values.return_value = ["val1"]
+        metrics = [{
+            "name": "${labels.namespace.keyword}",
+            "metricName.keyword": "containerCPU",
+            "group_by": "labels.namespace.keyword",
+        }]
+        result = expand_group_by(metrics, matcher, ["uuid1"], logger)
+
+        assert len(result) == 1
+        assert result[0]["name"] == "val1"
+
+    def test_multiple_fields_errors(self, logger):
+        metrics = [{
+            "name": "test",
+            "group_by": ["field1", "field2"],
+        }]
+        matcher = _make_matcher()
+        with pytest.raises(SystemExit):
+            expand_group_by(metrics, matcher, ["uuid1"], logger)

--- a/orion/tests/test_group_by.py
+++ b/orion/tests/test_group_by.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from opensearchpy.exceptions import ConnectionError as OpenSearchConnectionError
+
 from orion.config import expand_group_by, _replace_placeholders
 from orion.matcher import Matcher
 from orion.logger import SingletonLogger
@@ -116,6 +118,25 @@ class TestDiscoverFieldValues:
         values = matcher.discover_field_values(metric, "labels.namespace.keyword", ["uuid1"])
 
         assert values == []
+
+    @patch("orion.matcher.Search")
+    def test_connection_error_returns_empty(self, mock_search_cls, logger):
+        matcher = Matcher.__new__(Matcher)
+        matcher.uuid_field = "uuid"
+        matcher.es = MagicMock()
+        matcher.index = "perf-scale-ci"
+        matcher.logger = MagicMock()
+
+        mock_search_instance = MagicMock()
+        mock_search_cls.return_value.query.return_value.extra.return_value = mock_search_instance
+        mock_search_instance.aggs = MagicMock()
+        mock_search_instance.execute.side_effect = OpenSearchConnectionError("connection refused")
+
+        metric = {"name": "test", "metricName.keyword": "containerCPU"}
+        values = matcher.discover_field_values(metric, "labels.namespace.keyword", ["uuid1"])
+
+        assert values == []
+        matcher.logger.warning.assert_called_once()
 
 
 class TestExpandGroupBy:

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -17,6 +17,7 @@ import pandas as pd
 import requests
 from tabulate import tabulate
 
+from orion.config import expand_group_by
 from orion.matcher import Matcher
 from orion.logger import SingletonLogger
 from orion.constants import BATCH_METRIC_CHUNK_SIZE
@@ -70,6 +71,7 @@ class Utils:
             ts = metric.pop("timestamp", global_timestamp_field)
             correlation = metric.pop("correlation", "")
             context = metric.pop("context", 5)
+            metric.pop("group_by", None)
             metric_type = metric.get("type")
 
             meta_by_name[metric["name"]] = {
@@ -576,7 +578,11 @@ class Utils:
             options["baseline"],
             options["node_count"],
         )
-        # get metrics data and dataframe
+        # expand groupBy metric templates using live OpenSearch data
+        test["metrics"] = expand_group_by(
+            test["metrics"], match, uuids, self.logger
+        )
+
         metrics = test["metrics"]
         dataframe_list, metrics_config, metadata_columns = self.get_metric_data(
             uuids, metrics, match, test_threshold, timestamp_field


### PR DESCRIPTION
## Type of change
- [x] New feature
## Description
Allow metric definitions to use a `fan_out` key that expands a single template into multiple metrics with ${var} placeholder substitution and field overrides, reducing config duplication.

Add group_by support for dynamic metric expansion

Query OpenSearch for distinct label values scoped by metric filters and UUIDs, then expand metric templates per discovered value. Enables auto-discovery instead of listing values manually in fan_out entries.

Document fan_out and group_by metric expansion features

Add Metric Expansion section to configuration.md covering static fan_out and dynamic group_by with examples, comparison table, and usage guidance.

Assisted-by: Claude Code
## Related Tickets & Documents
- Closes #425
## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
## Testing
Run against 4.22 with 5d lookback:
```VERSION=4.22 orion --column-group-size=4 --collapse --node-count true --config examples/trt-external-payload-cluster-density-group-by.yaml --lookback 5d --hunter-analyze```
See output in this [gist](https://gist.github.com/afcollins/b4cfc9efefc8ac177147da9392c877fa).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metric expansion using `fan_out`, allowing one template to generate multiple metrics with variable substitution and per-entry overrides.
  * Added dynamic `group_by` expansion, creating metrics for distinct values discovered from OpenSearch data.
  * Added documentation and configuration examples for metric expansion.
  * Expanded support across filters, labels, aggregations, correlation, and metadata metrics.

* **Tests**
  * Added comprehensive coverage for static and dynamic metric expansion, substitutions, overrides, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->