### PR TITLE
Adding batch churn metrics separately

### DIFF
--- a/examples/batch-churn.yaml
+++ b/examples/batch-churn.yaml
@@ -1,0 +1,120 @@
+tests:
+  - name: batch-churn-fips-6nodes
+    metadata:
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6i.4xlarge
+      masterNodesCount: 3
+      workerNodesType: m6i.2xlarge
+      workerNodesCount: 6
+      infraNodesType: r5.xlarge
+      infraNodesCount: 3
+      benchmark.keyword: batch-churn
+      wildcard:
+        ocpVersion: "{{ version }}*"
+      networkType: OVNKubernetes
+      fips: "true"
+      jobType: "{{ jobtype | default('periodic') }}"
+      pullNumber: "{{ pull_number | default(0) }}"
+      organization: "{{ organization | default('') }}"
+      repository: "{{ repository | default('') }}"
+      not:
+        stream: okd
+
+    metrics:
+      - name: watchCountByResource-${labels.resource.keyword}
+        metricName.keyword: watchCountByResource
+        metric_of_interest: value
+        group_by:
+          - labels.resource.keyword
+        agg:
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+
+      - name: watchCountByInstance-${labels.instance.keyword}
+        metricName.keyword: watchCountByInstance
+        metric_of_interest: value
+        group_by:
+          - labels.instance.keyword
+        agg:
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+
+      - name: watchCountTotal
+        metricName.keyword: watchCountTotal
+        metric_of_interest: value
+        agg:
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+
+      - name: apiserverGoThreads-${ag}
+        metricName.keyword: apiserverGoThreads
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: apiserverGoGoroutines-${ag}
+        metricName.keyword: apiserverGoGoroutines
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: apiserverOpenFDs-${ag}
+        metricName.keyword: apiserverOpenFDs
+        metric_of_interest: value
+        agg:
+          agg_type: ${ag}
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+        fan_out:
+          - ag: avg
+          - ag: max
+
+      - name: watchRequestRate-${labels.resource.keyword}
+        metricName.keyword: watchRequestRate
+        metric_of_interest: value
+        group_by:
+          - labels.resource.keyword
+        agg:
+          agg_type: avg
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10
+
+      - name: 99thWatchRequestLatency-${labels.resource.keyword}
+        metricName.keyword: 99thWatchRequestLatency
+        metric_of_interest: value
+        group_by:
+          - labels.resource.keyword
+        agg:
+          agg_type: max
+        labels:
+          - "[Jira: kube-apiserver]"
+        direction: 1
+        threshold: 10


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Adds metrics that help us monitor go thread exhaustion during a watcher storm on the cluster. 

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/PERFSCALE-5463

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Tested and verified in local
```
  orion \
    --hunter-analyze \
    --debug \
    --config "examples/batch-churn.yaml" \
    --lookback "7d" \
    --es-server "$ES_SERVER" \
    --benchmark-index "ripsaw-kube-burner" \
    --metadata-index "perf_scale_ci" \
    --input-vars '{"version": "5.0", "jobtype": "rehearse", "pull_number": "83495"}'
```
