### PR TITLE
Add acceptable range filtering for metric changepoints

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,10 +291,10 @@ threshold: 10  # Only detect changes > 10%
 ```
 
 ### Acceptable Range
-An `acceptable_range` can be used when a metric should only trigger when it
-steps from inside a permitted value range to outside it. The bounds are
-inclusive, and configuring a range takes precedence over `threshold` and
-`direction` for that metric.
+An `acceptable_range` can be used when a metric should only trigger when the
+actual value at a detected changepoint is outside a permitted value range.
+The bounds are inclusive, and configuring a range takes precedence over
+`threshold` and `direction` for that metric.
 
 ```yaml
 - name: nodeMajorFaults
@@ -306,7 +306,8 @@ inclusive, and configuring a range takes precedence over `threshold` and
 ```
 
 The range can also be written as `acceptable_range: {min: 0, max: 10}`.
-Changes that remain inside the range, or move back into it, are not reported.
+The value at the changepoint index is checked directly; the before/after
+segment means are not used for range filtering.
 
 ### Correlation
 A filter that skips changepoint detection if a dependent metric has no changepoint:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,6 +290,24 @@ Example:
 threshold: 10  # Only detect changes > 10%
 ```
 
+### Acceptable Range
+An `acceptable_range` can be used when a metric should only trigger when it
+steps from inside a permitted value range to outside it. The bounds are
+inclusive, and configuring a range takes precedence over `threshold` and
+`direction` for that metric.
+
+```yaml
+- name: nodeMajorFaults
+  metricName: nodeMajorFaults
+  metric_of_interest: value
+  agg:
+    agg_type: avg
+  acceptable_range: [0, 10]
+```
+
+The range can also be written as `acceptable_range: {min: 0, max: 10}`.
+Changes that remain inside the range, or move back into it, are not reported.
+
 ### Correlation
 A filter that skips changepoint detection if a dependent metric has no changepoint:
 

--- a/orion/algorithms/algorithm.py
+++ b/orion/algorithms/algorithm.py
@@ -69,3 +69,20 @@ class Algorithm(ABC): # pylint: disable = too-many-arguments, too-many-instance-
         )
 
         return series
+
+    def _has_acceptable_range(self, metric):
+        """Return whether a metric uses an acceptable value range."""
+        return self.metrics_config[metric].get("acceptable_range") is not None
+
+    def _steps_outside_acceptable_range(self, metric, change_point):
+        """Return whether a change moves from inside the range to outside it."""
+        acceptable_range = self.metrics_config[metric].get("acceptable_range")
+        if acceptable_range is None:
+            return False
+
+        minimum, maximum = acceptable_range
+        before = change_point.stats.mean_1
+        after = change_point.stats.mean_2
+        was_inside = minimum <= before <= maximum
+        is_outside = after < minimum or after > maximum
+        return was_inside and is_outside

--- a/orion/algorithms/algorithm.py
+++ b/orion/algorithms/algorithm.py
@@ -75,14 +75,15 @@ class Algorithm(ABC): # pylint: disable = too-many-arguments, too-many-instance-
         return self.metrics_config[metric].get("acceptable_range") is not None
 
     def _steps_outside_acceptable_range(self, metric, change_point):
-        """Return whether a change moves from inside the range to outside it."""
+        """Return whether the actual value at a changepoint is outside its range."""
         acceptable_range = self.metrics_config[metric].get("acceptable_range")
         if acceptable_range is None:
             return False
 
         minimum, maximum = acceptable_range
-        before = change_point.stats.mean_1
-        after = change_point.stats.mean_2
-        was_inside = minimum <= before <= maximum
-        is_outside = after < minimum or after > maximum
-        return was_inside and is_outside
+        index = change_point.index
+        if not 0 <= index < len(self.dataframe):
+            return False
+
+        value = self.dataframe.iloc[index][metric]
+        return value < minimum or value > maximum

--- a/orion/algorithms/cmr/cmr.py
+++ b/orion/algorithms/cmr/cmr.py
@@ -46,7 +46,12 @@ class CMR(Algorithm):
 
         for metric, cps in change_points_by_metric.items():
             direction = self.metrics_config[metric]["direction"]
