### PR TITLE
Add Orion config for LCS load generator

### DIFF
--- a/examples/config/lcs-load-generator-config.yaml
+++ b/examples/config/lcs-load-generator-config.yaml
@@ -1,0 +1,19 @@
+# Metadata configuration for lcs-load-generator Orion tests.
+#
+# These fields must match the ES document fields indexed by the load generator.
+# Orion uses them to filter ES results to the correct test run.
+
+lcsTestWorkers: "{{ lcs_test_workers }}"
+platform: AWS
+clusterType: self-managed
+masterNodesType.keyword: m6a.xlarge
+masterNodesCount: 3
+workerNodesType.keyword: m6i.xlarge
+workerNodesCount: 3
+benchmark.keyword: lcs-load-generator
+wildcard:
+  ocpVersion: "{{ version }}*"
+networkType: OVNKubernetes
+fips: "{{ fips | default('false') }}"
+not:
+  stream: okd

--- a/examples/lcs-load-generator.yaml
+++ b/examples/lcs-load-generator.yaml
@@ -1,0 +1,17 @@
+parentConfig: config/lcs-load-generator-config.yaml
+metricsFile: metrics/lcs-load-generator-metrics.yaml
+tests:
+  - name: lcs-load-generator-{{ lcs_test_workers }}w-5m
+    metadata:
+      lcsTestDuration: "5m"
+    metrics:
+
+  - name: lcs-load-generator-{{ lcs_test_workers }}w-10m
+    metadata:
+      lcsTestDuration: "10m"
+    metrics:
+
+  - name: lcs-load-generator-{{ lcs_test_workers }}w-20m
+    metadata:
+      lcsTestDuration: "20m"
+    metrics:

