### PR TITLE
Adding go thread exhaustion metrics

### DIFF
--- a/examples/batch-churn.yaml
+++ b/examples/batch-churn.yaml
@@ -1,0 +1,30 @@
+# batch-churn (AWS, FIPS, 6 workers) — inherits the shared density metrics
+# from metrics.yaml. Metadata mirrors the metadata document indexed by
+# kube-burner for the batch-churn job (benchmark.keyword: batch-churn).
+metricsFile: metrics.yaml
+tests:
+  - name: batch-churn-fips-6nodes
+    metadata:
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6i.4xlarge
+      masterNodesCount: 3
+      workerNodesType: m6i.2xlarge
+      workerNodesCount: 6
+      infraNodesType: r5.xlarge
+      infraNodesCount: 3
+      benchmark.keyword: batch-churn
+      wildcard:
+        ocpVersion: "{{ version }}*"
+      networkType: OVNKubernetes
+      fips: "true"
+      jobType: "{{ jobtype | default('periodic') }}"
+      pullNumber: "{{ pull_number | default(0) }}"
+      organization: "{{ organization | default('') }}"
+      repository: "{{ repository | default('') }}"
+      not:
+        stream: okd
+
+    # Metrics are inherited from metrics.yaml. All shared density metrics are
+    # collected for batch-churn per the build-log. Add batch-churn-specific
+    # metrics below if needed.

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -157,6 +157,103 @@
     - ag: max
     - ag: sum
 
+- name: watchCountByResource-${labels.resource.keyword}
+  metricName.keyword: watchCountByResource
+  metric_of_interest: value
+  group_by:
+    - labels.resource.keyword
+  agg:
+    agg_type: max
+  labels:
+    - "[Jira: kube-apiserver]"
+  direction: 1
+  threshold: 10
+
+- name: watchCountByInstance-${labels.instance.keyword}
+  metricName.keyword: watchCountByInstance
+  metric_of_interest: value
+  group_by:
+    - labels.instance.keyword
+  agg:
+    agg_type: max
+  labels:
+    - "[Jira: kube-apiserver]"
+  direction: 1
+  threshold: 10
+
+- name: watchCountTotal
+  metricName.keyword: watchCountTotal
+  metric_of_interest: value
+  agg:
+    agg_type: max
+  labels:
+    - "[Jira: kube-apiserver]"
+  direction: 1
+  threshold: 10
+
+- name: apiserverGoThreads-${ag}
+  metricName.keyword: apiserverGoThreads
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  labels:
+    - "[Jira: kube-apiserver]"
+  direction: 1
+  threshold: 10
+  fan_out:
+    - ag: avg
+    - ag: max
+
+- name: apiserverGoGoroutines-${ag}
+  metricName.keyword: apiserverGoGoroutines
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  labels:
+    - "[Jira: kube-apiserver]"
+  direction: 1
+  threshold: 10
+  fan_out:
+    - ag: avg
+    - ag: max
+
+- name: apiserverOpenFDs-${ag}
+  metricName.keyword: apiserverOpenFDs
+  metric_of_interest: value
+  agg:
+    agg_type: ${ag}
+  labels:
+    - "[Jira: kube-apiserver]"
+  direction: 1
+  threshold: 10
+  fan_out:
+    - ag: avg
+    - ag: max
+
+- name: watchRequestRate-${labels.resource.keyword}
+  metricName.keyword: watchRequestRate
+  metric_of_interest: value
+  group_by:
+    - labels.resource.keyword
+  agg:
+    agg_type: avg
+  labels:
+    - "[Jira: kube-apiserver]"
+  direction: 1
+  threshold: 10
+
+- name: 99thWatchRequestLatency-${labels.resource.keyword}
+  metricName.keyword: 99thWatchRequestLatency
+  metric_of_interest: value
+  group_by:
+    - labels.resource.keyword
+  agg:
+    agg_type: max
+  labels:
+    - "[Jira: kube-apiserver]"
+  direction: 1
+  threshold: 10
+
 - name: ovnCPU
   metricName.keyword: containerCPU
   labels.namespace.keyword: openshift-ovn-kubernetes

--- a/examples/trt-external-payload-cluster-density.yaml
+++ b/examples/trt-external-payload-cluster-density.yaml
@@ -220,6 +220,103 @@ tests:
           - ag: max
           - ag: sum
 
+      - name: watchCountByResource-${labels.resource.keyword}
+        metricName.keyword: watchCountByResource
+        metric_of_interest: value
+        group_by:
+          - labels.resource.keyword
+        agg:
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+
+      - name: watchCountByInstance-${labels.instance.keyword}
+        metricName.keyword: watchCountByInstance
+        metric_of_interest: value
+        group_by:
+          - labels.instance.keyword
+        agg:
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+
+      - name: watchCountTotal
+        metricName.keyword: watchCountTotal
+        metric_of_interest: value
+        agg:
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+
+      - name: apiserverGoThreads-${ag}
+        metricName.keyword: apiserverGoThreads
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: apiserverGoGoroutines-${ag}
+        metricName.keyword: apiserverGoGoroutines
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: apiserverOpenFDs-${ag}
+        metricName.keyword: apiserverOpenFDs
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: watchRequestRate-${labels.resource.keyword}
+        metricName.keyword: watchRequestRate
+        metric_of_interest: value
+        group_by:
+          - labels.resource.keyword
+        agg:
+          agg_type: avg
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+
+      - name: 99thWatchRequestLatency-${labels.resource.keyword}
+        metricName.keyword: 99thWatchRequestLatency
+        metric_of_interest: value
+        group_by:
+          - labels.resource.keyword
+        agg:
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+
       - name: etcdWALFsyncLatency
         metricName.keyword: 99thEtcdDiskWalFsyncDurationSeconds
         metric_of_interest: value


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Adds metrics that help us monitor go thread exhaustion during a watcher storm on the cluster. 

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/PERFSCALE-5463

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Tested and verified in local
```
  orion \
    --hunter-analyze \
    --debug \
    --config "examples/batch-churn.yaml" \
    --lookback "7d" \
    --es-server "$ES_SERVER" \
    --benchmark-index "ripsaw-kube-burner" \
    --metadata-index "perf_scale_ci" \
    --input-vars '{"version": "5.0", "jobtype": "rehearse", "pull_number": "83495"}'
```