-            if direction != 0:
+            if self._has_acceptable_range(metric):
+                change_points_by_metric[metric] = [
+                    cp for cp in cps
+                    if self._steps_outside_acceptable_range(metric, cp)
+                ]
+            elif direction != 0:
                 filtered = []
                 for cp in cps:
                     delta = cp.stats.mean_2 - cp.stats.mean_1

--- a/orion/algorithms/edivisive/edivisive.py
+++ b/orion/algorithms/edivisive/edivisive.py
@@ -52,9 +52,9 @@ class EDivisive(Algorithm):
             is_dry_run = self.metrics_config[metric].get("dry_run", False)
             for i in range(len(changepoint_list)-1, -1, -1):
                 deleted = False
-                if (self._has_changepoint(metric, changepoint_list, i) or
+                if (self._is_irrelevant_changepoint(metric, changepoint_list, i) or
                     (not is_dry_run and self._is_acked(ackSet, metric, changepoint_list, i)) or
-                    self._is_under_threshold(metric, changepoint_list, i)):
+                    self._is_filtered_by_threshold(metric, changepoint_list, i)):
                     deleted=True
                     del changepoint_list[i]
                 if (not deleted and self.metrics_config[metric]["correlation"] != ""):
@@ -79,9 +79,11 @@ class EDivisive(Algorithm):
         changepoint_list = change_points_by_metric[depending_metric]
         for i in range(len(changepoint_list)-1, -1, -1):
             if (changepoint_list[i].index >= index-context) and (changepoint_list[i].index <= index+context):
-                if (self._has_changepoint(depending_metric, changepoint_list, i) or
-                    self._is_acked(ackSet, depending_metric, changepoint_list, i) or
-                    self._is_under_threshold(depending_metric, changepoint_list, i)):
+                if (
+                    self._is_irrelevant_changepoint(depending_metric, changepoint_list, i)
+                    or self._is_acked(ackSet, depending_metric, changepoint_list, i)
+                    or self._is_filtered_by_threshold(depending_metric, changepoint_list, i)
+                ):
                     return False
                 return True
         return False
@@ -89,6 +91,19 @@ class EDivisive(Algorithm):
 
     def _is_under_threshold(self, metric, changepoint_list, i):
         return self.metrics_config[metric]["threshold"] > abs((changepoint_list[i].stats.mean_1 - changepoint_list[i].stats.mean_2)/changepoint_list[i].stats.mean_1)*100
+
+    def _is_irrelevant_changepoint(self, metric, changepoint_list, i):
+        """Filter changes that do not cross an acceptable range boundary."""
+        if self._has_acceptable_range(metric):
+            return not self._steps_outside_acceptable_range(metric, changepoint_list[i])
+        return self._has_changepoint(metric, changepoint_list, i)
+
+    def _is_filtered_by_threshold(self, metric, changepoint_list, i):
+        """Apply the percentage threshold only when no value range is configured."""
+        return (
+            not self._has_acceptable_range(metric)
+            and self._is_under_threshold(metric, changepoint_list, i)
+        )
 
 
     def _is_acked(self, ackSet, metric, changepoint_list, i):

--- a/orion/matcher.py
+++ b/orion/matcher.py
@@ -735,7 +735,7 @@ class Matcher:
         reserved_keys = {
             "name", "metric_of_interest", "not", "agg", "type",
             "labels", "direction", "threshold", "timestamp",
-            "correlation", "context",
+            "correlation", "context", "acceptable_range",
         }
 
         must_clauses = [Q("terms", **{self.uuid_field + ".keyword": uuids})]

