### PR TITLE
Remove API latency avg metrics and add acceptable ranges

### DIFF
--- a/examples/crd-scale.yaml
+++ b/examples/crd-scale.yaml
@@ -120,25 +120,21 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -156,6 +152,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/metal-perfscale-cpt-node-density-heavy.yaml
+++ b/examples/metal-perfscale-cpt-node-density-heavy.yaml
@@ -98,25 +98,21 @@ tests:
           agg_type: avg
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -134,6 +130,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/metal-perfscale-cpt-node-density.yaml
+++ b/examples/metal-perfscale-cpt-node-density.yaml
@@ -107,25 +107,21 @@ tests:
           agg_type: avg
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -143,6 +139,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/metal-perfscale-cpt-rds-core.yaml
+++ b/examples/metal-perfscale-cpt-rds-core.yaml
@@ -127,40 +127,26 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 10
+
       - name: max-ro-apicalls-latency
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
           agg_type: max
+        acceptable_range: [0, 2]
         labels:
           - "[Jira: max-ro-apicalls-latency]"
         direction: 1
         threshold: 10
-      - name: avg-ro-apicalls-latency
-        metricName.keyword: avg-ro-apicalls-latency
-        metric_of_interest: value
-        agg:
-          agg_type: avg
-        labels:
-          - "[Jira: avg-ro-apicalls-latency]"
-        direction: 1
-        threshold: 10
+
       - name: max-mutating-apicalls-latency
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
           agg_type: max
+        acceptable_range: [0, 2]
         labels:
           - "[Jira: max-mutating-apicalls-latency]"
-        direction: 1
-        threshold: 10
-      - name: avg-mutating-apicalls-latency
-        metricName.keyword: avg-mutating-apicalls-latency
-        metric_of_interest: value
-        agg:
-          agg_type: avg
-        labels:
-          - "[Jira: avg-mutating-apicalls-latency]"
         direction: 1
         threshold: 10
       - name: max-cpu-etcd

--- a/examples/metal-perfscale-cpt-virt-density-nomount.yaml
+++ b/examples/metal-perfscale-cpt-virt-density-nomount.yaml
@@ -105,25 +105,21 @@ tests:
         threshold: 10
         direction: 1
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -141,6 +137,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/metal-perfscale-cpt-virt-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-density.yaml
@@ -105,25 +105,21 @@ tests:
         threshold: 10
         direction: 1
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -141,6 +137,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/metal-perfscale-cpt-virt-udn-density.yaml
+++ b/examples/metal-perfscale-cpt-virt-udn-density.yaml
@@ -105,25 +105,21 @@ tests:
         threshold: 10
         direction: 1
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -141,6 +137,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -117,25 +117,21 @@
   direction: 1
   threshold: 10
 
-- name: max-mutating-apicalls-latency-${ag}
+- name: max-mutating-apicalls-latency-max
   metricName.keyword: max-mutating-apicalls-latency
   metric_of_interest: value
   agg:
-    agg_type: ${ag}
+    agg_type: max
   direction: 1
-  fan_out:
-    - ag: avg
-    - ag: max
+  acceptable_range: [0, 2]
 
-- name: max-ro-apicalls-latency-${ag}
+- name: max-ro-apicalls-latency-max
   metricName.keyword: max-ro-apicalls-latency
   metric_of_interest: value
   agg:
-    agg_type: ${ag}
+    agg_type: max
   direction: 1
-  fan_out:
-    - ag: avg
-    - ag: max
+  acceptable_range: [0, 2]
 
 - name: 99thEtcdCompaction-${ag}
   metricName.keyword: 99thEtcdCompaction
@@ -153,6 +149,7 @@
   agg:
     agg_type: ${ag}
   direction: 1
+  acceptable_range: [0, 1800]
   fan_out:
     - ag: max
     - ag: sum

--- a/examples/metrics/chaos-scenarios-metrics.yaml
+++ b/examples/metrics/chaos-scenarios-metrics.yaml
@@ -461,25 +461,21 @@
   agg:
     agg_type: avg
 
-- name: max-mutating-apicalls-latency-${ag}
+- name: max-mutating-apicalls-latency-max
   metricName.keyword: max-mutating-apicalls-latency
   metric_of_interest: value
   agg:
-    agg_type: ${ag}
+    agg_type: max
   direction: 1
-  fan_out:
-    - ag: avg
-    - ag: max
+  acceptable_range: [0, 2]
 