--- a/examples/metrics/lcs-load-generator-metrics.yaml
+++ b/examples/metrics/lcs-load-generator-metrics.yaml
@@ -1,0 +1,259 @@
+# ==========================================================================
+# LCS Load Generator — Orion Metrics Configuration
+#
+# 27 KPIs across 8 categories:
+#   - P99 Latency (2)       - P95 Latency (2)
+#   - TTFT (2)              - Stream Time (2)
+#   - Throughput 200s (2)   - Throughput RPS (2)
+#   - Error Rates (8)       - Prometheus / System (6)
+#   - Total: 27 (expands to ~40 when /v1/responses endpoints are added)
+#
+# direction: 1 = lower is better (latency, errors, resource usage)
+# direction: -1 = higher is better (throughput, success counts)
+# threshold: 10 = flag changepoints with >= 10% change
+# ==========================================================================
+
+
+# ==========================================================================
+# CATEGORY 1: P99 LATENCY (2 metrics)
+# Primary regression indicators — lower is better.
+# Correlated with throughput to distinguish real regressions from load drops.
+# ==========================================================================
+
+- name: postQuery
+  metricName.keyword: post_query
+  metric_of_interest: p99Latency
+  direction: 1
+  threshold: 10
+  context: 10
+  correlation: postQuery_statusCodes.200
+
+- name: postStreamingQuery
+  metricName.keyword: post_streaming_query
+  metric_of_interest: p99Latency
+  direction: 1
+  threshold: 10
+  context: 10
+  correlation: postStreamingQuery_statusCodes.200
+
+
+# ==========================================================================
+# CATEGORY 2: P95 LATENCY (2 metrics)
+# Catches regressions that affect the 95th percentile but not the 99th.
+# ==========================================================================
+
+- name: postQuery_p95
+  metricName.keyword: post_query
+  metric_of_interest: p95Latency
+  direction: 1
+  threshold: 10
+  correlation: postQuery_p95_statusCodes.200
+
+- name: postStreamingQuery_p95
+  metricName.keyword: post_streaming_query
+  metric_of_interest: p95Latency
+  direction: 1
+  threshold: 10
+  correlation: postStreamingQuery_p95_statusCodes.200
+
+
+# ==========================================================================
+# CATEGORY 3: TTFT — Time to First Token (2 metrics, streaming only)
+# Unique to LCS — OLS does NOT track this.
+# Critical UX metric: how long the user waits before seeing the first token.
+# ==========================================================================
+
+- name: postStreamingQuery_TTFT
+  metricName.keyword: post_streaming_query
+  metric_of_interest: ttft_p99
+  direction: 1
+  threshold: 10
+
+- name: postStreamingQuery_TTFT_P95
+  metricName.keyword: post_streaming_query
+  metric_of_interest: ttft_p95
+  direction: 1
+  threshold: 10
+
+
+# ==========================================================================
+# CATEGORY 4: STREAM TIME (2 metrics, streaming only)
+# Total time from request to last SSE event.
+# Unique to LCS — OLS does NOT track this.
+# ==========================================================================
+
+- name: postStreamingQuery_StreamTime
+  metricName.keyword: post_streaming_query
+  metric_of_interest: streamTime_p99
+  direction: 1
+  threshold: 10
+
+- name: postStreamingQuery_StreamTime_P95
+  metricName.keyword: post_streaming_query
+  metric_of_interest: streamTime_p95
+  direction: 1
+  threshold: 10
+
+
+# ==========================================================================
+# CATEGORY 5: THROUGHPUT — Success Count (2 metrics)
+# Successful request count — a drop means fewer 200s under the same load.
+# Higher is better → direction: -1
+# ==========================================================================
+
+- name: postQuery_statusCodes200
+  metricName.keyword: post_query
+  metric_of_interest: statusCodes.200
+  direction: -1
+  threshold: 10
+
+- name: postStreamingQuery_statusCodes200
+  metricName.keyword: post_streaming_query
+  metric_of_interest: statusCodes.200
+  direction: -1
+  threshold: 10
+
+
+# ==========================================================================
+# CATEGORY 6: THROUGHPUT — Requests Per Second (2 metrics)
+# Direct measure of service capacity.
+# Unique to LCS — OLS does NOT track RPS in Orion.
+# Higher is better → direction: -1
+# ==========================================================================
+
+- name: postQuery_throughput
+  metricName.keyword: post_query
+  metric_of_interest: throughput
+  direction: -1
+  threshold: 10
+
+- name: postStreamingQuery_throughput
+  metricName.keyword: post_streaming_query
+  metric_of_interest: throughput
+  direction: -1
+  threshold: 10
+
+
+# ==========================================================================
+# CATEGORY 7: ERROR RATES (8 metrics)
+# Track error status codes — a spike means something broke.
+# Lower is better → direction: 1
+#
+# 403 = auth failure
+# 413 = request entity too large (prompt exceeds max — important for
+#        growing conversations that approach the context window limit)
+# 422 = validation error
+# 500 = server error
+# ==========================================================================
+
+# --- /v1/query errors ---
+- name: postQuery_403
+  metricName.keyword: post_query
+  metric_of_interest: statusCodes.403
+  direction: 1
+  threshold: 10
+
+- name: postQuery_413
+  metricName.keyword: post_query
+  metric_of_interest: statusCodes.413
+  direction: 1
+  threshold: 10
+
+- name: postQuery_422
+  metricName.keyword: post_query
+  metric_of_interest: statusCodes.422
+  direction: 1
+  threshold: 10
+
+- name: postQuery_500
+  metricName.keyword: post_query
+  metric_of_interest: statusCodes.500
+  direction: 1
+  threshold: 10
+
+# --- /v1/streaming_query errors ---
+- name: postStreamingQuery_403
+  metricName.keyword: post_streaming_query
+  metric_of_interest: statusCodes.403
+  direction: 1
+  threshold: 10
+
+- name: postStreamingQuery_413
+  metricName.keyword: post_streaming_query
+  metric_of_interest: statusCodes.413
+  direction: 1
+  threshold: 10
+
+- name: postStreamingQuery_422
+  metricName.keyword: post_streaming_query
+  metric_of_interest: statusCodes.422
+  direction: 1
+  threshold: 10
+
+- name: postStreamingQuery_500
+  metricName.keyword: post_streaming_query
+  metric_of_interest: statusCodes.500
+  direction: 1
+  threshold: 10
+
+
+# ==========================================================================
+# CATEGORY 8: PROMETHEUS / SYSTEM METRICS (6 metrics)
+# Scraped by kube-burner, indexed separately from Locust results.
+# These track lightspeed-core container resource usage and LLM health.
+# Lower is better → direction: 1
+# ==========================================================================
+
+# --- Container CPU usage (avg across pods) ---
+- name: lightSpeedCPU
+  metricName.keyword: avg-cpu-lcs
+  metric_of_interest: value
+  agg:
+    agg_type: avg
+  direction: 1
+  threshold: 10
+
+# --- Container Memory usage (avg across pods) ---
+- name: lightSpeedMemory
+  metricName.keyword: avg-memory-lcs
+  metric_of_interest: value
+  agg:
+    agg_type: avg
+  direction: 1
+  threshold: 10
+
+# --- CPU Throttling (containers hitting CPU limits) ---
+- name: lightSpeedCPUThrottle
+  metricName.keyword: max-cpu-throttled-lcs
+  metric_of_interest: value
+  agg:
+    agg_type: max
+  direction: 1
+  threshold: 10
+
+# --- Pod Restarts (stability issue indicator) ---
+- name: lightSpeedPodRestarts
+  metricName.keyword: pod-restarts
+  metric_of_interest: value
+  agg:
+    agg_type: max
+  direction: 1
+  threshold: 10
+
+# --- LLM Call Failures ---
+- name: LLMCallFailures
+  metricName.keyword: avg-llm-call-failures
+  metric_of_interest: value
+  agg:
+    agg_type: avg
+  direction: 1
+  threshold: 10
+
+# --- LLM Validation Errors ---
+- name: LLMValidationErrors
+  metricName.keyword: avg-llm-validation-errors
+  metric_of_interest: value
+  agg:
+    agg_type: avg
+  direction: 1
+  threshold: 10


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds Orion changepoint detection configuration for the LCS (LightSpeed Core) performance test pipeline, covering all 4 LCS endpoints

- Tracks latency (P99/P95), TTFT, stream time, throughput, error rates, and system metrics across all 4 LCS endpoints with 10% threshold 
- Have latency-throughput correlation to filter false positives.