--- a/orion/tests/test_acceptable_range.py
+++ b/orion/tests/test_acceptable_range.py
@@ -1,0 +1,42 @@
+"""Tests for acceptable value range filtering."""
+
+from orion.algorithms.edivisive.edivisive import EDivisive
+from orion.algorithms.cmr.cmr import CMR
+from orion.tests.conftest import make_change_point
+
+
+def _algorithm(metric_config):
+    algorithm = object.__new__(EDivisive)
+    algorithm.metrics_config = {"metric": metric_config}
+    return algorithm
+
+
+def test_steps_outside_acceptable_range():
+    algorithm = _algorithm({"acceptable_range": (0.0, 10.0)})
+    change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=11.0)
+
+    assert algorithm._steps_outside_acceptable_range("metric", change_point)
+
+
+def test_changes_inside_or_back_into_range_are_ignored():
+    algorithm = _algorithm({"acceptable_range": (0.0, 10.0)})
+
+    inside = make_change_point("metric", 1, mean_1=5.0, mean_2=8.0)
+    back_inside = make_change_point("metric", 1, mean_1=12.0, mean_2=8.0)
+
+    assert not algorithm._steps_outside_acceptable_range("metric", inside)
+    assert not algorithm._steps_outside_acceptable_range("metric", back_inside)
+
+
+def test_cmr_range_crossing_ignores_direction_and_percentage_threshold():
+    algorithm = CMR.__new__(CMR)
+    algorithm.metrics_config = {
+        "metric": {
+            "direction": 1,
+            "threshold": 100,
+            "acceptable_range": (0.0, 10.0),
+        }
+    }
+    change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=-1.0)
+
+    assert algorithm._steps_outside_acceptable_range("metric", change_point)

--- a/orion/tests/test_acceptable_range.py
+++ b/orion/tests/test_acceptable_range.py
@@ -1,5 +1,7 @@
 """Tests for acceptable value range filtering."""
 
+import pandas as pd
+
 from orion.algorithms.edivisive.edivisive import EDivisive
 from orion.algorithms.cmr.cmr import CMR
 from orion.tests.conftest import make_change_point
@@ -8,24 +10,23 @@ from orion.tests.conftest import make_change_point
 def _algorithm(metric_config):
     algorithm = object.__new__(EDivisive)
     algorithm.metrics_config = {"metric": metric_config}
+    algorithm.dataframe = pd.DataFrame({"metric": [5.0, 11.0]})
     return algorithm
 
 
 def test_steps_outside_acceptable_range():
     algorithm = _algorithm({"acceptable_range": (0.0, 10.0)})
-    change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=11.0)
+    change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=6.0)
 
     assert algorithm._steps_outside_acceptable_range("metric", change_point)
 
 
-def test_changes_inside_or_back_into_range_are_ignored():
+def test_actual_value_inside_range_is_ignored_even_if_mean_is_outside():
     algorithm = _algorithm({"acceptable_range": (0.0, 10.0)})
+    change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=100.0)
 
-    inside = make_change_point("metric", 1, mean_1=5.0, mean_2=8.0)
-    back_inside = make_change_point("metric", 1, mean_1=12.0, mean_2=8.0)
-
-    assert not algorithm._steps_outside_acceptable_range("metric", inside)
-    assert not algorithm._steps_outside_acceptable_range("metric", back_inside)
+    algorithm.dataframe.loc[1, "metric"] = 8.0
+    assert not algorithm._steps_outside_acceptable_range("metric", change_point)
 
 
 def test_cmr_range_crossing_ignores_direction_and_percentage_threshold():
@@ -37,6 +38,7 @@ def test_cmr_range_crossing_ignores_direction_and_percentage_threshold():
             "acceptable_range": (0.0, 10.0),
         }
     }
+    algorithm.dataframe = pd.DataFrame({"metric": [5.0, -1.0]})
     change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=-1.0)
 
     assert algorithm._steps_outside_acceptable_range("metric", change_point)

--- a/orion/tests/test_acceptable_range.py
+++ b/orion/tests/test_acceptable_range.py
@@ -1,13 +1,16 @@
 """Tests for acceptable value range filtering."""
 
 import pandas as pd
+import pytest
 
 from orion.algorithms.edivisive.edivisive import EDivisive
 from orion.algorithms.cmr.cmr import CMR
 from orion.tests.conftest import make_change_point
+from orion.utils import Utils
 
 
 def _algorithm(metric_config):
