### PR TITLE
Check for duplicate metrics and warn the user

### DIFF
--- a/orion/tests/test_utils_batch.py
+++ b/orion/tests/test_utils_batch.py
@@ -731,3 +731,28 @@ class TestCustomTimestampBatch:
         assert match_mock.get_agg_metrics_batch.call_count == 1
         assert ts_fields_seen == ["iso_timestamp"]
         assert len(df_list) == 2
+
+
+class TestDuplicateMetricNames:
+
+    def test_duplicate_agg_metric_name_is_skipped(self, utils, match_mock):
+        m1 = _agg_metric("apiserverCPU")
+        m1["labels.namespace.keyword"] = "openshift-apiserver"
+        m2 = _agg_metric("apiserverCPU")
+        m2["labels.container.keyword"] = "openshift-apiserver"
+        metrics = [copy.deepcopy(m1), copy.deepcopy(m2)]
+
+        match_mock.get_agg_metrics_batch.return_value = {
+            "apiserverCPU": _agg_batch_data(),
+        }
+
+        df_list, metrics_config, _ = utils.get_metric_data(
+            UUIDS, metrics, match_mock, test_threshold=0
+        )
+
+        # Only one dataframe produced — duplicate was skipped
+        assert len(df_list) == 1
+        assert "apiserverCPU_avg" in metrics_config
+        # Batch called once with single metric, not two
+        batch_call_metrics = match_mock.get_agg_metrics_batch.call_args[0][1]
+        assert len(batch_call_metrics) == 1

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -64,7 +64,19 @@ class Utils:
         std_metrics = []
         meta_by_name = {}
 
+        seen_names = set()
         for metric in metrics:
+            name = metric["name"]
+            if name in seen_names:
+                self.logger.warning(
+                    "Duplicate metric name '%s' — skipping. "
+                    "Each metric must have a unique name to avoid "
+                    "column collisions in the merged dataframe.",
+                    name,
+                )
+                continue
+            seen_names.add(name)
+
             labels = metric.pop("labels", None)
             direction = int(metric.pop("direction", 1))
             threshold = abs(int(metric.pop("threshold", test_threshold)))


### PR DESCRIPTION
Prior behavior will just throw an uncaught exception

## Type of change

- [x] Bug fix

## Description

If there are two metrics with the same name, then an exception can be thrown.

Instead, we can check if there are duplicate metric names and log a warning.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.