-- name: max-ro-apicalls-latency-${ag}
+- name: max-ro-apicalls-latency-max
   metricName.keyword: max-ro-apicalls-latency
   metric_of_interest: value
   agg:
-    agg_type: ${ag}
+    agg_type: max
   direction: 1
-  fan_out:
-    - ag: avg
-    - ag: max
+  acceptable_range: [0, 2]
 
 - name: 99thEtcdCompaction-${ag}
   metricName.keyword: 99thEtcdCompaction
@@ -497,6 +493,7 @@
   agg:
     agg_type: ${ag}
   direction: 1
+  acceptable_range: [0, 1800]
   fan_out:
     - ag: max
     - ag: sum

--- a/examples/netpol-24nodes.yaml
+++ b/examples/netpol-24nodes.yaml
@@ -255,25 +255,21 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -291,6 +287,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/okd-control-plane-cluster-density.yaml
+++ b/examples/okd-control-plane-cluster-density.yaml
@@ -89,25 +89,21 @@ tests:
           agg_type: avg
         direction: 1
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -125,6 +121,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/okd-control-plane-node-density-cni.yaml
+++ b/examples/okd-control-plane-node-density-cni.yaml
@@ -236,25 +236,21 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -272,6 +268,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/rosa-hcp-crd-scale.yaml
+++ b/examples/rosa-hcp-crd-scale.yaml
@@ -98,25 +98,21 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -134,6 +130,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/rosa-hcp-metrics.yaml
+++ b/examples/rosa-hcp-metrics.yaml
@@ -212,25 +212,21 @@
   direction: 1
   threshold: 10
 
-- name: max-mutating-apicalls-latency-${ag}
+- name: max-mutating-apicalls-latency-max
   metricName.keyword: max-mutating-apicalls-latency
   metric_of_interest: value
   agg:
-    agg_type: ${ag}
+    agg_type: max
   direction: 1
-  fan_out:
-    - ag: avg
-    - ag: max
+  acceptable_range: [0, 2]
 
-- name: max-ro-apicalls-latency-${ag}
+- name: max-ro-apicalls-latency-max
   metricName.keyword: max-ro-apicalls-latency
   metric_of_interest: value
   agg:
-    agg_type: ${ag}
+    agg_type: max
   direction: 1
-  fan_out:
-    - ag: avg
-    - ag: max
+  acceptable_range: [0, 2]
 
 - name: 99thEtcdCompaction-${ag}
   metricName.keyword: 99thEtcdCompaction
@@ -248,6 +244,7 @@
   agg:
     agg_type: ${ag}
   direction: 1
+  acceptable_range: [0, 1800]
   fan_out:
     - ag: max
     - ag: sum

--- a/examples/trt-external-payload-cluster-density.yaml
+++ b/examples/trt-external-payload-cluster-density.yaml
@@ -180,25 +180,21 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -216,6 +212,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/trt-external-payload-node-density-cni.yaml
+++ b/examples/trt-external-payload-node-density-cni.yaml
@@ -120,25 +120,21 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -156,6 +152,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/trt-external-payload-node-density.yaml
+++ b/examples/trt-external-payload-node-density.yaml
@@ -172,25 +172,21 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -208,6 +204,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/trt-external-payload-udn-density-pods.yaml
+++ b/examples/trt-external-payload-udn-density-pods.yaml
@@ -157,25 +157,21 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -193,6 +189,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum

--- a/examples/udn-density-pods.yaml
+++ b/examples/udn-density-pods.yaml
@@ -159,25 +159,21 @@ tests:
         direction: 1
         threshold: 10
 
-      - name: max-mutating-apicalls-latency-${ag}
+      - name: max-mutating-apicalls-latency-max
         metricName.keyword: max-mutating-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
-      - name: max-ro-apicalls-latency-${ag}
+      - name: max-ro-apicalls-latency-max
         metricName.keyword: max-ro-apicalls-latency
         metric_of_interest: value
         agg:
-          agg_type: ${ag}
+          agg_type: max
         direction: 1
-        fan_out:
-          - ag: avg
-          - ag: max
+        acceptable_range: [0, 2]
 
       - name: 99thEtcdCompaction-${ag}
         metricName.keyword: 99thEtcdCompaction
@@ -195,6 +191,7 @@ tests:
         agg:
           agg_type: ${ag}
         direction: 1
+        acceptable_range: [0, 1800]
         fan_out:
           - ag: max
           - ag: sum


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

- Keep only max aggregation for API latency metrics
- Add [0, 2] ranges for API latency metrics
- Add [0, 1800] range for nodeMajorFaults