+    """Create an EDivisive instance with a small metric dataframe."""
     algorithm = object.__new__(EDivisive)
     algorithm.metrics_config = {"metric": metric_config}
     algorithm.dataframe = pd.DataFrame({"metric": [5.0, 11.0]})
@@ -15,13 +18,22 @@ def _algorithm(metric_config):
 
 
 def test_steps_outside_acceptable_range():
+    """Report a changepoint whose actual value is above the maximum."""
     algorithm = _algorithm({"acceptable_range": (0.0, 10.0)})
     change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=6.0)
 
     assert algorithm._steps_outside_acceptable_range("metric", change_point)
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_acceptable_range_rejects_non_finite_bounds(value):
+    """Reject bounds that cannot produce meaningful range comparisons."""
+    with pytest.raises(ValueError, match="finite"):
+        Utils._parse_acceptable_range([0.0, value])
+
+
 def test_actual_value_inside_range_is_ignored_even_if_mean_is_outside():
+    """Ignore an in-range actual value even when the segment mean is outside."""
     algorithm = _algorithm({"acceptable_range": (0.0, 10.0)})
     change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=100.0)
 
@@ -29,16 +41,66 @@ def test_actual_value_inside_range_is_ignored_even_if_mean_is_outside():
     assert not algorithm._steps_outside_acceptable_range("metric", change_point)
 
 
-def test_cmr_range_crossing_ignores_direction_and_percentage_threshold():
-    algorithm = CMR.__new__(CMR)
-    algorithm.metrics_config = {
+@pytest.mark.parametrize(
+    ("mean_1", "mean_2", "actual_value", "expected"),
+    [
+        (0.0, 100.0, 0.0, False),
+        (10.0, -100.0, 10.0, False),
+        (5.0, 0.0, 0.0, False),
+        (5.0, 10.0, 10.0, False),
+        (5.0, 10.0, -0.1, True),
+        (5.0, 10.0, 10.1, True),
+    ],
+)
+def test_range_bounds_are_inclusive(mean_1, mean_2, actual_value, expected):
+    """Use actual changepoint values when checking inclusive range bounds."""
+    algorithm = _algorithm({"acceptable_range": (0.0, 10.0)})
+    algorithm.dataframe.loc[1, "metric"] = actual_value
+    change_point = make_change_point("metric", 1, mean_1=mean_1, mean_2=mean_2)
+
+    assert bool(algorithm._steps_outside_acceptable_range("metric", change_point)) is expected
+
+
+def _cmr_config():
+    """Build the metric configuration used by the CMR integration test."""
+    return {
         "metric": {
             "direction": 1,
             "threshold": 100,
+            "correlation": "",
+            "context": 5,
             "acceptable_range": (0.0, 10.0),
         }
     }
-    algorithm.dataframe = pd.DataFrame({"metric": [5.0, -1.0]})
-    change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=-1.0)
 
-    assert algorithm._steps_outside_acceptable_range("metric", change_point)
+
+def test_cmr_analyze_uses_range_instead_of_direction():
+    """CMR keeps a downward range violation despite direction=1."""
+    algorithm = CMR(
+        dataframe=pd.DataFrame({
+            "uuid": ["baseline", "current"],
+            "ocpVersion": ["4.20", "4.20"],
+            "timestamp": [1700000000, 1700000060],
+            "metric": [5.0, -1.0],
+        }),
+        test={"name": "test", "uuid_field": "uuid", "version_field": "ocpVersion"},
+        options={"ackMap": None, "collapse": False},
+        metrics_config=_cmr_config(),
+    )
+
+    _, change_points = algorithm._analyze()
+
+    assert len(change_points["metric"]) == 1
+
+
+def test_edivisive_irrelevant_filter_uses_actual_value():
+    """EDivisive keeps range violations even when means suggest otherwise."""
+    algorithm = _algorithm({
+        "direction": 1,
+        "threshold": 100,
+        "acceptable_range": (0.0, 10.0),
+    })
+    algorithm.dataframe.loc[1, "metric"] = -1.0
+    change_point = make_change_point("metric", 1, mean_1=5.0, mean_2=100.0)
+
+    assert not algorithm._is_irrelevant_changepoint("metric", [change_point], 0)

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -81,6 +81,9 @@ class Utils:
             labels = metric.pop("labels", None)
             direction = int(metric.pop("direction", 1))
             threshold = abs(int(metric.pop("threshold", test_threshold)))
