### PR TITLE
Adding node page fault as a metric

### DIFF
--- a/examples/crd-scale.yaml
+++ b/examples/crd-scale.yaml
@@ -117,3 +117,43 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
+
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum

--- a/examples/metal-perfscale-cpt-node-density-heavy.yaml
+++ b/examples/metal-perfscale-cpt-node-density-heavy.yaml
@@ -97,3 +97,43 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
+
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum

--- a/examples/metal-perfscale-cpt-node-density.yaml
+++ b/examples/metal-perfscale-cpt-node-density.yaml
@@ -106,3 +106,43 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
+
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum

--- a/examples/metal-perfscale-cpt-virt-density-nomount.yaml
+++ b/examples/metal-perfscale-cpt-virt-density-nomount.yaml
@@ -104,3 +104,43 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
+
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -104,3 +104,43 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
+
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum

--- a/examples/metal-perfscale-cpt-virt-udn-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-udn-density.yaml
@@ -104,3 +104,43 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
+
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -117,6 +117,46 @@
   direction: 1
   threshold: 10
 
+- name: max-mutating-apicalls-latency-${ag}
+  metricName.keyword: max-mutating-apicalls-latency
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: avg
+    - ag: max
+
+- name: max-ro-apicalls-latency-${ag}
+  metricName.keyword: max-ro-apicalls-latency
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: avg
+    - ag: max
+
+- name: 99thEtcdCompaction-${ag}
+  metricName.keyword: 99thEtcdCompaction
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: sum
+    - ag: max
+
+- name: nodeMajorFaults-${ag}
+  metricName.keyword: nodeMajorFaults
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: max
+    - ag: sum
+
 - name: ovnCPU
   metricName.keyword: containerCPU
   labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/metrics/chaos-scenarios-metrics.yaml
+++ b/examples/metrics/chaos-scenarios-metrics.yaml
@@ -460,3 +460,43 @@
   metric_of_interest: value
   agg:
     agg_type: avg
+
+- name: max-mutating-apicalls-latency-${ag}
+  metricName.keyword: max-mutating-apicalls-latency
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: avg
+    - ag: max
+
+- name: max-ro-apicalls-latency-${ag}
+  metricName.keyword: max-ro-apicalls-latency
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: avg
+    - ag: max
+
+- name: 99thEtcdCompaction-${ag}
+  metricName.keyword: 99thEtcdCompaction
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: sum
+    - ag: max
+
+- name: nodeMajorFaults-${ag}
+  metricName.keyword: nodeMajorFaults
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: max
+    - ag: sum

--- a/examples/netpol-24nodes.yaml
+++ b/examples/netpol-24nodes.yaml
@@ -255,6 +255,46 @@ tests:
         direction: 1
         threshold: 10
 
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum
+
       # ── API server CPU/Memory — master nodes ──────────────────────────────────
       - name: apiserverCPU
         metricName.keyword: containerCPU-Masters

--- a/examples/okd-control-plane-cluster-density.yaml
+++ b/examples/okd-control-plane-cluster-density.yaml
@@ -88,3 +88,43 @@ tests:
         agg:
           agg_type: avg
         direction: 1
+
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum

--- a/examples/okd-control-plane-node-density-cni.yaml
+++ b/examples/okd-control-plane-node-density-cni.yaml
@@ -235,3 +235,43 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
+
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum

--- a/examples/rosa-hcp-crd-scale.yaml
+++ b/examples/rosa-hcp-crd-scale.yaml
@@ -97,3 +97,43 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
+
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum

--- a/examples/rosa-hcp-metrics.yaml
+++ b/examples/rosa-hcp-metrics.yaml
@@ -212,6 +212,46 @@
   direction: 1
   threshold: 10
 
+- name: max-mutating-apicalls-latency-${ag}
+  metricName.keyword: max-mutating-apicalls-latency
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: avg
+    - ag: max
+
+- name: max-ro-apicalls-latency-${ag}
+  metricName.keyword: max-ro-apicalls-latency
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: avg
+    - ag: max
+
+- name: 99thEtcdCompaction-${ag}
+  metricName.keyword: 99thEtcdCompaction
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: sum
+    - ag: max
+
+- name: nodeMajorFaults-${ag}
+  metricName.keyword: nodeMajorFaults
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  direction: 1
+  fan_out:
+    - ag: max
+    - ag: sum
+
 # --- Worker Node: OVN-Kubernetes CPU (runs on workers) ---
 
 - name: ovnCPU

--- a/examples/trt-external-payload-cluster-density.yaml
+++ b/examples/trt-external-payload-cluster-density.yaml
@@ -180,6 +180,46 @@ tests:
         direction: 1
         threshold: 10
 
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum
+
       - name: etcdWALFsyncLatency
         metricName.keyword: 99thEtcdDiskWalFsyncDurationSeconds
         metric_of_interest: value

--- a/examples/trt-external-payload-node-density-cni.yaml
+++ b/examples/trt-external-payload-node-density-cni.yaml
@@ -120,6 +120,46 @@ tests:
         direction: 1
         threshold: 10
 
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum
+
       - name: etcdWALFsyncLatency
         metricName.keyword: 99thEtcdDiskWalFsyncDurationSeconds
         metric_of_interest: value

--- a/examples/trt-external-payload-node-density.yaml
+++ b/examples/trt-external-payload-node-density.yaml
@@ -172,6 +172,46 @@ tests:
         direction: 1
         threshold: 10
 
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum
+
       - name: multusCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-multus

--- a/examples/trt-external-payload-udn-density-pods.yaml
+++ b/examples/trt-external-payload-udn-density-pods.yaml
@@ -157,6 +157,46 @@ tests:
         direction: 1
         threshold: 10
 
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum
+
       - name: ovnCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/udn-density-pods.yaml
+++ b/examples/udn-density-pods.yaml
@@ -157,6 +157,46 @@ tests:
         direction: 1
         threshold: 10
 
+      - name: max-mutating-apicalls-latency-${ag}
+        metricName.keyword: max-mutating-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: max-ro-apicalls-latency-${ag}
+        metricName.keyword: max-ro-apicalls-latency
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: 99thEtcdCompaction-${ag}
+        metricName.keyword: 99thEtcdCompaction
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: sum
+          - ag: max
+
+      - name: nodeMajorFaults-${ag}
+        metricName.keyword: nodeMajorFaults
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        direction: 1
+        fan_out:
+          - ag: max
+          - ag: sum
+
       - name: ovnCPU
         metricName.keyword: containerCPU
         labels.namespace.keyword: openshift-ovn-kubernetes


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adding `nodeMajorFaults` as a metric to the config files.

## Related Tickets & Documents
- Closes # https://redhat-internal.slack.com/archives/CNKHL6076/p1785525895313329

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Tested and verified in local using
```
  orion \
    --hunter-analyze \
    --node-count \
    --sippy-pr-search \
    --viz \
    --debug \
    --config "examples/trt-external-payload-cluster-density.yaml" \
    --lookback "30d" \
    --es-server "$ES_SERVER" \
    --benchmark-index "$INDEX" \
    --metadata-index "$INDEX" \
    --input-vars '{"version": "5.0"}'
```
