### PR TITLE
Revises #431

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,30 +4,22 @@ This file contains rules and context for AI agents and LLMs contributing to or g
 
 ## Configuration Anti-Patterns
 
-### Do not combine `.keyword` fields with `wildcard:`
+### Avoid leading `*` on `.keyword` fields under `wildcard:`
 
-The `wildcard:` section in Orion configs generates OpenSearch wildcard queries for pattern/glob matching. The `.keyword` suffix on a field name denotes an exact-match (not-analyzed) field in OpenSearch. Placing a `.keyword` field under `wildcard:` is contradictory and **will be rejected by config validation**.
-
-**Rules:**
-
-- `.keyword` fields belong in **top-level metadata** for exact matching — never under `wildcard:`.
-- `wildcard:` is **only** for fields that genuinely need glob/pattern matching (e.g., version prefixes like `ocpVersion: "4.17*"`).
-- Do not use `wildcard:` as a general-purpose filter. If the value is known exactly, use top-level metadata with an exact match.
+Do not use a leading `*` on `.keyword` fields in the `wildcard:` section. Prefer trailing wildcards or exact match in top-level metadata.
 
 ```yaml
-# WRONG — rejected by validation
+# BAD — triggers warning
 metadata:
   wildcard:
     upstreamJob.keyword: "*my-job-name*"
 
-# CORRECT — exact match on a keyword field
-metadata:
-  upstreamJob.keyword: periodic-ci-my-exact-job-name
-
-# CORRECT — pattern match on a non-keyword field
+# OK
 metadata:
   wildcard:
-    ocpVersion: "4.17*"
-```
+    upstreamJob.keyword: "my-job-name*"
 
-See `docs/configuration.md` (Wildcard Matching section) for full documentation.
+# BETTER — exact match in top-level metadata
+metadata:
+  upstreamJob.keyword: periodic-ci-my-exact-job-name
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -493,14 +493,19 @@ This matches any `ocpVersion` starting with `4.17` (e.g., `4.17.0`, `4.17.5-rc1`
 
 > **Important:** The `wildcard` section is strictly for fields that need pattern/glob matching. Do not use it as a general-purpose filter for metadata fields that can be matched exactly.
 >
-> - **Do not** use `.keyword` fields under `wildcard`. The `.keyword` suffix denotes an exact-match field in OpenSearch — combining it with wildcard patterns is contradictory. Place `.keyword` fields directly in the top-level metadata for exact matching.
+> - **Avoid** a leading `*` on `.keyword` fields under `wildcard`. OpenSearch expands leading wildcards against every unique token in the index, which can be very slow or hit the max-expansion limit. Orion will emit a warning when it detects this pattern. See the [OpenSearch wildcard expressions docs](https://docs.opensearch.org/latest/query-dsl/full-text/query-string/#wildcard-expressions) for details.
 > - **Do not** use `wildcard` for fields whose value is already known exactly. Put those in top-level metadata instead.
 >
 > ```yaml
-> # WRONG — .keyword field under wildcard
+> # WARNING — leading '*' on .keyword field triggers a warning
 > metadata:
 >   wildcard:
 >     upstreamJob.keyword: "*my-job-name*"
+>
+> # OK — .keyword with trailing wildcard only
+> metadata:
+>   wildcard:
+>     upstreamJob.keyword: "my-job-name*"
 >
 > # CORRECT — exact match in top-level metadata
 > metadata:

--- a/orion/config.py
+++ b/orion/config.py
@@ -71,15 +71,16 @@ def load_config(config_path: str, input_vars: Dict[str, Any]) -> Dict[str, Any]:
             test["metrics"] = merge_lists(test.get("metrics", []), parent_metrics)
 
         wildcard_fields = test.get("metadata", {}).get("wildcard", {})
-        keyword_wildcards = [f for f in wildcard_fields if f.endswith(".keyword")]
-        if keyword_wildcards:
-            logger.error(
-                "Test '%s': wildcard fields must not use .keyword suffix "
-                "(keyword fields are exact-match; put them in top-level metadata instead). "
-                "Found: %s",
-                test["name"], keyword_wildcards
+        leading_star_keywords = [
+            f for f in wildcard_fields
+            if f.endswith(".keyword") and str(wildcard_fields[f]).startswith("*")
+        ]
+        if leading_star_keywords:
+            logger.warning(
+                "Test '%s': leading '*' on .keyword wildcard fields is an "
+                "anti-pattern (see docs/configuration.md). Found: %s",
+                test["name"], leading_star_keywords
             )
-            sys.exit(1)
 
         # Expand fan_out metric templates into individual metrics
         test["metrics"] = expand_fan_out(test["metrics"], logger)

--- a/orion/tests/test_config.py
+++ b/orion/tests/test_config.py
@@ -104,35 +104,47 @@ class TestPercentileValidation:
 
 
 class TestWildcardKeywordValidation:
-    """Tests that .keyword fields under wildcard: are rejected."""
+    """Tests that leading '*' on .keyword wildcard fields triggers a warning."""
 
-    def test_keyword_field_in_wildcard_exits(self):
-        config = {
-            "tests": [
-                {
+    def test_leading_star_keyword_warns_but_passes(self):
+        config = { "tests": [ {
                     "name": "test1",
                     "metadata": {
                         "platform": "AWS",
-                        "wildcard": {
-                            "upstreamJob.keyword": "*some-job*",
-                        },
+                        "wildcard": { "upstreamJob.keyword": "*some-job*", },
                     },
-                    "metrics": [
-                        {
+                    "metrics": [ {
                             "name": "m1",
                             "metricName": "test",
                             "metric_of_interest": "value",
                             "threshold": 10,
                             "direction": 1,
-                        }
-                    ],
-                }
-            ]
-        }
+                        } ], } ] }
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = _write_config(tmp_dir, config)
-            with pytest.raises(SystemExit):
-                load_config(path, {})
+            result = load_config(path, {})
+            assert result is not None
+            assert len(result["tests"]) == 1
+
+    def test_trailing_star_keyword_passes(self):
+        config = { "tests": [ {
+                    "name": "test1",
+                    "metadata": {
+                        "platform": "AWS",
+                        "wildcard": { "upstreamJob.keyword": "some-job*", },
+                    },
+                    "metrics": [ {
+                            "name": "m1",
+                            "metricName": "test",
+                            "metric_of_interest": "value",
+                            "threshold": 10,
+                            "direction": 1,
+                        } ], } ] }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _write_config(tmp_dir, config)
+            result = load_config(path, {})
+            assert result is not None
+            assert len(result["tests"]) == 1
 
     def test_non_keyword_wildcard_field_passes(self):
         config = {


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] Documentation Update

## Description

We shouldn't prevent users from using wildcard on
indexed fields, but we should discourage agents
from proposing a leading '*' that can cause
memory problems.

## Related Tickets & Documents

- Related Issue #431 
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Updates**
  * `.keyword` wildcard patterns are now allowed in configuration.
  * A warning is shown when a pattern begins with `*`, as these patterns may be less efficient.
  * Trailing-wildcard and exact-match patterns are recommended for better performance.

* **Documentation**
  * Updated configuration guidance with clearer examples of supported and discouraged wildcard patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->