+            acceptable_range = metric.pop("acceptable_range", None)
+            if acceptable_range is not None:
+                acceptable_range = self._parse_acceptable_range(acceptable_range)
             ts = metric.pop("timestamp", global_timestamp_field)
             correlation = metric.pop("correlation", "")
             context = metric.pop("context", 5)
@@ -97,7 +100,8 @@ class Utils:
             meta_by_name[metric["name"]] = {
                 "labels": labels, "direction": direction, "threshold": threshold,
                 "correlation": correlation, "context": context, "timestamp": ts,
-                "type": metric_type, "dry_run": dry_run,
+                "type": metric_type, "acceptable_range": acceptable_range,
+                "dry_run": dry_run,
             }
 
             if "agg" in metric:
@@ -141,10 +145,31 @@ class Utils:
         metric["labels"] = meta["labels"]
         metric["direction"] = meta["direction"]
         metric["threshold"] = meta["threshold"]
+        metric["acceptable_range"] = meta["acceptable_range"]
         metric["timestamp"] = meta["timestamp"]
         metric["correlation"] = meta["correlation"]
         metric["context"] = meta["context"]
         metric["dry_run"] = meta["dry_run"]
+
+    @staticmethod
+    def _parse_acceptable_range(value):
+        """Normalize an acceptable range to an inclusive (minimum, maximum) tuple."""
+        if isinstance(value, dict):
+            if set(value) != {"min", "max"}:
+                raise ValueError("acceptable_range must contain exactly 'min' and 'max'")
+            bounds = (value["min"], value["max"])
+        elif isinstance(value, (list, tuple)) and len(value) == 2:
+            bounds = tuple(value)
+        else:
+            raise ValueError("acceptable_range must be [min, max] or {min: ..., max: ...}")
+
+        try:
+            minimum, maximum = (float(bound) for bound in bounds)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("acceptable_range bounds must be numeric") from exc
+        if minimum > maximum:
+            raise ValueError("acceptable_range minimum must not exceed maximum")
+        return minimum, maximum
 
     @staticmethod
     def _group_by_timestamp(metrics, meta_by_name):

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -6,6 +6,7 @@ module for all utility functions orion uses
 # pylint: disable = import-error
 
 import json
+import math
 import re
 import urllib.parse
 import xml.etree.ElementTree as ET
@@ -167,6 +168,8 @@ class Utils:
             minimum, maximum = (float(bound) for bound in bounds)
         except (TypeError, ValueError) as exc:
             raise ValueError("acceptable_range bounds must be numeric") from exc
+        if not math.isfinite(minimum) or not math.isfinite(maximum):
+            raise ValueError("acceptable_range bounds must be finite")
         if minimum > maximum:
             raise ValueError("acceptable_range minimum must not exceed maximum")
         return minimum, maximum


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Introduce the acceptable_range metric option for defining inclusive minimum and maximum values. Orion now reports a changepoint when a metric steps from inside the configured range to outside it, while ignoring changes that remain within the range or return to the acceptable range.

Apply range-based filtering to the EDivisive and CMR algorithms, with range configuration taking precedence over percentage thresholds and direction filters. Validate range formats and bounds during metric configuration processing.

## Related Tickets & Documents

Slack thread reference: https://redhat-internal.slack.com/archives/C020CKMP6CT/p1788942353699089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring inclusive acceptable ranges for metrics using list or object syntax.
  * Change detection now evaluates the value at each changepoint against the configured range, independently of direction or percentage thresholds.
  * Changelpoints within the acceptable range are ignored.
  * Invalid ranges, including non-finite or reversed bounds, are rejected with validation errors.

* **Documentation**
  * Documented acceptable-range syntax, inclusive bounds, precedence, and changepoint filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->